### PR TITLE
feat: add repo_profiles table for repo-level learning

### DIFF
--- a/cmd/auto-contributor/cmd_discover.go
+++ b/cmd/auto-contributor/cmd_discover.go
@@ -33,6 +33,18 @@ func discoverIssues(cmd *cobra.Command, args []string) error {
 			continue
 		}
 
+		// Check repo profile: skip blacklisted or cooling-down repos
+		if profile, err := database.GetRepoProfile(issue.Repo); err == nil && profile != nil {
+			if profile.Blacklisted {
+				fmt.Printf("Skipping profile-blacklisted repo: %s (%s)\n", issue.Repo, profile.BlacklistReason)
+				continue
+			}
+			if profile.IsOnCooldown() {
+				fmt.Printf("Skipping repo on cooldown: %s (until %s)\n", issue.Repo, profile.CooldownUntil.Format("2006-01-02"))
+				continue
+			}
+		}
+
 		// Save to database
 		if err := database.CreateIssue(issue); err != nil {
 			fmt.Printf("Warning: failed to save issue %s#%d: %v\n", issue.Repo, issue.IssueNumber, err)
@@ -139,6 +151,18 @@ func smartDiscover(cmd *cobra.Command, args []string) error {
 				if isBlacklisted {
 					fmt.Printf("   Skipping blacklisted repo: %s\n", issue.Repo)
 					continue
+				}
+
+				// Check repo profile: skip blacklisted or cooling-down repos
+				if profile, err := database.GetRepoProfile(issue.Repo); err == nil && profile != nil {
+					if profile.Blacklisted {
+						fmt.Printf("   Skipping profile-blacklisted repo: %s (%s)\n", issue.Repo, profile.BlacklistReason)
+						continue
+					}
+					if profile.IsOnCooldown() {
+						fmt.Printf("   Skipping repo on cooldown: %s (until %s)\n", issue.Repo, profile.CooldownUntil.Format("2006-01-02"))
+						continue
+					}
 				}
 
 				dbIssue := &models.Issue{

--- a/cmd/auto-contributor/cmd_discover.go
+++ b/cmd/auto-contributor/cmd_discover.go
@@ -34,7 +34,10 @@ func discoverIssues(cmd *cobra.Command, args []string) error {
 		}
 
 		// Check repo profile: skip blacklisted or cooling-down repos
-		if profile, err := database.GetRepoProfile(issue.Repo); err == nil && profile != nil {
+		if profile, err := database.GetRepoProfile(issue.Repo); err != nil {
+			fmt.Printf("Warning: failed to check repo profile for %s, skipping to be safe: %v\n", issue.Repo, err)
+			continue
+		} else if profile != nil {
 			if profile.Blacklisted {
 				fmt.Printf("Skipping profile-blacklisted repo: %s (%s)\n", issue.Repo, profile.BlacklistReason)
 				continue
@@ -154,7 +157,10 @@ func smartDiscover(cmd *cobra.Command, args []string) error {
 				}
 
 				// Check repo profile: skip blacklisted or cooling-down repos
-				if profile, err := database.GetRepoProfile(issue.Repo); err == nil && profile != nil {
+				if profile, err := database.GetRepoProfile(issue.Repo); err != nil {
+					fmt.Printf("   Warning: failed to check repo profile for %s, skipping to be safe: %v\n", issue.Repo, err)
+					continue
+				} else if profile != nil {
 					if profile.Blacklisted {
 						fmt.Printf("   Skipping profile-blacklisted repo: %s (%s)\n", issue.Repo, profile.BlacklistReason)
 						continue

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -269,6 +269,24 @@ func (db *DB) sqliteSchema() string {
 	);
 
 	CREATE INDEX IF NOT EXISTS idx_blacklist_repo ON blacklist(repo);
+
+	CREATE TABLE IF NOT EXISTS repo_profiles (
+		repo TEXT PRIMARY KEY,
+		total_prs_submitted INTEGER DEFAULT 0,
+		total_merged INTEGER DEFAULT 0,
+		total_rejected INTEGER DEFAULT 0,
+		merge_rate REAL DEFAULT 0,
+		avg_response_time_hours REAL,
+		requires_cla INTEGER DEFAULT 0,
+		requires_assignment INTEGER DEFAULT 0,
+		preferred_pr_size TEXT,
+		blacklisted INTEGER DEFAULT 0,
+		blacklist_reason TEXT,
+		cooldown_until DATETIME,
+		strategy_notes TEXT,
+		last_interaction DATETIME,
+		updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+	);
 	`
 }
 
@@ -424,6 +442,24 @@ func (db *DB) postgresSchema() string {
 	);
 
 	CREATE INDEX IF NOT EXISTS idx_blacklist_repo ON blacklist(repo);
+
+	CREATE TABLE IF NOT EXISTS repo_profiles (
+		repo TEXT PRIMARY KEY,
+		total_prs_submitted INT DEFAULT 0,
+		total_merged INT DEFAULT 0,
+		total_rejected INT DEFAULT 0,
+		merge_rate FLOAT DEFAULT 0,
+		avg_response_time_hours FLOAT,
+		requires_cla BOOLEAN DEFAULT FALSE,
+		requires_assignment BOOLEAN DEFAULT FALSE,
+		preferred_pr_size TEXT,
+		blacklisted BOOLEAN DEFAULT FALSE,
+		blacklist_reason TEXT,
+		cooldown_until TIMESTAMP,
+		strategy_notes TEXT,
+		last_interaction TIMESTAMP,
+		updated_at TIMESTAMP DEFAULT NOW()
+	);
 	`
 }
 

--- a/internal/db/repo_profiles.go
+++ b/internal/db/repo_profiles.go
@@ -172,8 +172,8 @@ func (db *DB) SyncRepoProfileStats(repo string) error {
 	countQ := fmt.Sprintf(`
 		SELECT
 			COUNT(DISTINCT pr.id),
-			SUM(CASE WHEN pr.status = 'merged' THEN 1 ELSE 0 END),
-			SUM(CASE WHEN pr.status = 'closed' THEN 1 ELSE 0 END)
+			COALESCE(SUM(CASE WHEN pr.status = 'merged' THEN 1 ELSE 0 END), 0),
+			COALESCE(SUM(CASE WHEN pr.status = 'closed' THEN 1 ELSE 0 END), 0)
 		FROM pull_requests pr
 		JOIN issues i ON pr.issue_id = i.id
 		WHERE i.repo = %s

--- a/internal/db/repo_profiles.go
+++ b/internal/db/repo_profiles.go
@@ -1,0 +1,271 @@
+package db
+
+import (
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/majiayu000/auto-contributor/pkg/models"
+)
+
+// UpsertRepoProfile creates or fully replaces a repo profile record.
+// Use this for manually managed fields (RequiresCLA, StrategyNotes, CooldownUntil, etc.).
+// Stats fields are overwritten too, so call SyncRepoProfileStats afterwards if you
+// want to keep computed stats accurate.
+func (db *DB) UpsertRepoProfile(p *models.RepoProfile) error {
+	now := time.Now()
+	p.UpdatedAt = now
+
+	var query string
+	if db.IsPostgres() {
+		query = fmt.Sprintf(`
+			INSERT INTO repo_profiles (
+				repo, total_prs_submitted, total_merged, total_rejected, merge_rate,
+				avg_response_time_hours, requires_cla, requires_assignment, preferred_pr_size,
+				blacklisted, blacklist_reason, cooldown_until, strategy_notes,
+				last_interaction, updated_at
+			) VALUES (%s)
+			ON CONFLICT(repo) DO UPDATE SET
+				total_prs_submitted   = EXCLUDED.total_prs_submitted,
+				total_merged          = EXCLUDED.total_merged,
+				total_rejected        = EXCLUDED.total_rejected,
+				merge_rate            = EXCLUDED.merge_rate,
+				avg_response_time_hours = EXCLUDED.avg_response_time_hours,
+				requires_cla          = EXCLUDED.requires_cla,
+				requires_assignment   = EXCLUDED.requires_assignment,
+				preferred_pr_size     = EXCLUDED.preferred_pr_size,
+				blacklisted           = EXCLUDED.blacklisted,
+				blacklist_reason      = EXCLUDED.blacklist_reason,
+				cooldown_until        = EXCLUDED.cooldown_until,
+				strategy_notes        = EXCLUDED.strategy_notes,
+				last_interaction      = EXCLUDED.last_interaction,
+				updated_at            = EXCLUDED.updated_at
+		`, db.placeholders(15))
+	} else {
+		query = fmt.Sprintf(`
+			INSERT INTO repo_profiles (
+				repo, total_prs_submitted, total_merged, total_rejected, merge_rate,
+				avg_response_time_hours, requires_cla, requires_assignment, preferred_pr_size,
+				blacklisted, blacklist_reason, cooldown_until, strategy_notes,
+				last_interaction, updated_at
+			) VALUES (%s)
+			ON CONFLICT(repo) DO UPDATE SET
+				total_prs_submitted   = excluded.total_prs_submitted,
+				total_merged          = excluded.total_merged,
+				total_rejected        = excluded.total_rejected,
+				merge_rate            = excluded.merge_rate,
+				avg_response_time_hours = excluded.avg_response_time_hours,
+				requires_cla          = excluded.requires_cla,
+				requires_assignment   = excluded.requires_assignment,
+				preferred_pr_size     = excluded.preferred_pr_size,
+				blacklisted           = excluded.blacklisted,
+				blacklist_reason      = excluded.blacklist_reason,
+				cooldown_until        = excluded.cooldown_until,
+				strategy_notes        = excluded.strategy_notes,
+				last_interaction      = excluded.last_interaction,
+				updated_at            = excluded.updated_at
+		`, db.placeholders(15))
+	}
+
+	_, err := db.Exec(query,
+		p.Repo,
+		p.TotalPRsSubmitted,
+		p.TotalMerged,
+		p.TotalRejected,
+		p.MergeRate,
+		p.AvgResponseTimeHours,
+		p.RequiresCLA,
+		p.RequiresAssignment,
+		p.PreferredPRSize,
+		p.Blacklisted,
+		p.BlacklistReason,
+		p.CooldownUntil,
+		p.StrategyNotes,
+		p.LastInteraction,
+		p.UpdatedAt,
+	)
+	return err
+}
+
+// GetRepoProfile retrieves the profile for a repo.
+// Returns (nil, nil) when no profile exists yet.
+func (db *DB) GetRepoProfile(repo string) (*models.RepoProfile, error) {
+	query := fmt.Sprintf(`
+		SELECT repo, total_prs_submitted, total_merged, total_rejected, merge_rate,
+		       avg_response_time_hours, requires_cla, requires_assignment, preferred_pr_size,
+		       blacklisted, blacklist_reason, cooldown_until, strategy_notes,
+		       last_interaction, updated_at
+		FROM repo_profiles WHERE repo = %s
+	`, db.placeholder(1))
+
+	p := &models.RepoProfile{}
+	var (
+		avgResp     sql.NullFloat64
+		prefSize    sql.NullString
+		blackReason sql.NullString
+		cooldown    sql.NullTime
+		strategy    sql.NullString
+		lastInter   sql.NullTime
+	)
+	err := db.QueryRow(query, repo).Scan(
+		&p.Repo,
+		&p.TotalPRsSubmitted,
+		&p.TotalMerged,
+		&p.TotalRejected,
+		&p.MergeRate,
+		&avgResp,
+		&p.RequiresCLA,
+		&p.RequiresAssignment,
+		&prefSize,
+		&p.Blacklisted,
+		&blackReason,
+		&cooldown,
+		&strategy,
+		&lastInter,
+		&p.UpdatedAt,
+	)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if avgResp.Valid {
+		p.AvgResponseTimeHours = &avgResp.Float64
+	}
+	if prefSize.Valid {
+		p.PreferredPRSize = prefSize.String
+	}
+	if blackReason.Valid {
+		p.BlacklistReason = blackReason.String
+	}
+	if cooldown.Valid {
+		p.CooldownUntil = &cooldown.Time
+	}
+	if strategy.Valid {
+		p.StrategyNotes = strategy.String
+	}
+	if lastInter.Valid {
+		p.LastInteraction = &lastInter.Time
+	}
+
+	return p, nil
+}
+
+// SyncRepoProfileStats recomputes the stat fields for a repo from pull_requests
+// and issues, then upserts only those fields — leaving manually set fields
+// (RequiresCLA, StrategyNotes, CooldownUntil, etc.) untouched.
+func (db *DB) SyncRepoProfileStats(repo string) error {
+	// Compute stats from pull_requests JOIN issues.
+	type stats struct {
+		submitted    int
+		merged       int
+		rejected     int
+		mergeRate    float64
+		avgRespHours sql.NullFloat64
+		lastInter    sql.NullTime
+	}
+
+	var s stats
+
+	countQ := fmt.Sprintf(`
+		SELECT
+			COUNT(DISTINCT pr.id),
+			SUM(CASE WHEN pr.status = 'merged' THEN 1 ELSE 0 END),
+			SUM(CASE WHEN pr.status = 'closed' THEN 1 ELSE 0 END)
+		FROM pull_requests pr
+		JOIN issues i ON pr.issue_id = i.id
+		WHERE i.repo = %s
+	`, db.placeholder(1))
+	if err := db.QueryRow(countQ, repo).Scan(&s.submitted, &s.merged, &s.rejected); err != nil {
+		return fmt.Errorf("count PRs for %s: %w", repo, err)
+	}
+
+	terminal := s.merged + s.rejected
+	if terminal > 0 {
+		s.mergeRate = float64(s.merged) / float64(terminal)
+	}
+
+	// Average response time: hours from PR creation to first review, where available.
+	var avgQ string
+	if db.IsPostgres() {
+		avgQ = fmt.Sprintf(`
+			SELECT AVG(EXTRACT(EPOCH FROM (pr.first_review_at - pr.created_at)) / 3600)
+			FROM pull_requests pr
+			JOIN issues i ON pr.issue_id = i.id
+			WHERE i.repo = %s AND pr.first_review_at IS NOT NULL
+		`, db.placeholder(1))
+	} else {
+		avgQ = fmt.Sprintf(`
+			SELECT AVG((julianday(pr.first_review_at) - julianday(pr.created_at)) * 24)
+			FROM pull_requests pr
+			JOIN issues i ON pr.issue_id = i.id
+			WHERE i.repo = %s AND pr.first_review_at IS NOT NULL
+		`, db.placeholder(1))
+	}
+	db.QueryRow(avgQ, repo).Scan(&s.avgRespHours) //nolint:errcheck — NULL is fine
+
+	// Last interaction: most recent PR updated_at.
+	lastQ := fmt.Sprintf(`
+		SELECT MAX(pr.updated_at)
+		FROM pull_requests pr
+		JOIN issues i ON pr.issue_id = i.id
+		WHERE i.repo = %s
+	`, db.placeholder(1))
+	db.QueryRow(lastQ, repo).Scan(&s.lastInter) //nolint:errcheck — NULL is fine
+
+	// Upsert only stat columns; preserve manually set fields on conflict.
+	now := time.Now()
+	var upsertQ string
+	if db.IsPostgres() {
+		upsertQ = fmt.Sprintf(`
+			INSERT INTO repo_profiles (repo, total_prs_submitted, total_merged, total_rejected,
+				merge_rate, avg_response_time_hours, last_interaction, updated_at)
+			VALUES (%s)
+			ON CONFLICT(repo) DO UPDATE SET
+				total_prs_submitted     = EXCLUDED.total_prs_submitted,
+				total_merged            = EXCLUDED.total_merged,
+				total_rejected          = EXCLUDED.total_rejected,
+				merge_rate              = EXCLUDED.merge_rate,
+				avg_response_time_hours = EXCLUDED.avg_response_time_hours,
+				last_interaction        = EXCLUDED.last_interaction,
+				updated_at              = EXCLUDED.updated_at
+		`, db.placeholders(8))
+	} else {
+		upsertQ = fmt.Sprintf(`
+			INSERT INTO repo_profiles (repo, total_prs_submitted, total_merged, total_rejected,
+				merge_rate, avg_response_time_hours, last_interaction, updated_at)
+			VALUES (%s)
+			ON CONFLICT(repo) DO UPDATE SET
+				total_prs_submitted     = excluded.total_prs_submitted,
+				total_merged            = excluded.total_merged,
+				total_rejected          = excluded.total_rejected,
+				merge_rate              = excluded.merge_rate,
+				avg_response_time_hours = excluded.avg_response_time_hours,
+				last_interaction        = excluded.last_interaction,
+				updated_at              = excluded.updated_at
+		`, db.placeholders(8))
+	}
+
+	var avgRespVal interface{}
+	if s.avgRespHours.Valid {
+		avgRespVal = s.avgRespHours.Float64
+	}
+	var lastInterVal interface{}
+	if s.lastInter.Valid {
+		lastInterVal = s.lastInter.Time
+	}
+
+	_, err := db.Exec(upsertQ,
+		repo,
+		s.submitted,
+		s.merged,
+		s.rejected,
+		s.mergeRate,
+		avgRespVal,
+		lastInterVal,
+		now,
+	)
+	return err
+}

--- a/internal/pipeline/feedback.go
+++ b/internal/pipeline/feedback.go
@@ -34,12 +34,18 @@ func (p *Pipeline) ProcessPR(ctx context.Context, pr *models.PullRequest) error 
 	switch prInfo.State {
 	case "MERGED":
 		p.db.UpdatePRStatus(pr.ID, models.PRStatusMerged)
+		if err := p.db.SyncRepoProfileStats(prRepo); err != nil {
+			log.WithFields(Fields{"repo": prRepo, "error": err}).Warn("sync repo profile stats after merge")
+		}
 		p.extractAndStoreLessons(ctx, pr, prRepo, prInfo)
 		p.cleanupWorkspace(pr)
 		log.WithField("pr", pr.PRURL).Info("PR merged")
 		return nil
 	case "CLOSED":
 		p.db.UpdatePRStatus(pr.ID, models.PRStatusClosed)
+		if err := p.db.SyncRepoProfileStats(prRepo); err != nil {
+			log.WithFields(Fields{"repo": prRepo, "error": err}).Warn("sync repo profile stats after close")
+		}
 		p.extractAndStoreLessons(ctx, pr, prRepo, prInfo)
 		p.cleanupWorkspace(pr)
 		log.WithField("pr", pr.PRURL).Info("PR closed")
@@ -477,19 +483,19 @@ func (p *Pipeline) buildResponderCtx(
 	}
 
 	return map[string]any{
-		"Repo":                 issue.Repo,
-		"IssueNumber":          issue.IssueNumber,
-		"IssueTitle":           issue.Title,
-		"IssueBody":            issue.Body,
+		"Repo":                  issue.Repo,
+		"IssueNumber":           issue.IssueNumber,
+		"IssueTitle":            issue.Title,
+		"IssueBody":             issue.Body,
 		"OriginalIssueComments": p.fetchOriginalIssueComments(issue),
-		"PRNumber":             pr.PRNumber,
-		"PRURL":                pr.PRURL,
-		"BranchName":           pr.BranchName,
-		"FeedbackRound":        pr.FeedbackRound + 1,
-		"Reviews":              reviewsText,
-		"InlineComments":       commentsText,
-		"IssueComments":        issueCommentsText,
-		"Rules":                p.ruleLoader.FormatForPrompt("responder"),
+		"PRNumber":              pr.PRNumber,
+		"PRURL":                 pr.PRURL,
+		"BranchName":            pr.BranchName,
+		"FeedbackRound":         pr.FeedbackRound + 1,
+		"Reviews":               reviewsText,
+		"InlineComments":        commentsText,
+		"IssueComments":         issueCommentsText,
+		"Rules":                 p.ruleLoader.FormatForPrompt("responder"),
 	}
 }
 

--- a/internal/pipeline/feedback.go
+++ b/internal/pipeline/feedback.go
@@ -65,6 +65,9 @@ func (p *Pipeline) ProcessPR(ctx context.Context, pr *models.PullRequest) error 
 			log.WithError(err).Warn("failed to auto-close stale PR")
 		} else {
 			p.db.UpdatePRStatus(pr.ID, models.PRStatusClosed)
+			if err := p.db.SyncRepoProfileStats(prRepo); err != nil {
+				log.WithFields(Fields{"repo": prRepo, "error": err}).Warn("sync repo profile stats after stale auto-close")
+			}
 		}
 		return nil
 	}
@@ -126,6 +129,9 @@ func (p *Pipeline) handleDraft(ctx context.Context, pr *models.PullRequest, prRe
 				log.WithError(err).Warn("failed to auto-close CI-failed PR")
 			} else {
 				p.db.UpdatePRStatus(pr.ID, models.PRStatusClosed)
+				if err := p.db.SyncRepoProfileStats(prRepo); err != nil {
+					log.WithFields(Fields{"repo": prRepo, "error": err}).Warn("sync repo profile stats after CI auto-close")
+				}
 			}
 			return nil
 		}

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -17,20 +17,20 @@ const (
 
 	// V2 pipeline statuses
 	IssueStatusAnalyzing   IssueStatus = "analyzing"   // Analyst agent running
-	IssueStatusEngineering IssueStatus = "engineering"  // Engineer agent running
-	IssueStatusReviewing   IssueStatus = "reviewing"    // Reviewer agent running
-	IssueStatusRework      IssueStatus = "rework"       // Engineer reworking after review
-	IssueStatusSubmitting  IssueStatus = "submitting"   // Submitter agent running
+	IssueStatusEngineering IssueStatus = "engineering" // Engineer agent running
+	IssueStatusReviewing   IssueStatus = "reviewing"   // Reviewer agent running
+	IssueStatusRework      IssueStatus = "rework"      // Engineer reworking after review
+	IssueStatusSubmitting  IssueStatus = "submitting"  // Submitter agent running
 )
 
 // PRStatus represents the status of a pull request
 type PRStatus string
 
 const (
-	PRStatusDraft      PRStatus = "draft" // Draft PR, waiting for CI
-	PRStatusOpen       PRStatus = "open"  // Ready for review, checking feedback
-	PRStatusMerged     PRStatus = "merged"
-	PRStatusClosed     PRStatus = "closed"
+	PRStatusDraft          PRStatus = "draft" // Draft PR, waiting for CI
+	PRStatusOpen           PRStatus = "open"  // Ready for review, checking feedback
+	PRStatusMerged         PRStatus = "merged"
+	PRStatusClosed         PRStatus = "closed"
 	PRStatusResponding     PRStatus = "responding"
 	PRStatusNeedsAttention PRStatus = "needs_attention" // Requires manual action (e.g. CLA signing)
 )
@@ -39,16 +39,16 @@ const (
 type FailureReason string
 
 const (
-	FailureReasonTimeout          FailureReason = "timeout"
-	FailureReasonNoChanges        FailureReason = "no_changes"
-	FailureReasonTestsFailed      FailureReason = "tests_failed"
-	FailureReasonCIFailed         FailureReason = "ci_failed"
-	FailureReasonCloneFailed      FailureReason = "clone_failed"
-	FailureReasonPRFailed         FailureReason = "pr_failed"
-	FailureReasonComplexityHigh   FailureReason = "complexity_too_high"
-	FailureReasonAlreadyHasPR     FailureReason = "already_has_pr"
-	FailureReasonAlreadyFixed     FailureReason = "already_fixed"
-	FailureReasonUnknown          FailureReason = "unknown"
+	FailureReasonTimeout        FailureReason = "timeout"
+	FailureReasonNoChanges      FailureReason = "no_changes"
+	FailureReasonTestsFailed    FailureReason = "tests_failed"
+	FailureReasonCIFailed       FailureReason = "ci_failed"
+	FailureReasonCloneFailed    FailureReason = "clone_failed"
+	FailureReasonPRFailed       FailureReason = "pr_failed"
+	FailureReasonComplexityHigh FailureReason = "complexity_too_high"
+	FailureReasonAlreadyHasPR   FailureReason = "already_has_pr"
+	FailureReasonAlreadyFixed   FailureReason = "already_fixed"
+	FailureReasonUnknown        FailureReason = "unknown"
 )
 
 // Issue represents a discovered GitHub issue
@@ -85,22 +85,22 @@ func (r FailureReason) IsRetryable() bool {
 
 // PullRequest represents a created pull request
 type PullRequest struct {
-	ID                 int64      `db:"id" json:"id"`
-	IssueID            int64      `db:"issue_id" json:"issue_id"`
-	PRURL              string     `db:"pr_url" json:"pr_url"`
-	PRNumber           int        `db:"pr_number" json:"pr_number"`
-	BranchName         string     `db:"branch_name" json:"branch_name"`
-	Status             PRStatus   `db:"status" json:"status"`
-	CIStatus           string     `db:"ci_status" json:"ci_status"`
-	RetryCount         int        `db:"retry_count" json:"retry_count"`
-	MergedAt           *time.Time `db:"merged_at" json:"merged_at,omitempty"`
-	ClosedAt           *time.Time `db:"closed_at" json:"closed_at,omitempty"`
-	ReviewCommentCount int        `db:"review_comment_count" json:"review_comment_count"`
-	FirstReviewAt      *time.Time `db:"first_review_at" json:"first_review_at,omitempty"`
-	CreatedAt            time.Time  `db:"created_at" json:"created_at"`
-	UpdatedAt            time.Time  `db:"updated_at" json:"updated_at"`
-	LastFeedbackCheckAt  *time.Time `db:"last_feedback_check_at" json:"last_feedback_check_at,omitempty"`
-	FeedbackRound        int        `db:"feedback_round" json:"feedback_round"`
+	ID                  int64      `db:"id" json:"id"`
+	IssueID             int64      `db:"issue_id" json:"issue_id"`
+	PRURL               string     `db:"pr_url" json:"pr_url"`
+	PRNumber            int        `db:"pr_number" json:"pr_number"`
+	BranchName          string     `db:"branch_name" json:"branch_name"`
+	Status              PRStatus   `db:"status" json:"status"`
+	CIStatus            string     `db:"ci_status" json:"ci_status"`
+	RetryCount          int        `db:"retry_count" json:"retry_count"`
+	MergedAt            *time.Time `db:"merged_at" json:"merged_at,omitempty"`
+	ClosedAt            *time.Time `db:"closed_at" json:"closed_at,omitempty"`
+	ReviewCommentCount  int        `db:"review_comment_count" json:"review_comment_count"`
+	FirstReviewAt       *time.Time `db:"first_review_at" json:"first_review_at,omitempty"`
+	CreatedAt           time.Time  `db:"created_at" json:"created_at"`
+	UpdatedAt           time.Time  `db:"updated_at" json:"updated_at"`
+	LastFeedbackCheckAt *time.Time `db:"last_feedback_check_at" json:"last_feedback_check_at,omitempty"`
+	FeedbackRound       int        `db:"feedback_round" json:"feedback_round"`
 }
 
 // TimeToMerge returns the duration from PR creation to merge
@@ -179,22 +179,22 @@ type IssueMetrics struct {
 
 // DailyStats holds daily aggregated statistics
 type DailyStats struct {
-	ID                     int64     `db:"id"`
-	Date                   string    `db:"date"` // YYYY-MM-DD
-	IssuesDiscovered       int       `db:"issues_discovered"`
-	IssuesAttempted        int       `db:"issues_attempted"`
-	IssuesSolved           int       `db:"issues_solved"`
-	PRsCreated             int       `db:"prs_created"`
-	PRsMerged              int       `db:"prs_merged"`
-	PRsClosed              int       `db:"prs_closed"`
-	AvgSolveTimeSeconds    *float64  `db:"avg_solve_time_seconds"`
-	AvgAttemptsPerIssue    *float64  `db:"avg_attempts_per_issue"`
-	FirstAttemptSuccessRate *float64 `db:"first_attempt_success_rate"`
-	OverallSuccessRate     *float64  `db:"overall_success_rate"`
-	StatsByLanguage        string    `db:"stats_by_language"`     // JSON
-	StatsByRepo            string    `db:"stats_by_repo"`         // JSON
-	FailureReasonsCount    string    `db:"failure_reasons_count"` // JSON
-	CreatedAt              time.Time `db:"created_at"`
+	ID                      int64     `db:"id"`
+	Date                    string    `db:"date"` // YYYY-MM-DD
+	IssuesDiscovered        int       `db:"issues_discovered"`
+	IssuesAttempted         int       `db:"issues_attempted"`
+	IssuesSolved            int       `db:"issues_solved"`
+	PRsCreated              int       `db:"prs_created"`
+	PRsMerged               int       `db:"prs_merged"`
+	PRsClosed               int       `db:"prs_closed"`
+	AvgSolveTimeSeconds     *float64  `db:"avg_solve_time_seconds"`
+	AvgAttemptsPerIssue     *float64  `db:"avg_attempts_per_issue"`
+	FirstAttemptSuccessRate *float64  `db:"first_attempt_success_rate"`
+	OverallSuccessRate      *float64  `db:"overall_success_rate"`
+	StatsByLanguage         string    `db:"stats_by_language"`     // JSON
+	StatsByRepo             string    `db:"stats_by_repo"`         // JSON
+	FailureReasonsCount     string    `db:"failure_reasons_count"` // JSON
+	CreatedAt               time.Time `db:"created_at"`
 }
 
 // RepoMetrics holds aggregated metrics per repository
@@ -249,14 +249,14 @@ type LanguageMetrics struct {
 
 // PRMetrics holds PR-related aggregate statistics
 type PRMetrics struct {
-	TotalPRs           int     `json:"total_prs"`
-	OpenPRs            int     `json:"open_prs"`
-	MergedPRs          int     `json:"merged_prs"`
-	ClosedPRs          int     `json:"closed_prs"`
-	MergeRate          float64 `json:"merge_rate"`
-	AvgTimeToMerge     float64 `json:"avg_time_to_merge_hours"`
+	TotalPRs             int     `json:"total_prs"`
+	OpenPRs              int     `json:"open_prs"`
+	MergedPRs            int     `json:"merged_prs"`
+	ClosedPRs            int     `json:"closed_prs"`
+	MergeRate            float64 `json:"merge_rate"`
+	AvgTimeToMerge       float64 `json:"avg_time_to_merge_hours"`
 	AvgTimeToFirstReview float64 `json:"avg_time_to_first_review_hours"`
-	AvgReviewComments  float64 `json:"avg_review_comments"`
+	AvgReviewComments    float64 `json:"avg_review_comments"`
 }
 
 // BlacklistEntry represents a blacklisted repository
@@ -267,14 +267,44 @@ type BlacklistEntry struct {
 	AddedAt time.Time `db:"added_at" json:"added_at"`
 }
 
+// RepoProfile stores repo-level learning data to improve scout decisions.
+// Stats fields (TotalPRsSubmitted, TotalMerged, TotalRejected, MergeRate,
+// AvgResponseTimeHours, LastInteraction) are auto-computed by SyncRepoProfileStats.
+// All other fields are manually maintained via UpsertRepoProfile.
+type RepoProfile struct {
+	Repo                 string     `db:"repo" json:"repo"`
+	TotalPRsSubmitted    int        `db:"total_prs_submitted" json:"total_prs_submitted"`
+	TotalMerged          int        `db:"total_merged" json:"total_merged"`
+	TotalRejected        int        `db:"total_rejected" json:"total_rejected"`
+	MergeRate            float64    `db:"merge_rate" json:"merge_rate"`
+	AvgResponseTimeHours *float64   `db:"avg_response_time_hours" json:"avg_response_time_hours,omitempty"`
+	RequiresCLA          bool       `db:"requires_cla" json:"requires_cla"`
+	RequiresAssignment   bool       `db:"requires_assignment" json:"requires_assignment"`
+	PreferredPRSize      string     `db:"preferred_pr_size" json:"preferred_pr_size,omitempty"`
+	Blacklisted          bool       `db:"blacklisted" json:"blacklisted"`
+	BlacklistReason      string     `db:"blacklist_reason" json:"blacklist_reason,omitempty"`
+	CooldownUntil        *time.Time `db:"cooldown_until" json:"cooldown_until,omitempty"`
+	StrategyNotes        string     `db:"strategy_notes" json:"strategy_notes,omitempty"`
+	LastInteraction      *time.Time `db:"last_interaction" json:"last_interaction,omitempty"`
+	UpdatedAt            time.Time  `db:"updated_at" json:"updated_at"`
+}
+
+// IsOnCooldown returns true if this repo's cooldown period has not yet expired.
+func (p *RepoProfile) IsOnCooldown() bool {
+	if p.CooldownUntil == nil {
+		return false
+	}
+	return time.Now().Before(*p.CooldownUntil)
+}
+
 // ReviewLesson represents a lesson learned from upstream reviewer feedback.
 // These are extracted from PR reviews and used to improve future contributions.
 type ReviewLesson struct {
 	ID            int64     `db:"id" json:"id"`
 	PRID          int64     `db:"pr_id" json:"pr_id"`
 	Repo          string    `db:"repo" json:"repo"`
-	Category      string    `db:"category" json:"category"`           // testing, style, scope, docs, ci, logic
-	Lesson        string    `db:"lesson" json:"lesson"`               // extracted actionable lesson
+	Category      string    `db:"category" json:"category"`             // testing, style, scope, docs, ci, logic
+	Lesson        string    `db:"lesson" json:"lesson"`                 // extracted actionable lesson
 	SourceComment string    `db:"source_comment" json:"source_comment"` // original reviewer text
 	Reviewer      string    `db:"reviewer" json:"reviewer"`
 	CreatedAt     time.Time `db:"created_at" json:"created_at"`
@@ -282,20 +312,20 @@ type ReviewLesson struct {
 
 // PipelineEvent records a single agent invocation in the pipeline.
 type PipelineEvent struct {
-	ID               int64      `db:"id" json:"id"`
-	IssueID          int64      `db:"issue_id" json:"issue_id"`
-	PRID             *int64     `db:"pr_id" json:"pr_id,omitempty"`
-	Repo             string     `db:"repo" json:"repo"`
-	IssueNumber      int        `db:"issue_number" json:"issue_number"`
-	Stage            string     `db:"stage" json:"stage"`
-	Round            int        `db:"round" json:"round"`
-	StartedAt        time.Time  `db:"started_at" json:"started_at"`
-	CompletedAt      *time.Time `db:"completed_at" json:"completed_at,omitempty"`
-	DurationSeconds  float64    `db:"duration_seconds" json:"duration_seconds"`
-	OutputSummary    string     `db:"output_summary" json:"output_summary"`
-	Verdict          string     `db:"verdict" json:"verdict"`
-	Success          bool       `db:"success" json:"success"`
-	ErrorMessage     string     `db:"error_message" json:"error_message,omitempty"`
-	OutcomeLabel     string     `db:"outcome_label" json:"outcome_label,omitempty"`
-	CreatedAt        time.Time  `db:"created_at" json:"created_at"`
+	ID              int64      `db:"id" json:"id"`
+	IssueID         int64      `db:"issue_id" json:"issue_id"`
+	PRID            *int64     `db:"pr_id" json:"pr_id,omitempty"`
+	Repo            string     `db:"repo" json:"repo"`
+	IssueNumber     int        `db:"issue_number" json:"issue_number"`
+	Stage           string     `db:"stage" json:"stage"`
+	Round           int        `db:"round" json:"round"`
+	StartedAt       time.Time  `db:"started_at" json:"started_at"`
+	CompletedAt     *time.Time `db:"completed_at" json:"completed_at,omitempty"`
+	DurationSeconds float64    `db:"duration_seconds" json:"duration_seconds"`
+	OutputSummary   string     `db:"output_summary" json:"output_summary"`
+	Verdict         string     `db:"verdict" json:"verdict"`
+	Success         bool       `db:"success" json:"success"`
+	ErrorMessage    string     `db:"error_message" json:"error_message,omitempty"`
+	OutcomeLabel    string     `db:"outcome_label" json:"outcome_label,omitempty"`
+	CreatedAt       time.Time  `db:"created_at" json:"created_at"`
 }


### PR DESCRIPTION
## Summary

Implements #14 — adds a `repo_profiles` table to capture repo-level learning data that drives smarter scout decisions.

- **Schema**: `repo_profiles` table added to both SQLite and PostgreSQL schemas in `internal/db/db.go`
- **Model**: `RepoProfile` struct in `pkg/models/models.go` with an `IsOnCooldown()` helper
- **CRUD**: `UpsertRepoProfile`, `GetRepoProfile`, `SyncRepoProfileStats` extracted into a separate `internal/db/repo_profiles.go` (keeps `db.go` from growing further)
- **Scout integration**: `discoverIssues` and `smartDiscover` now check the repo profile for blacklisting and active cooldowns before saving candidates
- **Auto-sync**: `SyncRepoProfileStats` is called in `feedback.go` whenever a PR reaches a terminal state (MERGED or CLOSED), keeping merge-rate statistics current

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes  
- [ ] On fresh DB: `repo_profiles` table created automatically via `Migrate()`
- [ ] On existing DB: `CREATE TABLE IF NOT EXISTS` is idempotent — no migration error
- [ ] Scout skips a repo whose profile has `blacklisted=true`
- [ ] Scout skips a repo whose profile has `cooldown_until` in the future
- [ ] After a PR is merged/closed, `repo_profiles` row for that repo is upserted with updated counts and merge rate