### PR TITLE
fix: learn from PR close reasons and detect upstream-dependency issues

### DIFF
--- a/internal/pipeline/agents.go
+++ b/internal/pipeline/agents.go
@@ -21,6 +21,11 @@ func (p *Pipeline) runScout(ctx context.Context, issue *models.Issue) (*ScoutRes
 		"Rules":       p.ruleLoader.FormatForPrompt("scout"),
 	}
 
+	// Inject repo_structure lessons so scout can detect wrong-repo patterns
+	if lessons, err := p.db.GetRecentLessons(10); err == nil && len(lessons) > 0 {
+		tmplCtx["PastLessons"] = formatLessonsForPrompt(lessons)
+	}
+
 	start := time.Now()
 	var result ScoutResult
 	if _, err := p.runner.RunJSON(ctx, "scout", p.cfg.WorkspaceDir, tmplCtx, &result); err != nil {

--- a/internal/pipeline/lessons.go
+++ b/internal/pipeline/lessons.go
@@ -20,6 +20,7 @@ var lessonCategories = []struct {
 	{"docs", []string{"comment", "docstring", "documentation", "readme", "typo"}},
 	{"ci", []string{"ci", "build", "compile", "workflow", "action"}},
 	{"logic", []string{"bug", "logic", "incorrect", "wrong", "fix", "error", "crash", "race", "nil"}},
+	{"repo_structure", []string{"upstream", "belongs in", "other repo", "separate repo", "dependency bump", "go-mysql-server", "the actual change is in", "change is in"}},
 }
 
 // categorizeComment returns the best-matching category for a reviewer comment.
@@ -95,6 +96,38 @@ func extractLessons(
 	return lessons
 }
 
+// extractLessonsFromIssueComments extracts lessons from issue-level comments on a closed PR.
+// Maintainers often explain close reasons here (e.g. "fix belongs in upstream dependency X").
+func extractLessonsFromIssueComments(
+	pr *models.PullRequest,
+	repo string,
+	comments []ghclient.IssueComment,
+) []*models.ReviewLesson {
+	var lessons []*models.ReviewLesson
+	for _, c := range comments {
+		if c.Body == "" || len(c.Body) < 20 {
+			continue
+		}
+		if isBot(c.Author) {
+			continue
+		}
+		category := categorizeComment(c.Body)
+		// Only record comments that match a known actionable category
+		if category == "other" {
+			continue
+		}
+		lessons = append(lessons, &models.ReviewLesson{
+			PRID:          pr.ID,
+			Repo:          repo,
+			Category:      category,
+			Lesson:        summarizeToLesson(c.Body),
+			SourceComment: truncate(c.Body, 500),
+			Reviewer:      c.Author,
+		})
+	}
+	return lessons
+}
+
 // summarizeToLesson trims a reviewer comment to a concise actionable lesson.
 func summarizeToLesson(body string) string {
 	// Take first sentence or first 200 chars, whichever is shorter
@@ -150,16 +183,21 @@ func (p *Pipeline) extractAndStoreLessons(ctx context.Context, pr *models.PullRe
 		return
 	}
 
-	// Get inline comments
+	// Get inline review comments
 	comments, err := p.gh.GetPRReviewComments(ctx, prRepo, pr.PRNumber)
 	if err != nil {
 		log.WithError(err).WithField("pr", pr.PRURL).Warn("failed to fetch comments for lesson extraction")
 		comments = nil
 	}
 
+	// Get issue-level comments — maintainers often explain close reasons here
+	issueComments, _ := p.gh.GetPRIssueComments(ctx, prRepo, pr.PRNumber)
+
 	lessons := extractLessons(pr, prRepo, prInfo.Reviews, comments)
-	if len(lessons) == 0 {
-		return
+
+	// Also extract from issue comments when PR was closed without merge
+	if prInfo.State == "CLOSED" {
+		lessons = append(lessons, extractLessonsFromIssueComments(pr, prRepo, issueComments)...)
 	}
 
 	saved := 0
@@ -171,13 +209,14 @@ func (p *Pipeline) extractAndStoreLessons(ctx context.Context, pr *models.PullRe
 		saved++
 	}
 
-	log.WithFields(Fields{
-		"pr":      pr.PRURL,
-		"lessons": saved,
-	}).Info("extracted review lessons")
+	if saved > 0 {
+		log.WithFields(Fields{
+			"pr":      pr.PRURL,
+			"lessons": saved,
+		}).Info("extracted review lessons")
+	}
 
 	// Label all pipeline events for this PR/issue with the outcome
-	issueComments, _ := p.gh.GetPRIssueComments(ctx, prRepo, pr.PRNumber)
 	label := ClassifyOutcome(prInfo, issueComments, pr)
 	if err := p.db.LabelEventsByIssue(pr.IssueID, label); err != nil {
 		log.WithFields(Fields{"error": err}).Warn("failed to label pipeline events")

--- a/prompts/analyst.md
+++ b/prompts/analyst.md
@@ -56,6 +56,19 @@ Read CI config to identify:
 - Understand the code structure around the bug
 - Identify test patterns used in the project
 
+### 4b. Check Dependency Boundaries
+
+Before declaring `can_fix: true`, verify the code to change actually lives in **this** repo:
+
+- **Go**: read `go.mod` — if the relevant package is listed under `require`, the fix belongs upstream in that module
+- **Node.js**: read `package.json` — if the code lives in `node_modules/`, it belongs upstream
+- **Rust**: read `Cargo.toml` — if the relevant crate is a dependency entry, it belongs upstream
+
+If the required change is in a dependency, set:
+```json
+{ "can_fix": false, "reason": "fix belongs in upstream dependency <owner/repo>" }
+```
+
 ### 5. Create Fix Plan
 
 Design the minimal fix:

--- a/prompts/scout.md
+++ b/prompts/scout.md
@@ -11,6 +11,15 @@ Evaluate whether GitHub issue #{{ .IssueNumber }} in {{ .Repo }} is a viable con
 {{ .IssueBody }}
 **Labels:** {{ .IssueLabels }}
 
+{{ if .PastLessons }}
+## Lessons from Past Contributions
+
+{{ .PastLessons }}
+
+If any `repo_structure` lesson indicates that changes for **{{ .Repo }}** belong in a different repository,
+output VERDICT: SKIP with reason referencing that lesson.
+
+{{ end }}
 ## Checks (execute ALL before making a decision)
 
 ### 1. Upstream Redirection Check


### PR DESCRIPTION
Closes #5

## Summary

- **`internal/pipeline/lessons.go`**: Added `repo_structure` lesson category (keywords: `upstream`, `belongs in`, `other repo`, `dependency bump`, etc.). New `extractLessonsFromIssueComments` function extracts lessons from issue-level comments on closed PRs. `extractAndStoreLessons` now fetches issue comments upfront and appends repo_structure lessons when `prInfo.State == "CLOSED"`.
- **`internal/pipeline/agents.go`**: `runScout` now loads recent lessons from DB and injects them as `PastLessons` into the scout prompt template.
- **`prompts/analyst.md`**: Added step 4b — checks `go.mod`/`package.json`/`Cargo.toml` to detect if the required change lives in a dependency; sets `can_fix: false` if so.
- **`prompts/scout.md`**: Added `PastLessons` block at the top; instructs scout to SKIP if any `repo_structure` lesson indicates changes belong in a different repo.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./...` — all pass (pipeline, github, rules, utils packages)