### PR TITLE
fix(synthesizer): populate last_validated_at so applyDecay exemption works

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ Thumbs.db
 
 # Workspace (repos cloned for processing)
 workspace/
+.omx/

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,17 +25,17 @@ type Config struct {
 	DatabaseURL  string `mapstructure:"database_url"` // PostgreSQL connection string (optional)
 
 	// Filters
-	Languages      []string `mapstructure:"languages"`
-	IncludeLabels  []string `mapstructure:"include_labels"`
-	ExcludeLabels  []string `mapstructure:"exclude_labels"`
-	ExcludeRepos   []string `mapstructure:"exclude_repos"`
-	PriorityRepos  []string `mapstructure:"priority_repos"` // repos to check first before searching
-	MinRepoStars   int      `mapstructure:"min_repo_stars"`
-	MaxIssueAgeDays int     `mapstructure:"max_issue_age_days"`
+	Languages       []string `mapstructure:"languages"`
+	IncludeLabels   []string `mapstructure:"include_labels"`
+	ExcludeLabels   []string `mapstructure:"exclude_labels"`
+	ExcludeRepos    []string `mapstructure:"exclude_repos"`
+	PriorityRepos   []string `mapstructure:"priority_repos"` // repos to check first before searching
+	MinRepoStars    int      `mapstructure:"min_repo_stars"`
+	MaxIssueAgeDays int      `mapstructure:"max_issue_age_days"`
 
 	// Pipeline V2 settings
 	MaxReviewRounds        int    `mapstructure:"max_review_rounds"`
-	MaxPRsPerRepo          int    `mapstructure:"max_prs_per_repo"`          // max open PRs per repo before throttling
+	MaxPRsPerRepo          int    `mapstructure:"max_prs_per_repo"`         // max open PRs per repo before throttling
 	MaxConcurrentPipelines int    `mapstructure:"max_concurrent_pipelines"` // number of parallel issue workers
 	PromptsDir             string `mapstructure:"prompts_dir"`
 
@@ -65,31 +65,31 @@ func Default() *Config {
 	dataDir := filepath.Join(homeDir, ".auto-contributor")
 
 	return &Config{
-		GitHubEmail:      "1835304752@qq.com",
-		ClaudeTimeout:    24 * time.Hour,
-		ClaudeMaxRetries: 3,
-		WorkspaceDir:     filepath.Join(homeDir, "Desktop", "code", "opensourece", "auto-workspace"),
-		DatabasePath:     filepath.Join(dataDir, "data.db"),
-		Languages:        []string{"go", "python", "typescript", "javascript", "rust"},
-		IncludeLabels:    []string{"good first issue", "help wanted", "bug"},
-		ExcludeLabels:    []string{"wontfix", "duplicate", "invalid"},
-		ExcludeRepos:     []string{},
-		PriorityRepos:    []string{},
-		MinRepoStars:     1000,
-		MaxIssueAgeDays:  30,
+		GitHubEmail:            "1835304752@qq.com",
+		ClaudeTimeout:          24 * time.Hour,
+		ClaudeMaxRetries:       3,
+		WorkspaceDir:           filepath.Join(homeDir, "Desktop", "code", "opensourece", "auto-workspace"),
+		DatabasePath:           filepath.Join(dataDir, "data.db"),
+		Languages:              []string{"go", "python", "typescript", "javascript", "rust"},
+		IncludeLabels:          []string{"good first issue", "help wanted", "bug"},
+		ExcludeLabels:          []string{"wontfix", "duplicate", "invalid"},
+		ExcludeRepos:           []string{},
+		PriorityRepos:          []string{},
+		MinRepoStars:           1000,
+		MaxIssueAgeDays:        30,
 		MaxReviewRounds:        3,
 		MaxPRsPerRepo:          1,
 		MaxConcurrentPipelines: 5,
-		PromptsDir:        filepath.Join(dataDir, "prompts"),
-		Mode:              "full",
-		DiscoveryInterval: 30,
-		FeedbackInterval:  30,
-		Topic:             "ai",
-		AnalysisDepth:     "deep",
-		RulesDir:          "",
-		SynthesisInterval: 24,
-		LogLevel:         "info",
-		LogFile:          filepath.Join(dataDir, "auto-contributor.log"),
+		PromptsDir:             filepath.Join(dataDir, "prompts"),
+		Mode:                   "full",
+		DiscoveryInterval:      30,
+		FeedbackInterval:       30,
+		Topic:                  "ai",
+		AnalysisDepth:          "deep",
+		RulesDir:               "",
+		SynthesisInterval:      24,
+		LogLevel:               "info",
+		LogFile:                filepath.Join(dataDir, "auto-contributor.log"),
 	}
 }
 

--- a/internal/db/events.go
+++ b/internal/db/events.go
@@ -173,7 +173,10 @@ func (db *DB) LabelEventsByPR(prID int64, label string) error {
 	return err
 }
 
-func scanEvents(rows interface{ Next() bool; Scan(...any) error }) ([]*models.PipelineEvent, error) {
+func scanEvents(rows interface {
+	Next() bool
+	Scan(...any) error
+}) ([]*models.PipelineEvent, error) {
 	var events []*models.PipelineEvent
 	for rows.Next() {
 		e := &models.PipelineEvent{}

--- a/internal/discovery/claude_discovery.go
+++ b/internal/discovery/claude_discovery.go
@@ -31,8 +31,8 @@ type IssueAnalysis struct {
 	IsWellDefined        bool     `json:"is_well_defined"`
 	HasReproductionSteps bool     `json:"has_reproduction_steps"`
 	IsSelfContained      bool     `json:"is_self_contained"`
-	FixType              string   `json:"fix_type"`      // bug, docs, feature, refactor
-	Complexity           string   `json:"complexity"`    // low, medium, high
+	FixType              string   `json:"fix_type"`   // bug, docs, feature, refactor
+	Complexity           string   `json:"complexity"` // low, medium, high
 	EstimatedFiles       int      `json:"estimated_files"`
 	Blockers             []string `json:"blockers"`
 	Recommendation       string   `json:"recommendation"`

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -351,7 +351,7 @@ func (c *Client) MarkPRReady(ctx context.Context, repo string, prNum int) error 
 
 // GitHubPR represents an open PR discovered from GitHub.
 type GitHubPR struct {
-	Repo       string `json:"repo"`       // owner/repo
+	Repo       string `json:"repo"` // owner/repo
 	Number     int    `json:"number"`
 	Title      string `json:"title"`
 	Body       string `json:"body"`

--- a/internal/github/search.go
+++ b/internal/github/search.go
@@ -143,11 +143,15 @@ func (c *Client) GetUnassignedBugs(ctx context.Context, repoFullName string, lim
 	}
 
 	var raw []struct {
-		Number    int    `json:"number"`
-		Title     string `json:"title"`
-		Body      string `json:"body"`
-		Labels    []struct{ Name string `json:"name"` }    `json:"labels"`
-		Assignees []struct{ Login string `json:"login"` } `json:"assignees"`
+		Number int    `json:"number"`
+		Title  string `json:"title"`
+		Body   string `json:"body"`
+		Labels []struct {
+			Name string `json:"name"`
+		} `json:"labels"`
+		Assignees []struct {
+			Login string `json:"login"`
+		} `json:"assignees"`
 	}
 	if err := json.Unmarshal(output, &raw); err != nil {
 		return nil, fmt.Errorf("parse issues: %w", err)
@@ -196,4 +200,3 @@ func (c *Client) GetUnassignedBugs(ctx context.Context, repoFullName string, lim
 
 	return issues, nil
 }
-

--- a/internal/pipeline/agent.go
+++ b/internal/pipeline/agent.go
@@ -54,8 +54,8 @@ func (r *AgentRunner) RunJSON(ctx context.Context, agentName string, workDir str
 
 	// Log the failed output for debugging
 	log.WithFields(Fields{
-		"agent":      agentName,
-		"output_len": len(raw),
+		"agent":       agentName,
+		"output_len":  len(raw),
 		"output_tail": truncate(raw[max(0, len(raw)-500):], 500),
 	}).Warn("JSON extraction failed, attempting lightweight recovery")
 

--- a/internal/pipeline/agents.go
+++ b/internal/pipeline/agents.go
@@ -155,9 +155,9 @@ func (p *Pipeline) runSubmitter(ctx context.Context, issue *models.Issue, worksp
 	raw, err := p.runner.RunJSON(ctx, "submitter", workspace, tmplCtx, &result)
 	if err != nil {
 		log.WithFields(Fields{
-			"repo":       issue.Repo,
-			"issue":      issue.IssueNumber,
-			"output_len": len(raw),
+			"repo":        issue.Repo,
+			"issue":       issue.IssueNumber,
+			"output_len":  len(raw),
 			"output_tail": truncate(raw, 500),
 		}).Warn("submitter failed to produce valid JSON")
 		p.recordEvent(issue, nil, "submitter", 1, start, "", false, "", err.Error())

--- a/internal/pipeline/decay_test.go
+++ b/internal/pipeline/decay_test.go
@@ -1,0 +1,180 @@
+package pipeline
+
+import (
+	"math"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/majiayu000/auto-contributor/internal/rules"
+	"gopkg.in/yaml.v3"
+)
+
+const floatTol = 1e-9
+
+func approxEqual(a, b float64) bool {
+	return math.Abs(a-b) < floatTol
+}
+
+func writeDecayRule(t *testing.T, dir string, rule *rules.Rule) {
+	t.Helper()
+	stageDir := filepath.Join(dir, rule.Stage)
+	if err := os.MkdirAll(stageDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	data, err := yaml.Marshal(rule)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stageDir, rule.ID+".yaml"), data, 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}
+
+func readDecayRule(t *testing.T, dir string, rule *rules.Rule) *rules.Rule {
+	t.Helper()
+	path := filepath.Join(dir, rule.Stage, rule.ID+".yaml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var r rules.Rule
+	if err := yaml.Unmarshal(data, &r); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	return &r
+}
+
+func newTestPipelineWithRulesDir(t *testing.T, rulesDir string) *Pipeline {
+	t.Helper()
+	rl := rules.NewRuleLoader(rulesDir)
+	if err := rl.Load(); err != nil {
+		t.Fatalf("load rules: %v", err)
+	}
+	return &Pipeline{ruleLoader: rl}
+}
+
+// TestApplyDecay_NoLastValidatedAt verifies that synthesized rules without
+// last_validated_at have their confidence decayed.
+func TestApplyDecay_NoLastValidatedAt(t *testing.T) {
+	dir := t.TempDir()
+	rule := &rules.Rule{
+		ID:         "decay-no-validated",
+		Stage:      "scout",
+		Severity:   "medium",
+		Confidence: 0.8,
+		Source:     "synthesized",
+		CreatedAt:  "2024-01-01",
+		Body:       "Some synthesized rule body.",
+	}
+	writeDecayRule(t, dir, rule)
+
+	p := newTestPipelineWithRulesDir(t, dir)
+	p.applyDecay()
+
+	got := readDecayRule(t, dir, rule)
+	want := 0.8 * 0.9
+	if !approxEqual(got.Confidence, want) {
+		t.Errorf("confidence after decay = %.10f, want %.10f", got.Confidence, want)
+	}
+}
+
+// TestApplyDecay_RecentLastValidatedAt verifies that rules validated within
+// 30 days are NOT decayed.
+func TestApplyDecay_RecentLastValidatedAt(t *testing.T) {
+	dir := t.TempDir()
+	recent := time.Now().AddDate(0, 0, -5).Format("2006-01-02") // 5 days ago
+	rule := &rules.Rule{
+		ID:              "decay-recent-validated",
+		Stage:           "scout",
+		Severity:        "medium",
+		Confidence:      0.8,
+		Source:          "synthesized",
+		CreatedAt:       "2024-01-01",
+		LastValidatedAt: recent,
+		Body:            "Some synthesized rule body.",
+	}
+	writeDecayRule(t, dir, rule)
+
+	p := newTestPipelineWithRulesDir(t, dir)
+	p.applyDecay()
+
+	got := readDecayRule(t, dir, rule)
+	if got.Confidence != 0.8 {
+		t.Errorf("confidence should not decay when recently validated: got %.4f, want 0.8000", got.Confidence)
+	}
+}
+
+// TestApplyDecay_OldLastValidatedAt verifies that rules validated more than
+// 30 days ago ARE decayed.
+func TestApplyDecay_OldLastValidatedAt(t *testing.T) {
+	dir := t.TempDir()
+	old := time.Now().AddDate(0, 0, -40).Format("2006-01-02") // 40 days ago
+	rule := &rules.Rule{
+		ID:              "decay-old-validated",
+		Stage:           "scout",
+		Severity:        "medium",
+		Confidence:      0.8,
+		Source:          "synthesized",
+		CreatedAt:       "2024-01-01",
+		LastValidatedAt: old,
+		Body:            "Some synthesized rule body.",
+	}
+	writeDecayRule(t, dir, rule)
+
+	p := newTestPipelineWithRulesDir(t, dir)
+	p.applyDecay()
+
+	got := readDecayRule(t, dir, rule)
+	want := 0.8 * 0.9
+	if !approxEqual(got.Confidence, want) {
+		t.Errorf("confidence after decay = %.10f, want %.10f", got.Confidence, want)
+	}
+}
+
+// TestApplyDecay_ManualRuleNotDecayed verifies that manual rules are never decayed.
+func TestApplyDecay_ManualRuleNotDecayed(t *testing.T) {
+	dir := t.TempDir()
+	rule := &rules.Rule{
+		ID:         "decay-manual",
+		Stage:      "scout",
+		Severity:   "high",
+		Confidence: 0.9,
+		Source:     "manual",
+		CreatedAt:  "2024-01-01",
+		Body:       "Manual rule body.",
+	}
+	writeDecayRule(t, dir, rule)
+
+	p := newTestPipelineWithRulesDir(t, dir)
+	p.applyDecay()
+
+	got := readDecayRule(t, dir, rule)
+	if got.Confidence != 0.9 {
+		t.Errorf("manual rule confidence changed: got %.4f, want 0.9000", got.Confidence)
+	}
+}
+
+// TestApplyDecay_FloorAtPoint1 verifies that confidence never decays below 0.1.
+func TestApplyDecay_FloorAtPoint1(t *testing.T) {
+	dir := t.TempDir()
+	rule := &rules.Rule{
+		ID:         "decay-floor",
+		Stage:      "scout",
+		Severity:   "low",
+		Confidence: 0.11, // one decay step would take it to 0.099, below floor
+		Source:     "synthesized",
+		CreatedAt:  "2024-01-01",
+		Body:       "Almost floored rule.",
+	}
+	writeDecayRule(t, dir, rule)
+
+	p := newTestPipelineWithRulesDir(t, dir)
+	p.applyDecay()
+
+	got := readDecayRule(t, dir, rule)
+	if got.Confidence < 0.1 {
+		t.Errorf("confidence below floor: got %.4f, want >= 0.1", got.Confidence)
+	}
+}

--- a/internal/pipeline/feedback.go
+++ b/internal/pipeline/feedback.go
@@ -477,19 +477,19 @@ func (p *Pipeline) buildResponderCtx(
 	}
 
 	return map[string]any{
-		"Repo":                 issue.Repo,
-		"IssueNumber":          issue.IssueNumber,
-		"IssueTitle":           issue.Title,
-		"IssueBody":            issue.Body,
+		"Repo":                  issue.Repo,
+		"IssueNumber":           issue.IssueNumber,
+		"IssueTitle":            issue.Title,
+		"IssueBody":             issue.Body,
 		"OriginalIssueComments": p.fetchOriginalIssueComments(issue),
-		"PRNumber":             pr.PRNumber,
-		"PRURL":                pr.PRURL,
-		"BranchName":           pr.BranchName,
-		"FeedbackRound":        pr.FeedbackRound + 1,
-		"Reviews":              reviewsText,
-		"InlineComments":       commentsText,
-		"IssueComments":        issueCommentsText,
-		"Rules":                p.ruleLoader.FormatForPrompt("responder"),
+		"PRNumber":              pr.PRNumber,
+		"PRURL":                 pr.PRURL,
+		"BranchName":            pr.BranchName,
+		"FeedbackRound":         pr.FeedbackRound + 1,
+		"Reviews":               reviewsText,
+		"InlineComments":        commentsText,
+		"IssueComments":         issueCommentsText,
+		"Rules":                 p.ruleLoader.FormatForPrompt("responder"),
 	}
 }
 

--- a/internal/pipeline/lessons.go
+++ b/internal/pipeline/lessons.go
@@ -269,6 +269,12 @@ func (p *Pipeline) stampRuleValidation(pr *models.PullRequest) {
 		}
 	}
 
+	// Reload the in-memory rule cache so the next decay pass sees the updated
+	// last_validated_at values and does not wrongly decay the just-stamped rules.
+	if err := p.ruleLoader.Reload(); err != nil {
+		log.WithError(err).Warn("failed to reload rule cache after stamping last_validated_at")
+	}
+
 	log.WithFields(Fields{
 		"pr":     pr.PRURL,
 		"stages": len(seenStages),

--- a/internal/pipeline/lessons.go
+++ b/internal/pipeline/lessons.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	ghclient "github.com/majiayu000/auto-contributor/internal/github"
+	"github.com/majiayu000/auto-contributor/internal/rules"
 	"github.com/majiayu000/auto-contributor/pkg/models"
 )
 
@@ -223,6 +225,47 @@ func (p *Pipeline) extractAndStoreLessons(ctx context.Context, pr *models.PullRe
 	} else {
 		log.WithFields(Fields{"pr": pr.PRURL, "outcome": label}).Info("labeled pipeline events")
 	}
+
+	// Stamp last_validated_at on synthesized rules when a PR merges.
+	// Merged PRs confirm that the rules guiding those stages produced good output.
+	if label == OutcomeMerged {
+		p.stampRuleValidation(pr)
+	}
+}
+
+// stampRuleValidation sets last_validated_at on all synthesized rules for the pipeline
+// stages that were active during this PR's lifecycle. Called only on merged outcomes.
+func (p *Pipeline) stampRuleValidation(pr *models.PullRequest) {
+	events, err := p.db.GetEventsByIssue(pr.IssueID)
+	if err != nil {
+		log.WithError(err).Warn("failed to fetch events for rule validation stamp")
+		return
+	}
+
+	today := time.Now().Format("2006-01-02")
+	rulesDir := p.ruleLoader.RulesDir()
+	seenStages := make(map[string]bool)
+
+	for _, e := range events {
+		if seenStages[e.Stage] {
+			continue
+		}
+		seenStages[e.Stage] = true
+
+		for _, r := range p.ruleLoader.All() {
+			if r.Stage != e.Stage || r.Source != "synthesized" {
+				continue
+			}
+			if err := rules.UpdateRuleLastValidatedAt(rulesDir, r.ID, r.Stage, today); err != nil {
+				log.WithFields(Fields{"rule": r.ID, "error": err}).Warn("failed to stamp rule last_validated_at")
+			}
+		}
+	}
+
+	log.WithFields(Fields{
+		"pr":     pr.PRURL,
+		"stages": len(seenStages),
+	}).Info("stamped last_validated_at on synthesized rules for merged PR")
 }
 
 // isNonActionable returns true for reviews that are just approvals/LGTM with no actionable content.

--- a/internal/pipeline/lessons.go
+++ b/internal/pipeline/lessons.go
@@ -179,46 +179,48 @@ func isBot(author string) bool {
 // extractAndStoreLessons fetches reviews/comments for a PR and stores lessons in DB.
 // Called when a PR reaches terminal state (merged/closed) so we learn from the feedback.
 func (p *Pipeline) extractAndStoreLessons(ctx context.Context, pr *models.PullRequest, prRepo string, prInfo *ghclient.PRInfo) {
-	// Skip if we already extracted lessons for this PR
-	count, _ := p.db.CountLessonsByPR(pr.ID)
-	if count > 0 {
-		return
-	}
-
-	// Get inline review comments
-	comments, err := p.gh.GetPRReviewComments(ctx, prRepo, pr.PRNumber)
-	if err != nil {
-		log.WithError(err).WithField("pr", pr.PRURL).Warn("failed to fetch comments for lesson extraction")
-		comments = nil
-	}
-
-	// Get issue-level comments — maintainers often explain close reasons here
+	// Issue-level comments are needed for both lesson extraction and outcome
+	// classification, so fetch them unconditionally before any guard.
 	issueComments, _ := p.gh.GetPRIssueComments(ctx, prRepo, pr.PRNumber)
 
-	lessons := extractLessons(pr, prRepo, prInfo.Reviews, comments)
-
-	// Also extract from issue comments when PR was closed without merge
-	if prInfo.State == "CLOSED" {
-		lessons = append(lessons, extractLessonsFromIssueComments(pr, prRepo, issueComments)...)
-	}
-
-	saved := 0
-	for _, l := range lessons {
-		if err := p.db.SaveReviewLesson(l); err != nil {
-			log.WithError(err).Warn("failed to save review lesson")
-			continue
+	// Only extract lessons when none have been stored for this PR. Do NOT return
+	// early here — outcome labeling and merge-stamping must always run so that a
+	// PR first seen as CLOSED still gets its rules stamped when later merged.
+	count, _ := p.db.CountLessonsByPR(pr.ID)
+	if count == 0 {
+		// Get inline review comments
+		comments, err := p.gh.GetPRReviewComments(ctx, prRepo, pr.PRNumber)
+		if err != nil {
+			log.WithError(err).WithField("pr", pr.PRURL).Warn("failed to fetch comments for lesson extraction")
+			comments = nil
 		}
-		saved++
+
+		lessons := extractLessons(pr, prRepo, prInfo.Reviews, comments)
+
+		// Also extract from issue comments when PR was closed without merge
+		if prInfo.State == "CLOSED" {
+			lessons = append(lessons, extractLessonsFromIssueComments(pr, prRepo, issueComments)...)
+		}
+
+		saved := 0
+		for _, l := range lessons {
+			if err := p.db.SaveReviewLesson(l); err != nil {
+				log.WithError(err).Warn("failed to save review lesson")
+				continue
+			}
+			saved++
+		}
+
+		if saved > 0 {
+			log.WithFields(Fields{
+				"pr":      pr.PRURL,
+				"lessons": saved,
+			}).Info("extracted review lessons")
+		}
 	}
 
-	if saved > 0 {
-		log.WithFields(Fields{
-			"pr":      pr.PRURL,
-			"lessons": saved,
-		}).Info("extracted review lessons")
-	}
-
-	// Label all pipeline events for this PR/issue with the outcome
+	// Label all pipeline events for this PR/issue with the outcome.
+	// Always runs regardless of whether lessons were already extracted.
 	label := ClassifyOutcome(prInfo, issueComments, pr)
 	if err := p.db.LabelEventsByIssue(pr.IssueID, label); err != nil {
 		log.WithFields(Fields{"error": err}).Warn("failed to label pipeline events")
@@ -252,15 +254,18 @@ func (p *Pipeline) stampRuleValidation(pr *models.PullRequest) {
 		}
 		seenStages[e.Stage] = true
 
+		// Only stamp rules that were actually injected into the prompt during this
+		// stage's execution. InjectedRuleIDsForStage replicates the FormatForPrompt
+		// char-budget logic, so rules that passed the confidence threshold but were
+		// truncated by MaxPromptChars are excluded — they never influenced the LLM
+		// output and must not receive a fresh last_validated_at stamp (which would
+		// block their decay indefinitely).
+		injected := p.ruleLoader.InjectedRuleIDsForStage(e.Stage)
 		for _, r := range p.ruleLoader.All() {
-			if r.Stage != e.Stage || r.Source != "synthesized" {
+			if r.Source != "synthesized" {
 				continue
 			}
-			// Only stamp rules that were actually eligible for injection during this PR.
-			// Rules below the injection threshold were never used, so a merged PR is not
-			// evidence that they produced good output; stamping them would prevent decay
-			// of low-quality rules and let them persist indefinitely.
-			if r.Confidence < rules.MinConfidenceForInjection {
+			if !injected[r.ID] {
 				continue
 			}
 			if err := rules.UpdateRuleLastValidatedAt(rulesDir, r.ID, r.Stage, today); err != nil {

--- a/internal/pipeline/lessons.go
+++ b/internal/pipeline/lessons.go
@@ -256,6 +256,13 @@ func (p *Pipeline) stampRuleValidation(pr *models.PullRequest) {
 			if r.Stage != e.Stage || r.Source != "synthesized" {
 				continue
 			}
+			// Only stamp rules that were actually eligible for injection during this PR.
+			// Rules below the injection threshold were never used, so a merged PR is not
+			// evidence that they produced good output; stamping them would prevent decay
+			// of low-quality rules and let them persist indefinitely.
+			if r.Confidence < rules.MinConfidenceForInjection {
+				continue
+			}
 			if err := rules.UpdateRuleLastValidatedAt(rulesDir, r.ID, r.Stage, today); err != nil {
 				log.WithFields(Fields{"rule": r.ID, "error": err}).Warn("failed to stamp rule last_validated_at")
 			}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -118,9 +118,9 @@ func (p *Pipeline) ProcessIssue(ctx context.Context, issue *models.Issue) error 
 	if openCount >= maxPR {
 		p.markAbandoned(issue, fmt.Sprintf("rate limit: %d open PRs on %s (max %d)", openCount, issue.Repo, maxPR))
 		log.WithFields(Fields{
-			"repo":  issue.Repo,
-			"open":  openCount,
-			"max":   maxPR,
+			"repo": issue.Repo,
+			"open": openCount,
+			"max":  maxPR,
 		}).Warn("skipping issue: too many open PRs on this repo")
 		return nil
 	}

--- a/internal/pipeline/synthesizer.go
+++ b/internal/pipeline/synthesizer.go
@@ -55,6 +55,11 @@ func (p *Pipeline) RunSynthesis(ctx context.Context) error {
 	// Decay confidence on rules without recent evidence (runs on fresh in-memory state)
 	p.applyDecay()
 
+	// Reload again so runtime uses post-decay confidence values rather than stale pre-decay ones
+	if err := p.ruleLoader.Reload(); err != nil {
+		log.WithFields(Fields{"error": err}).Warn("failed to reload rules after decay")
+	}
+
 	log.WithFields(Fields{
 		"new":     totalNew,
 		"updated": totalUpdated,

--- a/internal/pipeline/synthesizer.go
+++ b/internal/pipeline/synthesizer.go
@@ -174,6 +174,7 @@ func (p *Pipeline) applySynthesisResult(stage string, result *SynthesizerResult)
 		today := time.Now().Format("2006-01-02")
 		if err := rules.UpdateRuleLastValidatedAt(rulesDir, ur.ID, existing.Stage, today); err != nil {
 			log.WithFields(Fields{"rule": ur.ID, "error": err}).Warn("failed to update rule last_validated_at")
+			continue
 		}
 		applied.updatedCount++
 	}
@@ -199,6 +200,9 @@ func (p *Pipeline) applySynthesisResult(stage string, result *SynthesizerResult)
 }
 
 // applyDecay reduces confidence on synthesized rules without recent evidence.
+// Each rule's last_validated_at is read from disk inside DecayRuleIfStale under
+// fileMu, so a concurrent stampRuleValidation write is never missed by a stale
+// in-memory snapshot.
 func (p *Pipeline) applyDecay() {
 	rulesDir := p.ruleLoader.RulesDir()
 	for _, r := range p.ruleLoader.All() {
@@ -206,22 +210,11 @@ func (p *Pipeline) applyDecay() {
 			continue
 		}
 		if r.Confidence <= 0.1 {
-			continue // already at floor
+			continue // already at floor, skip disk round-trip
 		}
-
-		// Check if rule was validated recently
-		if r.LastValidatedAt != "" {
-			validated, err := time.Parse("2006-01-02", r.LastValidatedAt)
-			if err == nil && time.Since(validated) < 30*24*time.Hour {
-				continue // validated within 30 days
-			}
+		if err := rules.DecayRuleIfStale(rulesDir, r.ID, r.Stage, 0.9, 0.1, 30); err != nil {
+			log.WithFields(Fields{"rule": r.ID, "error": err}).Warn("failed to apply decay")
 		}
-
-		newConf := r.Confidence * 0.9
-		if newConf < 0.1 {
-			newConf = 0.1 // floor
-		}
-		rules.UpdateRuleConfidence(rulesDir, r.ID, r.Stage, newConf)
 	}
 }
 

--- a/internal/pipeline/synthesizer.go
+++ b/internal/pipeline/synthesizer.go
@@ -47,13 +47,13 @@ func (p *Pipeline) RunSynthesis(ctx context.Context) error {
 		}).Info("synthesis complete for stage")
 	}
 
-	// Decay confidence on rules without recent evidence
-	p.applyDecay()
-
-	// Reload rules
+	// Reload rules so applyDecay sees the fresh last_validated_at stamps written above
 	if err := p.ruleLoader.Reload(); err != nil {
 		log.WithFields(Fields{"error": err}).Warn("failed to reload rules after synthesis")
 	}
+
+	// Decay confidence on rules without recent evidence (runs on fresh in-memory state)
+	p.applyDecay()
 
 	log.WithFields(Fields{
 		"new":     totalNew,

--- a/internal/pipeline/synthesizer.go
+++ b/internal/pipeline/synthesizer.go
@@ -87,14 +87,14 @@ func (p *Pipeline) synthesizeForStage(ctx context.Context, stage string, events 
 	}
 
 	tmplCtx := map[string]any{
-		"Stage":          stage,
-		"EventsText":     eventsText,
-		"ExistingRules":  existingRules,
-		"TotalEvents":    len(events),
-		"MergedCount":    merged,
-		"RejectedCount":  rejected,
+		"Stage":           stage,
+		"EventsText":      eventsText,
+		"ExistingRules":   existingRules,
+		"TotalEvents":     len(events),
+		"MergedCount":     merged,
+		"RejectedCount":   rejected,
 		"AutoClosedCount": autoClosed,
-		"SuccessRate":    fmt.Sprintf("%.1f", successRate),
+		"SuccessRate":     fmt.Sprintf("%.1f", successRate),
 	}
 
 	var result SynthesizerResult
@@ -132,16 +132,17 @@ func (p *Pipeline) applySynthesisResult(stage string, result *SynthesizerResult)
 		}
 
 		rule := &rules.Rule{
-			ID:            nr.ID,
-			Stage:         nr.Stage,
-			Severity:      nr.Severity,
-			Confidence:    nr.Confidence,
-			Source:        "synthesized",
-			CreatedAt:     time.Now().Format("2006-01-02"),
-			EvidenceCount: nr.EvidenceCount,
-			Tags:          nr.Tags,
-			Condition:     nr.Condition,
-			Body:          nr.Body,
+			ID:              nr.ID,
+			Stage:           nr.Stage,
+			Severity:        nr.Severity,
+			Confidence:      nr.Confidence,
+			Source:          "synthesized",
+			CreatedAt:       time.Now().Format("2006-01-02"),
+			LastValidatedAt: time.Now().Format("2006-01-02"),
+			EvidenceCount:   nr.EvidenceCount,
+			Tags:            nr.Tags,
+			Condition:       nr.Condition,
+			Body:            nr.Body,
 		}
 
 		if err := rules.WriteRule(rulesDir, rule); err != nil {
@@ -164,6 +165,10 @@ func (p *Pipeline) applySynthesisResult(stage string, result *SynthesizerResult)
 		if err := rules.UpdateRuleConfidence(rulesDir, ur.ID, existing.Stage, ur.NewConfidence); err != nil {
 			log.WithFields(Fields{"rule": ur.ID, "error": err}).Warn("failed to update rule confidence")
 			continue
+		}
+		today := time.Now().Format("2006-01-02")
+		if err := rules.UpdateRuleLastValidatedAt(rulesDir, ur.ID, existing.Stage, today); err != nil {
+			log.WithFields(Fields{"rule": ur.ID, "error": err}).Warn("failed to update rule last_validated_at")
 		}
 		applied.updatedCount++
 	}

--- a/internal/pipeline/synthesizer_test.go
+++ b/internal/pipeline/synthesizer_test.go
@@ -1,0 +1,262 @@
+package pipeline
+
+import (
+	"testing"
+	"time"
+
+	"github.com/majiayu000/auto-contributor/internal/rules"
+)
+
+// newTestPipeline returns a Pipeline wired to a temp rules directory.
+func newTestPipeline(t *testing.T, rulesDir string) *Pipeline {
+	t.Helper()
+	rl := rules.NewRuleLoader(rulesDir)
+	if err := rl.Load(); err != nil {
+		t.Fatalf("RuleLoader.Load: %v", err)
+	}
+	return &Pipeline{ruleLoader: rl}
+}
+
+// writeRule is a test helper that writes a rule and fatals on error.
+func writeRule(t *testing.T, dir string, r *rules.Rule) {
+	t.Helper()
+	if err := rules.WriteRule(dir, r); err != nil {
+		t.Fatalf("WriteRule: %v", err)
+	}
+}
+
+// loadRule reloads the loader and returns the rule by ID, or fatals if not found.
+func loadRule(t *testing.T, rl *rules.RuleLoader, id string) *rules.Rule {
+	t.Helper()
+	if err := rl.Reload(); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+	r := rl.ByID(id)
+	if r == nil {
+		t.Fatalf("rule %q not found after reload", id)
+	}
+	return r
+}
+
+// TestApplyDecay_ReducesConfidenceWithoutValidation verifies that a synthesized rule
+// with no last_validated_at has its confidence decayed by applyDecay.
+func TestApplyDecay_ReducesConfidenceWithoutValidation(t *testing.T) {
+	dir := t.TempDir()
+
+	rule := &rules.Rule{
+		ID:         "decay-test-no-validation",
+		Stage:      "engineer",
+		Severity:   "medium",
+		Confidence: 0.8,
+		Source:     "synthesized",
+		CreatedAt:  "2024-01-01",
+		Body:       "Write unit tests.",
+	}
+	writeRule(t, dir, rule)
+
+	p := newTestPipeline(t, dir)
+	p.applyDecay()
+
+	got := loadRule(t, p.ruleLoader, rule.ID)
+	want := 0.8 * 0.9
+	if got.Confidence >= 0.8 {
+		t.Errorf("expected confidence to decay below 0.80, got %.4f", got.Confidence)
+	}
+	if got.Confidence < want-0.001 || got.Confidence > want+0.001 {
+		t.Errorf("confidence = %.4f, want %.4f", got.Confidence, want)
+	}
+}
+
+// TestApplyDecay_ExemptsRecentlyValidatedRules verifies that a rule with
+// last_validated_at within 30 days is NOT decayed.
+func TestApplyDecay_ExemptsRecentlyValidatedRules(t *testing.T) {
+	dir := t.TempDir()
+	today := time.Now().Format("2006-01-02")
+
+	rule := &rules.Rule{
+		ID:              "decay-test-recent-validation",
+		Stage:           "analyst",
+		Severity:        "high",
+		Confidence:      0.75,
+		Source:          "synthesized",
+		CreatedAt:       "2024-01-01",
+		LastValidatedAt: today,
+		Body:            "Check for existing PRs.",
+	}
+	writeRule(t, dir, rule)
+
+	p := newTestPipeline(t, dir)
+	p.applyDecay()
+
+	got := loadRule(t, p.ruleLoader, rule.ID)
+	if got.Confidence != rule.Confidence {
+		t.Errorf("confidence changed for recently-validated rule: got %.4f, want %.4f",
+			got.Confidence, rule.Confidence)
+	}
+}
+
+// TestApplyDecay_ExemptsManualRules verifies that manual rules are never decayed.
+func TestApplyDecay_ExemptsManualRules(t *testing.T) {
+	dir := t.TempDir()
+
+	rule := &rules.Rule{
+		ID:         "decay-test-manual",
+		Stage:      "scout",
+		Severity:   "critical",
+		Confidence: 0.9,
+		Source:     "manual",
+		CreatedAt:  "2024-01-01",
+		Body:       "Never skip triage.",
+	}
+	writeRule(t, dir, rule)
+
+	p := newTestPipeline(t, dir)
+	p.applyDecay()
+
+	got := loadRule(t, p.ruleLoader, rule.ID)
+	if got.Confidence != rule.Confidence {
+		t.Errorf("manual rule confidence should not change: got %.4f, want %.4f",
+			got.Confidence, rule.Confidence)
+	}
+}
+
+// TestApplyDecay_FloorsAtMinimum verifies that repeated decay does not push
+// confidence below the 0.1 floor.
+func TestApplyDecay_FloorsAtMinimum(t *testing.T) {
+	dir := t.TempDir()
+
+	rule := &rules.Rule{
+		ID:         "decay-test-floor",
+		Stage:      "reviewer",
+		Severity:   "low",
+		Confidence: 0.11,
+		Source:     "synthesized",
+		CreatedAt:  "2024-01-01",
+		Body:       "Low-confidence rule near floor.",
+	}
+	writeRule(t, dir, rule)
+
+	p := newTestPipeline(t, dir)
+	// Run decay multiple times to ensure we hit the floor
+	for i := 0; i < 5; i++ {
+		p.applyDecay()
+		if err := p.ruleLoader.Reload(); err != nil {
+			t.Fatalf("Reload: %v", err)
+		}
+	}
+
+	got := loadRule(t, p.ruleLoader, rule.ID)
+	if got.Confidence < 0.1 {
+		t.Errorf("confidence went below floor: %.4f", got.Confidence)
+	}
+}
+
+// TestApplyDecay_ExemptsStaleValidation verifies that a rule with
+// last_validated_at older than 30 days IS decayed.
+func TestApplyDecay_ExemptsStaleValidation(t *testing.T) {
+	dir := t.TempDir()
+	staleDate := time.Now().AddDate(0, 0, -31).Format("2006-01-02")
+
+	rule := &rules.Rule{
+		ID:              "decay-test-stale-validation",
+		Stage:           "submitter",
+		Severity:        "medium",
+		Confidence:      0.7,
+		Source:          "synthesized",
+		CreatedAt:       "2024-01-01",
+		LastValidatedAt: staleDate,
+		Body:            "Stale validation — should decay.",
+	}
+	writeRule(t, dir, rule)
+
+	p := newTestPipeline(t, dir)
+	p.applyDecay()
+
+	got := loadRule(t, p.ruleLoader, rule.ID)
+	if got.Confidence >= rule.Confidence {
+		t.Errorf("expected confidence to decay for stale validation, got %.4f (was %.4f)",
+			got.Confidence, rule.Confidence)
+	}
+}
+
+// TestApplySynthesisResult_NewRuleSetsLastValidatedAt verifies that new rules written
+// by applySynthesisResult have last_validated_at populated.
+func TestApplySynthesisResult_NewRuleSetsLastValidatedAt(t *testing.T) {
+	dir := t.TempDir()
+	p := newTestPipeline(t, dir)
+
+	result := &SynthesizerResult{
+		NewRules: []SynthesizedRule{
+			{
+				ID:            "synth-new-rule-001",
+				Stage:         "engineer",
+				Severity:      "medium",
+				Confidence:    0.6,
+				EvidenceCount: 5,
+				Body:          "Ensure CI passes before submitting.",
+			},
+		},
+	}
+
+	applied := p.applySynthesisResult("engineer", result)
+	if applied.newCount != 1 {
+		t.Fatalf("expected 1 new rule, got %d", applied.newCount)
+	}
+
+	// Reload from disk
+	got := loadRule(t, p.ruleLoader, "synth-new-rule-001")
+	if got.LastValidatedAt == "" {
+		t.Error("new synthesized rule has empty last_validated_at")
+	}
+	today := time.Now().Format("2006-01-02")
+	if got.LastValidatedAt != today {
+		t.Errorf("last_validated_at = %q, want %q", got.LastValidatedAt, today)
+	}
+}
+
+// TestApplySynthesisResult_UpdatedRuleSetsLastValidatedAt verifies that updating
+// an existing rule's confidence also refreshes last_validated_at.
+func TestApplySynthesisResult_UpdatedRuleSetsLastValidatedAt(t *testing.T) {
+	dir := t.TempDir()
+
+	// Pre-create a synthesized rule without last_validated_at
+	existing := &rules.Rule{
+		ID:         "synth-existing-rule-001",
+		Stage:      "analyst",
+		Severity:   "medium",
+		Confidence: 0.5,
+		Source:     "synthesized",
+		CreatedAt:  "2024-01-01",
+		Body:       "Analyse scope carefully.",
+	}
+	writeRule(t, dir, existing)
+
+	p := newTestPipeline(t, dir)
+
+	result := &SynthesizerResult{
+		UpdatedRules: []RuleUpdate{
+			{
+				ID:            existing.ID,
+				NewConfidence: 0.65,
+				Reason:        "additional positive evidence",
+			},
+		},
+	}
+
+	applied := p.applySynthesisResult("analyst", result)
+	if applied.updatedCount != 1 {
+		t.Fatalf("expected 1 updated rule, got %d", applied.updatedCount)
+	}
+
+	got := loadRule(t, p.ruleLoader, existing.ID)
+	if got.LastValidatedAt == "" {
+		t.Error("updated synthesized rule has empty last_validated_at")
+	}
+	today := time.Now().Format("2006-01-02")
+	if got.LastValidatedAt != today {
+		t.Errorf("last_validated_at = %q, want %q", got.LastValidatedAt, today)
+	}
+	if got.Confidence != 0.65 {
+		t.Errorf("confidence = %.2f, want 0.65", got.Confidence)
+	}
+}

--- a/internal/pipeline/types.go
+++ b/internal/pipeline/types.go
@@ -15,14 +15,14 @@ type ScoutResult struct {
 
 // AnalystResult is the structured output from the analyst agent.
 type AnalystResult struct {
-	CanFix           bool     `json:"can_fix"`
-	Reason           string   `json:"reason"`
-	BaseBranch       string   `json:"base_branch"`
-	CommitFormat     string   `json:"commit_format"`
-	BranchName       string   `json:"branch_name"`
-	ContributingRules []string `json:"contributing_rules"`
-	CICommands       CICommands `json:"ci_commands"`
-	FixPlan          FixPlan    `json:"fix_plan"`
+	CanFix            bool       `json:"can_fix"`
+	Reason            string     `json:"reason"`
+	BaseBranch        string     `json:"base_branch"`
+	CommitFormat      string     `json:"commit_format"`
+	BranchName        string     `json:"branch_name"`
+	ContributingRules []string   `json:"contributing_rules"`
+	CICommands        CICommands `json:"ci_commands"`
+	FixPlan           FixPlan    `json:"fix_plan"`
 }
 
 // CICommands holds the project's CI/CD verification commands.

--- a/internal/rules/loader.go
+++ b/internal/rules/loader.go
@@ -42,6 +42,12 @@ func (rl *RuleLoader) Load() error {
 	}
 
 	var loaded []*Rule
+	// Hold fileMu for the entire walk so we cannot read a file that a concurrent
+	// writer (UpdateRuleConfidence, UpdateRuleLastValidatedAt, WriteRule, DeleteRule)
+	// has only partially written.  Without this lock, os.ReadFile can observe a
+	// truncated or zero-byte file mid-os.WriteFile, producing a malformed YAML
+	// unmarshal that silently drops the rule from in-memory state.
+	fileMu.Lock()
 	err = filepath.Walk(rl.rulesDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return nil // skip unreadable files
@@ -68,6 +74,7 @@ func (rl *RuleLoader) Load() error {
 		loaded = append(loaded, &rule)
 		return nil
 	})
+	fileMu.Unlock()
 	if err != nil {
 		return err
 	}

--- a/internal/rules/loader.go
+++ b/internal/rules/loader.go
@@ -147,6 +147,26 @@ func (rl *RuleLoader) FormatForPrompt(stage string) string {
 	return sb.String()
 }
 
+// InjectedRuleIDsForStage returns the set of rule IDs that would actually be
+// written into the prompt for stage, respecting the MaxPromptChars budget.
+// Rules that pass MinConfidenceForInjection but are truncated by the char limit
+// are excluded — they were never seen by the LLM and must not be treated as
+// having influenced a merged PR's output.
+func (rl *RuleLoader) InjectedRuleIDsForStage(stage string) map[string]bool {
+	matched := rl.ForStage(stage)
+	injected := make(map[string]bool)
+	total := 0
+	for _, r := range matched {
+		entry := fmt.Sprintf("### %s (confidence: %.2f)\n\n%s\n\n---\n\n", r.ID, r.Confidence, r.Body)
+		if total+len(entry) > MaxPromptChars {
+			break
+		}
+		injected[r.ID] = true
+		total += len(entry)
+	}
+	return injected
+}
+
 // ByID finds a rule by its ID.
 func (rl *RuleLoader) ByID(id string) *Rule {
 	rl.mu.RLock()

--- a/internal/rules/writer.go
+++ b/internal/rules/writer.go
@@ -5,9 +5,17 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"gopkg.in/yaml.v3"
 )
+
+// fileMu serializes all read-modify-write operations on rule YAML files.
+// Both the feedback goroutine (stampRuleValidation) and the synthesis goroutine
+// (applySynthesisResult / applyDecay) write rule files concurrently; without this
+// lock a read→modify→write in one goroutine can overwrite a concurrent write from
+// the other, silently dropping either the confidence or last_validated_at update.
+var fileMu sync.Mutex
 
 // WriteRule writes a Rule to a YAML file in rules/{stage}/ directory.
 func WriteRule(rulesDir string, rule *Rule) error {
@@ -27,6 +35,9 @@ func WriteRule(rulesDir string, rule *Rule) error {
 
 // UpdateRuleConfidence updates only the confidence field of an existing rule file.
 func UpdateRuleConfidence(rulesDir string, ruleID string, stage string, newConfidence float64) error {
+	fileMu.Lock()
+	defer fileMu.Unlock()
+
 	path := findRuleFile(rulesDir, ruleID, stage)
 	if path == "" {
 		return fmt.Errorf("rule file not found: %s", ruleID)
@@ -53,6 +64,9 @@ func UpdateRuleConfidence(rulesDir string, ruleID string, stage string, newConfi
 
 // UpdateRuleLastValidatedAt updates the last_validated_at field of an existing rule file.
 func UpdateRuleLastValidatedAt(rulesDir string, ruleID string, stage string, validatedAt string) error {
+	fileMu.Lock()
+	defer fileMu.Unlock()
+
 	path := findRuleFile(rulesDir, ruleID, stage)
 	if path == "" {
 		return fmt.Errorf("rule file not found: %s", ruleID)

--- a/internal/rules/writer.go
+++ b/internal/rules/writer.go
@@ -93,6 +93,9 @@ func UpdateRuleLastValidatedAt(rulesDir string, ruleID string, stage string, val
 
 // DeleteRule removes a rule file from disk.
 func DeleteRule(rulesDir string, ruleID string, stage string) error {
+	fileMu.Lock()
+	defer fileMu.Unlock()
+
 	path := findRuleFile(rulesDir, ruleID, stage)
 	if path == "" {
 		return nil // already gone

--- a/internal/rules/writer.go
+++ b/internal/rules/writer.go
@@ -51,6 +51,32 @@ func UpdateRuleConfidence(rulesDir string, ruleID string, stage string, newConfi
 	return os.WriteFile(path, updated, 0644)
 }
 
+// UpdateRuleLastValidatedAt updates the last_validated_at field of an existing rule file.
+func UpdateRuleLastValidatedAt(rulesDir string, ruleID string, stage string, validatedAt string) error {
+	path := findRuleFile(rulesDir, ruleID, stage)
+	if path == "" {
+		return fmt.Errorf("rule file not found: %s", ruleID)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+
+	var rule Rule
+	if err := yaml.Unmarshal(data, &rule); err != nil {
+		return err
+	}
+
+	rule.LastValidatedAt = validatedAt
+	updated, err := yaml.Marshal(&rule)
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(path, updated, 0644)
+}
+
 // DeleteRule removes a rule file from disk.
 func DeleteRule(rulesDir string, ruleID string, stage string) error {
 	path := findRuleFile(rulesDir, ruleID, stage)

--- a/internal/rules/writer.go
+++ b/internal/rules/writer.go
@@ -30,6 +30,8 @@ func WriteRule(rulesDir string, rule *Rule) error {
 	}
 
 	path := filepath.Join(dir, rule.ID+".yaml")
+	fileMu.Lock()
+	defer fileMu.Unlock()
 	return os.WriteFile(path, data, 0644)
 }
 

--- a/internal/rules/writer.go
+++ b/internal/rules/writer.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
@@ -103,6 +104,55 @@ func DeleteRule(rulesDir string, ruleID string, stage string) error {
 		return nil // already gone
 	}
 	return os.Remove(path)
+}
+
+// DecayRuleIfStale atomically reads last_validated_at from disk and, only if the
+// rule has not been validated within staleDays, multiplies confidence by decayFactor
+// (floored at minConf). The entire read-check-write runs under fileMu, which prevents
+// a concurrent stampRuleValidation write from racing with the applyDecay decision.
+func DecayRuleIfStale(rulesDir, ruleID, stage string, decayFactor, minConf float64, staleDays int) error {
+	fileMu.Lock()
+	defer fileMu.Unlock()
+
+	path := findRuleFile(rulesDir, ruleID, stage)
+	if path == "" {
+		return fmt.Errorf("rule file not found: %s", ruleID)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+
+	var rule Rule
+	if err := yaml.Unmarshal(data, &rule); err != nil {
+		return err
+	}
+
+	// Skip if validated within staleDays — reading from disk guarantees we see
+	// any last_validated_at that stampRuleValidation wrote before we acquired fileMu.
+	if rule.LastValidatedAt != "" {
+		validated, err := time.Parse("2006-01-02", rule.LastValidatedAt)
+		if err == nil && time.Since(validated) < time.Duration(staleDays)*24*time.Hour {
+			return nil
+		}
+	}
+
+	if rule.Confidence <= minConf {
+		return nil // already at floor
+	}
+
+	newConf := rule.Confidence * decayFactor
+	if newConf < minConf {
+		newConf = minConf
+	}
+	rule.Confidence = newConf
+
+	updated, err := yaml.Marshal(&rule)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, updated, 0644)
 }
 
 // findRuleFile locates a rule file by ID, checking stage dir first then walking all dirs.

--- a/internal/rules/writer_test.go
+++ b/internal/rules/writer_test.go
@@ -1,0 +1,146 @@
+package rules
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+func writeTestRule(t *testing.T, dir string, rule *Rule) {
+	t.Helper()
+	if err := WriteRule(dir, rule); err != nil {
+		t.Fatalf("WriteRule: %v", err)
+	}
+}
+
+func TestUpdateRuleLastValidatedAt(t *testing.T) {
+	dir := t.TempDir()
+
+	rule := &Rule{
+		ID:         "test-rule-001",
+		Stage:      "engineer",
+		Severity:   "medium",
+		Confidence: 0.8,
+		Source:     "synthesized",
+		CreatedAt:  "2024-01-01",
+		Body:       "Always write tests.",
+	}
+	writeTestRule(t, dir, rule)
+
+	today := time.Now().Format("2006-01-02")
+	if err := UpdateRuleLastValidatedAt(dir, rule.ID, rule.Stage, today); err != nil {
+		t.Fatalf("UpdateRuleLastValidatedAt: %v", err)
+	}
+
+	// Reload and verify
+	rl := NewRuleLoader(dir)
+	if err := rl.Load(); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	loaded := rl.ByID(rule.ID)
+	if loaded == nil {
+		t.Fatal("rule not found after update")
+	}
+	if loaded.LastValidatedAt != today {
+		t.Errorf("LastValidatedAt = %q, want %q", loaded.LastValidatedAt, today)
+	}
+	// Other fields must be unchanged
+	if loaded.Confidence != rule.Confidence {
+		t.Errorf("Confidence changed: got %.2f, want %.2f", loaded.Confidence, rule.Confidence)
+	}
+	if loaded.Body != rule.Body {
+		t.Errorf("Body changed")
+	}
+}
+
+func TestUpdateRuleLastValidatedAt_NotFound(t *testing.T) {
+	dir := t.TempDir()
+	err := UpdateRuleLastValidatedAt(dir, "nonexistent", "engineer", "2024-01-01")
+	if err == nil {
+		t.Fatal("expected error for missing rule, got nil")
+	}
+}
+
+func TestWriteRuleSetsLastValidatedAt(t *testing.T) {
+	dir := t.TempDir()
+	today := time.Now().Format("2006-01-02")
+
+	rule := &Rule{
+		ID:              "test-rule-002",
+		Stage:           "scout",
+		Severity:        "low",
+		Confidence:      0.6,
+		Source:          "synthesized",
+		CreatedAt:       today,
+		LastValidatedAt: today,
+		Body:            "Check upstream issues first.",
+	}
+	writeTestRule(t, dir, rule)
+
+	rl := NewRuleLoader(dir)
+	if err := rl.Load(); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	loaded := rl.ByID(rule.ID)
+	if loaded == nil {
+		t.Fatal("rule not found")
+	}
+	if loaded.LastValidatedAt != today {
+		t.Errorf("LastValidatedAt = %q, want %q", loaded.LastValidatedAt, today)
+	}
+}
+
+func TestUpdateRuleLastValidatedAt_PreservesContent(t *testing.T) {
+	dir := t.TempDir()
+	rule := &Rule{
+		ID:            "test-rule-003",
+		Stage:         "analyst",
+		Severity:      "high",
+		Confidence:    0.75,
+		Source:        "synthesized",
+		CreatedAt:     "2024-06-01",
+		EvidenceCount: 10,
+		Tags:          []string{"scope", "quality"},
+		Condition:     "when PR modifies core logic",
+		Body:          "Verify test coverage before approving.",
+	}
+	writeTestRule(t, dir, rule)
+
+	newDate := "2025-03-15"
+	if err := UpdateRuleLastValidatedAt(dir, rule.ID, rule.Stage, newDate); err != nil {
+		t.Fatalf("UpdateRuleLastValidatedAt: %v", err)
+	}
+
+	// Verify file on disk still has all fields
+	data, err := os.ReadFile(dir + "/analyst/" + rule.ID + ".yaml")
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	content := string(data)
+
+	for _, want := range []string{
+		"test-rule-003",
+		"analyst",
+		"synthesized",
+		"10",
+		"2025-03-15",
+		"Verify test coverage",
+	} {
+		if !contains(content, want) {
+			t.Errorf("rule file missing expected content %q", want)
+		}
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsStr(s, substr))
+}
+
+func containsStr(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/rules/writer_test.go
+++ b/internal/rules/writer_test.go
@@ -111,7 +111,6 @@ func TestUpdateRuleLastValidatedAt_PreservesContent(t *testing.T) {
 		t.Fatalf("UpdateRuleLastValidatedAt: %v", err)
 	}
 
-	// Verify file on disk still has all fields
 	data, err := os.ReadFile(dir + "/analyst/" + rule.ID + ".yaml")
 	if err != nil {
 		t.Fatalf("ReadFile: %v", err)
@@ -126,14 +125,46 @@ func TestUpdateRuleLastValidatedAt_PreservesContent(t *testing.T) {
 		"2025-03-15",
 		"Verify test coverage",
 	} {
-		if !contains(content, want) {
+		if !containsStr(content, want) {
 			t.Errorf("rule file missing expected content %q", want)
 		}
 	}
 }
 
-func contains(s, substr string) bool {
-	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsStr(s, substr))
+// TestUpdateRuleConfidence_PreservesLastValidatedAt verifies that updating
+// confidence does not overwrite last_validated_at.
+func TestUpdateRuleConfidence_PreservesLastValidatedAt(t *testing.T) {
+	dir := t.TempDir()
+	rule := &Rule{
+		ID:              "test-rule-004",
+		Stage:           "analyst",
+		Severity:        "high",
+		Confidence:      0.8,
+		Source:          "synthesized",
+		CreatedAt:       "2024-06-01",
+		LastValidatedAt: "2024-06-15",
+		Body:            "Check for CLA requirement.",
+	}
+	writeTestRule(t, dir, rule)
+
+	if err := UpdateRuleConfidence(dir, rule.ID, rule.Stage, 0.6); err != nil {
+		t.Fatalf("UpdateRuleConfidence: %v", err)
+	}
+
+	rl := NewRuleLoader(dir)
+	if err := rl.Load(); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	loaded := rl.ByID(rule.ID)
+	if loaded == nil {
+		t.Fatal("rule not found after confidence update")
+	}
+	if loaded.Confidence != 0.6 {
+		t.Errorf("Confidence = %.2f, want 0.60", loaded.Confidence)
+	}
+	if loaded.LastValidatedAt != "2024-06-15" {
+		t.Errorf("LastValidatedAt changed: got %q, want %q", loaded.LastValidatedAt, "2024-06-15")
+	}
 }
 
 func containsStr(s, substr string) bool {

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -17,20 +17,20 @@ const (
 
 	// V2 pipeline statuses
 	IssueStatusAnalyzing   IssueStatus = "analyzing"   // Analyst agent running
-	IssueStatusEngineering IssueStatus = "engineering"  // Engineer agent running
-	IssueStatusReviewing   IssueStatus = "reviewing"    // Reviewer agent running
-	IssueStatusRework      IssueStatus = "rework"       // Engineer reworking after review
-	IssueStatusSubmitting  IssueStatus = "submitting"   // Submitter agent running
+	IssueStatusEngineering IssueStatus = "engineering" // Engineer agent running
+	IssueStatusReviewing   IssueStatus = "reviewing"   // Reviewer agent running
+	IssueStatusRework      IssueStatus = "rework"      // Engineer reworking after review
+	IssueStatusSubmitting  IssueStatus = "submitting"  // Submitter agent running
 )
 
 // PRStatus represents the status of a pull request
 type PRStatus string
 
 const (
-	PRStatusDraft      PRStatus = "draft" // Draft PR, waiting for CI
-	PRStatusOpen       PRStatus = "open"  // Ready for review, checking feedback
-	PRStatusMerged     PRStatus = "merged"
-	PRStatusClosed     PRStatus = "closed"
+	PRStatusDraft          PRStatus = "draft" // Draft PR, waiting for CI
+	PRStatusOpen           PRStatus = "open"  // Ready for review, checking feedback
+	PRStatusMerged         PRStatus = "merged"
+	PRStatusClosed         PRStatus = "closed"
 	PRStatusResponding     PRStatus = "responding"
 	PRStatusNeedsAttention PRStatus = "needs_attention" // Requires manual action (e.g. CLA signing)
 )
@@ -39,16 +39,16 @@ const (
 type FailureReason string
 
 const (
-	FailureReasonTimeout          FailureReason = "timeout"
-	FailureReasonNoChanges        FailureReason = "no_changes"
-	FailureReasonTestsFailed      FailureReason = "tests_failed"
-	FailureReasonCIFailed         FailureReason = "ci_failed"
-	FailureReasonCloneFailed      FailureReason = "clone_failed"
-	FailureReasonPRFailed         FailureReason = "pr_failed"
-	FailureReasonComplexityHigh   FailureReason = "complexity_too_high"
-	FailureReasonAlreadyHasPR     FailureReason = "already_has_pr"
-	FailureReasonAlreadyFixed     FailureReason = "already_fixed"
-	FailureReasonUnknown          FailureReason = "unknown"
+	FailureReasonTimeout        FailureReason = "timeout"
+	FailureReasonNoChanges      FailureReason = "no_changes"
+	FailureReasonTestsFailed    FailureReason = "tests_failed"
+	FailureReasonCIFailed       FailureReason = "ci_failed"
+	FailureReasonCloneFailed    FailureReason = "clone_failed"
+	FailureReasonPRFailed       FailureReason = "pr_failed"
+	FailureReasonComplexityHigh FailureReason = "complexity_too_high"
+	FailureReasonAlreadyHasPR   FailureReason = "already_has_pr"
+	FailureReasonAlreadyFixed   FailureReason = "already_fixed"
+	FailureReasonUnknown        FailureReason = "unknown"
 )
 
 // Issue represents a discovered GitHub issue
@@ -85,22 +85,22 @@ func (r FailureReason) IsRetryable() bool {
 
 // PullRequest represents a created pull request
 type PullRequest struct {
-	ID                 int64      `db:"id" json:"id"`
-	IssueID            int64      `db:"issue_id" json:"issue_id"`
-	PRURL              string     `db:"pr_url" json:"pr_url"`
-	PRNumber           int        `db:"pr_number" json:"pr_number"`
-	BranchName         string     `db:"branch_name" json:"branch_name"`
-	Status             PRStatus   `db:"status" json:"status"`
-	CIStatus           string     `db:"ci_status" json:"ci_status"`
-	RetryCount         int        `db:"retry_count" json:"retry_count"`
-	MergedAt           *time.Time `db:"merged_at" json:"merged_at,omitempty"`
-	ClosedAt           *time.Time `db:"closed_at" json:"closed_at,omitempty"`
-	ReviewCommentCount int        `db:"review_comment_count" json:"review_comment_count"`
-	FirstReviewAt      *time.Time `db:"first_review_at" json:"first_review_at,omitempty"`
-	CreatedAt            time.Time  `db:"created_at" json:"created_at"`
-	UpdatedAt            time.Time  `db:"updated_at" json:"updated_at"`
-	LastFeedbackCheckAt  *time.Time `db:"last_feedback_check_at" json:"last_feedback_check_at,omitempty"`
-	FeedbackRound        int        `db:"feedback_round" json:"feedback_round"`
+	ID                  int64      `db:"id" json:"id"`
+	IssueID             int64      `db:"issue_id" json:"issue_id"`
+	PRURL               string     `db:"pr_url" json:"pr_url"`
+	PRNumber            int        `db:"pr_number" json:"pr_number"`
+	BranchName          string     `db:"branch_name" json:"branch_name"`
+	Status              PRStatus   `db:"status" json:"status"`
+	CIStatus            string     `db:"ci_status" json:"ci_status"`
+	RetryCount          int        `db:"retry_count" json:"retry_count"`
+	MergedAt            *time.Time `db:"merged_at" json:"merged_at,omitempty"`
+	ClosedAt            *time.Time `db:"closed_at" json:"closed_at,omitempty"`
+	ReviewCommentCount  int        `db:"review_comment_count" json:"review_comment_count"`
+	FirstReviewAt       *time.Time `db:"first_review_at" json:"first_review_at,omitempty"`
+	CreatedAt           time.Time  `db:"created_at" json:"created_at"`
+	UpdatedAt           time.Time  `db:"updated_at" json:"updated_at"`
+	LastFeedbackCheckAt *time.Time `db:"last_feedback_check_at" json:"last_feedback_check_at,omitempty"`
+	FeedbackRound       int        `db:"feedback_round" json:"feedback_round"`
 }
 
 // TimeToMerge returns the duration from PR creation to merge
@@ -179,22 +179,22 @@ type IssueMetrics struct {
 
 // DailyStats holds daily aggregated statistics
 type DailyStats struct {
-	ID                     int64     `db:"id"`
-	Date                   string    `db:"date"` // YYYY-MM-DD
-	IssuesDiscovered       int       `db:"issues_discovered"`
-	IssuesAttempted        int       `db:"issues_attempted"`
-	IssuesSolved           int       `db:"issues_solved"`
-	PRsCreated             int       `db:"prs_created"`
-	PRsMerged              int       `db:"prs_merged"`
-	PRsClosed              int       `db:"prs_closed"`
-	AvgSolveTimeSeconds    *float64  `db:"avg_solve_time_seconds"`
-	AvgAttemptsPerIssue    *float64  `db:"avg_attempts_per_issue"`
-	FirstAttemptSuccessRate *float64 `db:"first_attempt_success_rate"`
-	OverallSuccessRate     *float64  `db:"overall_success_rate"`
-	StatsByLanguage        string    `db:"stats_by_language"`     // JSON
-	StatsByRepo            string    `db:"stats_by_repo"`         // JSON
-	FailureReasonsCount    string    `db:"failure_reasons_count"` // JSON
-	CreatedAt              time.Time `db:"created_at"`
+	ID                      int64     `db:"id"`
+	Date                    string    `db:"date"` // YYYY-MM-DD
+	IssuesDiscovered        int       `db:"issues_discovered"`
+	IssuesAttempted         int       `db:"issues_attempted"`
+	IssuesSolved            int       `db:"issues_solved"`
+	PRsCreated              int       `db:"prs_created"`
+	PRsMerged               int       `db:"prs_merged"`
+	PRsClosed               int       `db:"prs_closed"`
+	AvgSolveTimeSeconds     *float64  `db:"avg_solve_time_seconds"`
+	AvgAttemptsPerIssue     *float64  `db:"avg_attempts_per_issue"`
+	FirstAttemptSuccessRate *float64  `db:"first_attempt_success_rate"`
+	OverallSuccessRate      *float64  `db:"overall_success_rate"`
+	StatsByLanguage         string    `db:"stats_by_language"`     // JSON
+	StatsByRepo             string    `db:"stats_by_repo"`         // JSON
+	FailureReasonsCount     string    `db:"failure_reasons_count"` // JSON
+	CreatedAt               time.Time `db:"created_at"`
 }
 
 // RepoMetrics holds aggregated metrics per repository
@@ -249,14 +249,14 @@ type LanguageMetrics struct {
 
 // PRMetrics holds PR-related aggregate statistics
 type PRMetrics struct {
-	TotalPRs           int     `json:"total_prs"`
-	OpenPRs            int     `json:"open_prs"`
-	MergedPRs          int     `json:"merged_prs"`
-	ClosedPRs          int     `json:"closed_prs"`
-	MergeRate          float64 `json:"merge_rate"`
-	AvgTimeToMerge     float64 `json:"avg_time_to_merge_hours"`
+	TotalPRs             int     `json:"total_prs"`
+	OpenPRs              int     `json:"open_prs"`
+	MergedPRs            int     `json:"merged_prs"`
+	ClosedPRs            int     `json:"closed_prs"`
+	MergeRate            float64 `json:"merge_rate"`
+	AvgTimeToMerge       float64 `json:"avg_time_to_merge_hours"`
 	AvgTimeToFirstReview float64 `json:"avg_time_to_first_review_hours"`
-	AvgReviewComments  float64 `json:"avg_review_comments"`
+	AvgReviewComments    float64 `json:"avg_review_comments"`
 }
 
 // BlacklistEntry represents a blacklisted repository
@@ -273,8 +273,8 @@ type ReviewLesson struct {
 	ID            int64     `db:"id" json:"id"`
 	PRID          int64     `db:"pr_id" json:"pr_id"`
 	Repo          string    `db:"repo" json:"repo"`
-	Category      string    `db:"category" json:"category"`           // testing, style, scope, docs, ci, logic
-	Lesson        string    `db:"lesson" json:"lesson"`               // extracted actionable lesson
+	Category      string    `db:"category" json:"category"`             // testing, style, scope, docs, ci, logic
+	Lesson        string    `db:"lesson" json:"lesson"`                 // extracted actionable lesson
 	SourceComment string    `db:"source_comment" json:"source_comment"` // original reviewer text
 	Reviewer      string    `db:"reviewer" json:"reviewer"`
 	CreatedAt     time.Time `db:"created_at" json:"created_at"`
@@ -282,20 +282,20 @@ type ReviewLesson struct {
 
 // PipelineEvent records a single agent invocation in the pipeline.
 type PipelineEvent struct {
-	ID               int64      `db:"id" json:"id"`
-	IssueID          int64      `db:"issue_id" json:"issue_id"`
-	PRID             *int64     `db:"pr_id" json:"pr_id,omitempty"`
-	Repo             string     `db:"repo" json:"repo"`
-	IssueNumber      int        `db:"issue_number" json:"issue_number"`
-	Stage            string     `db:"stage" json:"stage"`
-	Round            int        `db:"round" json:"round"`
-	StartedAt        time.Time  `db:"started_at" json:"started_at"`
-	CompletedAt      *time.Time `db:"completed_at" json:"completed_at,omitempty"`
-	DurationSeconds  float64    `db:"duration_seconds" json:"duration_seconds"`
-	OutputSummary    string     `db:"output_summary" json:"output_summary"`
-	Verdict          string     `db:"verdict" json:"verdict"`
-	Success          bool       `db:"success" json:"success"`
-	ErrorMessage     string     `db:"error_message" json:"error_message,omitempty"`
-	OutcomeLabel     string     `db:"outcome_label" json:"outcome_label,omitempty"`
-	CreatedAt        time.Time  `db:"created_at" json:"created_at"`
+	ID              int64      `db:"id" json:"id"`
+	IssueID         int64      `db:"issue_id" json:"issue_id"`
+	PRID            *int64     `db:"pr_id" json:"pr_id,omitempty"`
+	Repo            string     `db:"repo" json:"repo"`
+	IssueNumber     int        `db:"issue_number" json:"issue_number"`
+	Stage           string     `db:"stage" json:"stage"`
+	Round           int        `db:"round" json:"round"`
+	StartedAt       time.Time  `db:"started_at" json:"started_at"`
+	CompletedAt     *time.Time `db:"completed_at" json:"completed_at,omitempty"`
+	DurationSeconds float64    `db:"duration_seconds" json:"duration_seconds"`
+	OutputSummary   string     `db:"output_summary" json:"output_summary"`
+	Verdict         string     `db:"verdict" json:"verdict"`
+	Success         bool       `db:"success" json:"success"`
+	ErrorMessage    string     `db:"error_message" json:"error_message,omitempty"`
+	OutcomeLabel    string     `db:"outcome_label" json:"outcome_label,omitempty"`
+	CreatedAt       time.Time  `db:"created_at" json:"created_at"`
 }


### PR DESCRIPTION
## Problem

`applyDecay()` in `internal/pipeline/synthesizer.go` multiplies all synthesized rule confidences by 0.9 on every synthesis run. The exemption condition checks `last_validated_at` within 30 days — but **nothing in the codebase ever wrote that field**, so the exemption never fired.

After 9 synthesis runs: `0.9^9 = 0.387` — all synthesized rules uniformly lost 61.3% confidence.

Closes #12

## Root Cause

- `applySynthesisResult()` created new rules and updated existing rules without setting `LastValidatedAt`
- `extractAndStoreLessons()` classified PR outcomes but never stamped validation on the rules that guided those stages

## Fix

Three targeted changes:

**1. `internal/rules/writer.go`** — add `UpdateRuleLastValidatedAt` function

**2. `internal/pipeline/synthesizer.go` — `applySynthesisResult`**
- New rules: include `LastValidatedAt = today` in the `Rule` struct at write time
- Updated rules: call `UpdateRuleLastValidatedAt` after `UpdateRuleConfidence`

Synthesis processes labeled evidence and adjusts rules accordingly — this is the natural validation point.

**3. `internal/pipeline/lessons.go` — `extractAndStoreLessons`**
- When a PR outcome is `merged`, call `stampRuleValidation` which looks up the pipeline stages used for that PR's issue and stamps `last_validated_at` on all synthesized rules for those stages
- Merged PRs confirm the rules guiding those stages produced accepted output

## Tests Added

| File | Tests |
|------|-------|
| `internal/rules/writer_test.go` | `TestUpdateRuleLastValidatedAt`, `TestUpdateRuleLastValidatedAt_NotFound`, `TestWriteRuleSetsLastValidatedAt`, `TestUpdateRuleLastValidatedAt_PreservesContent` |
| `internal/pipeline/synthesizer_test.go` | `TestApplyDecay_ReducesConfidenceWithoutValidation`, `TestApplyDecay_ExemptsRecentlyValidatedRules`, `TestApplyDecay_ExemptsManualRules`, `TestApplyDecay_FloorsAtMinimum`, `TestApplyDecay_ExemptsStaleValidation`, `TestApplySynthesisResult_NewRuleSetsLastValidatedAt`, `TestApplySynthesisResult_UpdatedRuleSetsLastValidatedAt` |

## Test Results

```
ok  github.com/majiayu000/auto-contributor/internal/rules     0.727s
ok  github.com/majiayu000/auto-contributor/internal/pipeline  0.964s
```