### PR TITLE
feat: add repo_profiles table for repo-level learning

### DIFF
--- a/cmd/auto-contributor/cmd_discover.go
+++ b/cmd/auto-contributor/cmd_discover.go
@@ -34,7 +34,12 @@ func discoverIssues(cmd *cobra.Command, args []string) error {
 		}
 
 		// Check repo profile: skip low-probability repos
-		if skip, reason, _ := database.ShouldSkipRepo(issue.Repo, 0.1, 3); skip {
+		skip, reason, err := database.ShouldSkipRepo(issue.Repo, 0.1, 3)
+		if err != nil {
+			fmt.Printf("Warning: repo safety check failed for %s: %v — skipping\n", issue.Repo, err)
+			continue
+		}
+		if skip {
 			fmt.Printf("Skipping repo %s: %s\n", issue.Repo, reason)
 			continue
 		}

--- a/cmd/auto-contributor/cmd_discover.go
+++ b/cmd/auto-contributor/cmd_discover.go
@@ -33,11 +33,13 @@ func discoverIssues(cmd *cobra.Command, args []string) error {
 			continue
 		}
 
-		// Check repo profile: skip low-probability repos
+		// Check repo profile: skip low-probability repos.
+		// On transient DB errors, fail-open (include the candidate) rather than
+		// silently suppressing valid issues for the entire run.
 		skip, reason, err := database.ShouldSkipRepo(issue.Repo, 0.1, 3)
 		if err != nil {
-			fmt.Printf("Warning: repo safety check failed for %s: %v — skipping\n", issue.Repo, err)
-			continue
+			fmt.Printf("Warning: repo safety check failed for %s: %v — including anyway\n", issue.Repo, err)
+			skip = false
 		}
 		if skip {
 			fmt.Printf("Skipping repo %s: %s\n", issue.Repo, reason)

--- a/cmd/auto-contributor/cmd_discover.go
+++ b/cmd/auto-contributor/cmd_discover.go
@@ -33,6 +33,12 @@ func discoverIssues(cmd *cobra.Command, args []string) error {
 			continue
 		}
 
+		// Check repo profile: skip low-probability repos
+		if skip, reason, _ := database.ShouldSkipRepo(issue.Repo, 0.1, 3); skip {
+			fmt.Printf("Skipping repo %s: %s\n", issue.Repo, reason)
+			continue
+		}
+
 		// Save to database
 		if err := database.CreateIssue(issue); err != nil {
 			fmt.Printf("Warning: failed to save issue %s#%d: %v\n", issue.Repo, issue.IssueNumber, err)

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -110,6 +110,7 @@ func (db *DB) Migrate() error {
 	db.runMigrations()
 	db.MigrateLessons()
 	db.MigrateEvents()
+	db.MigrateRepoProfiles()
 
 	return nil
 }
@@ -269,6 +270,24 @@ func (db *DB) sqliteSchema() string {
 	);
 
 	CREATE INDEX IF NOT EXISTS idx_blacklist_repo ON blacklist(repo);
+
+	CREATE TABLE IF NOT EXISTS repo_profiles (
+		repo TEXT PRIMARY KEY,
+		total_prs_submitted INTEGER DEFAULT 0,
+		total_merged INTEGER DEFAULT 0,
+		total_rejected INTEGER DEFAULT 0,
+		merge_rate REAL DEFAULT 0,
+		avg_response_time_hours REAL,
+		requires_cla INTEGER DEFAULT 0,
+		requires_assignment INTEGER DEFAULT 0,
+		preferred_pr_size TEXT,
+		blacklisted INTEGER DEFAULT 0,
+		blacklist_reason TEXT,
+		cooldown_until DATETIME,
+		strategy_notes TEXT,
+		last_interaction DATETIME,
+		updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+	);
 	`
 }
 
@@ -424,6 +443,24 @@ func (db *DB) postgresSchema() string {
 	);
 
 	CREATE INDEX IF NOT EXISTS idx_blacklist_repo ON blacklist(repo);
+
+	CREATE TABLE IF NOT EXISTS repo_profiles (
+		repo TEXT PRIMARY KEY,
+		total_prs_submitted INTEGER DEFAULT 0,
+		total_merged INTEGER DEFAULT 0,
+		total_rejected INTEGER DEFAULT 0,
+		merge_rate REAL DEFAULT 0,
+		avg_response_time_hours REAL,
+		requires_cla BOOLEAN DEFAULT FALSE,
+		requires_assignment BOOLEAN DEFAULT FALSE,
+		preferred_pr_size TEXT,
+		blacklisted BOOLEAN DEFAULT FALSE,
+		blacklist_reason TEXT,
+		cooldown_until TIMESTAMP,
+		strategy_notes TEXT,
+		last_interaction TIMESTAMP,
+		updated_at TIMESTAMP DEFAULT NOW()
+	);
 	`
 }
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -152,6 +152,7 @@ func (db *DB) sqliteSchema() string {
 		first_review_at DATETIME,
 		last_feedback_check_at DATETIME,
 		feedback_round INTEGER DEFAULT 0,
+		outcome_recorded INTEGER DEFAULT 0,
 		created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
 		updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
 		FOREIGN KEY (issue_id) REFERENCES issues(id)
@@ -328,6 +329,7 @@ func (db *DB) postgresSchema() string {
 		first_review_at TIMESTAMP,
 		last_feedback_check_at TIMESTAMP,
 		feedback_round INTEGER DEFAULT 0,
+		outcome_recorded INTEGER DEFAULT 0,
 		created_at TIMESTAMP DEFAULT NOW(),
 		updated_at TIMESTAMP DEFAULT NOW()
 	);
@@ -474,6 +476,7 @@ func (db *DB) runMigrations() {
 		db.Exec("ALTER TABLE pull_requests ADD COLUMN IF NOT EXISTS first_review_at TIMESTAMP")
 		db.Exec("ALTER TABLE pull_requests ADD COLUMN IF NOT EXISTS last_feedback_check_at TIMESTAMP")
 		db.Exec("ALTER TABLE pull_requests ADD COLUMN IF NOT EXISTS feedback_round INTEGER DEFAULT 0")
+		db.Exec("ALTER TABLE pull_requests ADD COLUMN IF NOT EXISTS outcome_recorded INTEGER DEFAULT 0")
 		db.Exec("ALTER TABLE solve_attempts ADD COLUMN IF NOT EXISTS prompt_tokens INTEGER DEFAULT 0")
 		db.Exec("ALTER TABLE solve_attempts ADD COLUMN IF NOT EXISTS completion_tokens INTEGER DEFAULT 0")
 		db.Exec("ALTER TABLE solve_attempts ADD COLUMN IF NOT EXISTS total_tokens INTEGER DEFAULT 0")
@@ -488,6 +491,7 @@ func (db *DB) runMigrations() {
 		db.Exec("ALTER TABLE pull_requests ADD COLUMN first_review_at DATETIME")
 		db.Exec("ALTER TABLE pull_requests ADD COLUMN last_feedback_check_at DATETIME")
 		db.Exec("ALTER TABLE pull_requests ADD COLUMN feedback_round INTEGER DEFAULT 0")
+		db.Exec("ALTER TABLE pull_requests ADD COLUMN outcome_recorded INTEGER DEFAULT 0")
 		db.Exec("ALTER TABLE solve_attempts ADD COLUMN prompt_tokens INTEGER DEFAULT 0")
 		db.Exec("ALTER TABLE solve_attempts ADD COLUMN completion_tokens INTEGER DEFAULT 0")
 		db.Exec("ALTER TABLE solve_attempts ADD COLUMN total_tokens INTEGER DEFAULT 0")

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -106,11 +106,14 @@ func (db *DB) Migrate() error {
 		return fmt.Errorf("failed to execute schema: %w", err)
 	}
 
-	// Run migrations (ignore errors for columns that already exist)
+	// Column-level migrations intentionally ignore errors (column may already exist).
 	db.runMigrations()
 	db.MigrateLessons()
 	db.MigrateEvents()
-	db.MigrateRepoProfiles()
+	// Table-level migration: propagate errors so startup fails fast on DDL failure.
+	if err := db.MigrateRepoProfiles(); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/internal/db/repo_profiles.go
+++ b/internal/db/repo_profiles.go
@@ -9,10 +9,13 @@ import (
 )
 
 // MigrateRepoProfiles ensures the repo_profiles table exists for existing DBs.
-func (db *DB) MigrateRepoProfiles() {
+// Returns an error if the DDL fails (e.g. permissions or locked DB), so the
+// caller can abort startup rather than silently continuing without the table.
+func (db *DB) MigrateRepoProfiles() error {
 	// Table is created in the main schema; this handles pre-existing databases.
+	var err error
 	if db.IsPostgres() {
-		db.Exec(`CREATE TABLE IF NOT EXISTS repo_profiles (
+		_, err = db.Exec(`CREATE TABLE IF NOT EXISTS repo_profiles (
 			repo TEXT PRIMARY KEY,
 			total_prs_submitted INTEGER DEFAULT 0,
 			total_merged INTEGER DEFAULT 0,
@@ -30,7 +33,7 @@ func (db *DB) MigrateRepoProfiles() {
 			updated_at TIMESTAMP DEFAULT NOW()
 		)`)
 	} else {
-		db.Exec(`CREATE TABLE IF NOT EXISTS repo_profiles (
+		_, err = db.Exec(`CREATE TABLE IF NOT EXISTS repo_profiles (
 			repo TEXT PRIMARY KEY,
 			total_prs_submitted INTEGER DEFAULT 0,
 			total_merged INTEGER DEFAULT 0,
@@ -48,6 +51,10 @@ func (db *DB) MigrateRepoProfiles() {
 			updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
 		)`)
 	}
+	if err != nil {
+		return fmt.Errorf("migrate repo_profiles: %w", err)
+	}
+	return nil
 }
 
 // GetRepoProfile returns the profile for a repo, or nil if not found.

--- a/internal/db/repo_profiles.go
+++ b/internal/db/repo_profiles.go
@@ -142,36 +142,76 @@ func (db *DB) UpsertRepoProfile(p *models.RepoProfile) error {
 // RecordPROutcome updates the repo profile after a PR reaches a terminal state.
 // merged=true means the PR was merged; merged=false means it was closed/rejected.
 // responseHours is the time from PR creation to the terminal event (may be 0 if unknown).
+//
+// Counters are incremented atomically in a single SQL statement to prevent lost
+// updates when multiple workers process PRs concurrently.
 func (db *DB) RecordPROutcome(repo string, merged bool, responseHours float64) error {
-	profile, err := db.GetRepoProfile(repo)
-	if err != nil {
-		return fmt.Errorf("get repo profile: %w", err)
-	}
 	now := time.Now()
-	if profile == nil {
-		profile = &models.RepoProfile{Repo: repo}
+
+	var mergedInc, rejectedInc int
+	if merged {
+		mergedInc = 1
+	} else {
+		rejectedInc = 1
+	}
+	mergeRate := float64(mergedInc) // merge_rate for a brand-new row (1 PR total)
+
+	// Single atomic upsert: increment counters and recompute merge_rate in-database.
+	// Using excluded.* to reference the INSERT values inside ON CONFLICT DO UPDATE.
+	query := fmt.Sprintf(`
+		INSERT INTO repo_profiles (
+			repo, total_prs_submitted, total_merged, total_rejected,
+			merge_rate, last_interaction, updated_at
+		) VALUES (%s, 1, %s, %s, %s, %s, %s)
+		ON CONFLICT(repo) DO UPDATE SET
+			total_prs_submitted = repo_profiles.total_prs_submitted + 1,
+			total_merged        = repo_profiles.total_merged + excluded.total_merged,
+			total_rejected      = repo_profiles.total_rejected + excluded.total_rejected,
+			merge_rate          = CAST(repo_profiles.total_merged + excluded.total_merged AS REAL)
+			                      / (repo_profiles.total_prs_submitted + 1),
+			last_interaction    = excluded.last_interaction,
+			updated_at          = excluded.updated_at`,
+		db.placeholder(1), // repo
+		db.placeholder(2), // mergedInc
+		db.placeholder(3), // rejectedInc
+		db.placeholder(4), // mergeRate (initial row only)
+		db.placeholder(5), // now (last_interaction)
+		db.placeholder(6), // now (updated_at)
+	)
+	if _, err := db.Exec(query, repo, mergedInc, rejectedInc, mergeRate, now, now); err != nil {
+		return fmt.Errorf("record PR outcome: %w", err)
 	}
 
-	profile.TotalPRsSubmitted++
-	if merged {
-		profile.TotalMerged++
-	} else {
-		profile.TotalRejected++
-	}
-	if profile.TotalPRsSubmitted > 0 {
-		profile.MergeRate = float64(profile.TotalMerged) / float64(profile.TotalPRsSubmitted)
-	}
+	// Update running average response time separately (best-effort; not used in
+	// skip-repo decisions, so a non-atomic update here is acceptable).
 	if responseHours > 0 {
-		if profile.AvgResponseTimeHours == nil {
-			profile.AvgResponseTimeHours = &responseHours
-		} else {
-			avg := (*profile.AvgResponseTimeHours*float64(profile.TotalPRsSubmitted-1) + responseHours) / float64(profile.TotalPRsSubmitted)
-			profile.AvgResponseTimeHours = &avg
+		if err := db.updateAvgResponseTime(repo, responseHours); err != nil {
+			// Non-fatal: avg_response_time_hours is informational only.
+			fmt.Printf("warn: updateAvgResponseTime for %s: %v\n", repo, err)
 		}
 	}
-	profile.LastInteraction = &now
 
-	return db.UpsertRepoProfile(profile)
+	return nil
+}
+
+// updateAvgResponseTime updates the running average response time for a repo.
+// Called after the counter upsert, so total_prs_submitted already reflects the new PR.
+func (db *DB) updateAvgResponseTime(repo string, responseHours float64) error {
+	query := fmt.Sprintf(`
+		UPDATE repo_profiles
+		SET avg_response_time_hours = CASE
+			WHEN avg_response_time_hours IS NULL THEN %s
+			ELSE (avg_response_time_hours * (total_prs_submitted - 1) + %s) / total_prs_submitted
+		END,
+		updated_at = %s
+		WHERE repo = %s`,
+		db.placeholder(1),
+		db.placeholder(2),
+		db.placeholder(3),
+		db.placeholder(4),
+	)
+	_, err := db.Exec(query, responseHours, responseHours, time.Now(), repo)
+	return err
 }
 
 // ShouldSkipRepo returns true when a repo's profile indicates it is not worth

--- a/internal/db/repo_profiles.go
+++ b/internal/db/repo_profiles.go
@@ -1,0 +1,203 @@
+package db
+
+import (
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/majiayu000/auto-contributor/pkg/models"
+)
+
+// MigrateRepoProfiles ensures the repo_profiles table exists for existing DBs.
+func (db *DB) MigrateRepoProfiles() {
+	// Table is created in the main schema; this handles pre-existing databases.
+	if db.IsPostgres() {
+		db.Exec(`CREATE TABLE IF NOT EXISTS repo_profiles (
+			repo TEXT PRIMARY KEY,
+			total_prs_submitted INTEGER DEFAULT 0,
+			total_merged INTEGER DEFAULT 0,
+			total_rejected INTEGER DEFAULT 0,
+			merge_rate REAL DEFAULT 0,
+			avg_response_time_hours REAL,
+			requires_cla BOOLEAN DEFAULT FALSE,
+			requires_assignment BOOLEAN DEFAULT FALSE,
+			preferred_pr_size TEXT,
+			blacklisted BOOLEAN DEFAULT FALSE,
+			blacklist_reason TEXT,
+			cooldown_until TIMESTAMP,
+			strategy_notes TEXT,
+			last_interaction TIMESTAMP,
+			updated_at TIMESTAMP DEFAULT NOW()
+		)`)
+	} else {
+		db.Exec(`CREATE TABLE IF NOT EXISTS repo_profiles (
+			repo TEXT PRIMARY KEY,
+			total_prs_submitted INTEGER DEFAULT 0,
+			total_merged INTEGER DEFAULT 0,
+			total_rejected INTEGER DEFAULT 0,
+			merge_rate REAL DEFAULT 0,
+			avg_response_time_hours REAL,
+			requires_cla INTEGER DEFAULT 0,
+			requires_assignment INTEGER DEFAULT 0,
+			preferred_pr_size TEXT,
+			blacklisted INTEGER DEFAULT 0,
+			blacklist_reason TEXT,
+			cooldown_until DATETIME,
+			strategy_notes TEXT,
+			last_interaction DATETIME,
+			updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+		)`)
+	}
+}
+
+// GetRepoProfile returns the profile for a repo, or nil if not found.
+func (db *DB) GetRepoProfile(repo string) (*models.RepoProfile, error) {
+	query := fmt.Sprintf(`
+		SELECT repo, total_prs_submitted, total_merged, total_rejected, merge_rate,
+		       avg_response_time_hours, requires_cla, requires_assignment, preferred_pr_size,
+		       blacklisted, blacklist_reason, cooldown_until, strategy_notes, last_interaction,
+		       updated_at
+		FROM repo_profiles WHERE repo = %s
+	`, db.placeholder(1))
+
+	row := db.QueryRow(query, repo)
+	p := &models.RepoProfile{}
+	var (
+		avgResp      sql.NullFloat64
+		preferredSz  sql.NullString
+		blackReason  sql.NullString
+		cooldown     sql.NullTime
+		stratNotes   sql.NullString
+		lastInteract sql.NullTime
+	)
+	err := row.Scan(
+		&p.Repo, &p.TotalPRsSubmitted, &p.TotalMerged, &p.TotalRejected, &p.MergeRate,
+		&avgResp, &p.RequiresCLA, &p.RequiresAssignment, &preferredSz,
+		&p.Blacklisted, &blackReason, &cooldown, &stratNotes, &lastInteract,
+		&p.UpdatedAt,
+	)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	if avgResp.Valid {
+		p.AvgResponseTimeHours = &avgResp.Float64
+	}
+	if preferredSz.Valid {
+		p.PreferredPRSize = preferredSz.String
+	}
+	if blackReason.Valid {
+		p.BlacklistReason = blackReason.String
+	}
+	if cooldown.Valid {
+		p.CooldownUntil = &cooldown.Time
+	}
+	if stratNotes.Valid {
+		p.StrategyNotes = stratNotes.String
+	}
+	if lastInteract.Valid {
+		p.LastInteraction = &lastInteract.Time
+	}
+	return p, nil
+}
+
+// UpsertRepoProfile inserts or updates a repo profile.
+func (db *DB) UpsertRepoProfile(p *models.RepoProfile) error {
+	now := time.Now()
+	query := fmt.Sprintf(`
+		INSERT INTO repo_profiles (
+			repo, total_prs_submitted, total_merged, total_rejected, merge_rate,
+			avg_response_time_hours, requires_cla, requires_assignment, preferred_pr_size,
+			blacklisted, blacklist_reason, cooldown_until, strategy_notes, last_interaction,
+			updated_at
+		) VALUES (%s)
+		ON CONFLICT(repo) DO UPDATE SET
+			total_prs_submitted = excluded.total_prs_submitted,
+			total_merged        = excluded.total_merged,
+			total_rejected      = excluded.total_rejected,
+			merge_rate          = excluded.merge_rate,
+			avg_response_time_hours = excluded.avg_response_time_hours,
+			requires_cla        = excluded.requires_cla,
+			requires_assignment = excluded.requires_assignment,
+			preferred_pr_size   = excluded.preferred_pr_size,
+			blacklisted         = excluded.blacklisted,
+			blacklist_reason    = excluded.blacklist_reason,
+			cooldown_until      = excluded.cooldown_until,
+			strategy_notes      = excluded.strategy_notes,
+			last_interaction    = excluded.last_interaction,
+			updated_at          = excluded.updated_at
+	`, db.placeholders(15))
+
+	_, err := db.Exec(query,
+		p.Repo, p.TotalPRsSubmitted, p.TotalMerged, p.TotalRejected, p.MergeRate,
+		p.AvgResponseTimeHours, p.RequiresCLA, p.RequiresAssignment, p.PreferredPRSize,
+		p.Blacklisted, p.BlacklistReason, p.CooldownUntil, p.StrategyNotes, p.LastInteraction,
+		now,
+	)
+	return err
+}
+
+// RecordPROutcome updates the repo profile after a PR reaches a terminal state.
+// merged=true means the PR was merged; merged=false means it was closed/rejected.
+// responseHours is the time from PR creation to the terminal event (may be 0 if unknown).
+func (db *DB) RecordPROutcome(repo string, merged bool, responseHours float64) error {
+	profile, err := db.GetRepoProfile(repo)
+	if err != nil {
+		return fmt.Errorf("get repo profile: %w", err)
+	}
+	now := time.Now()
+	if profile == nil {
+		profile = &models.RepoProfile{Repo: repo}
+	}
+
+	profile.TotalPRsSubmitted++
+	if merged {
+		profile.TotalMerged++
+	} else {
+		profile.TotalRejected++
+	}
+	if profile.TotalPRsSubmitted > 0 {
+		profile.MergeRate = float64(profile.TotalMerged) / float64(profile.TotalPRsSubmitted)
+	}
+	if responseHours > 0 {
+		if profile.AvgResponseTimeHours == nil {
+			profile.AvgResponseTimeHours = &responseHours
+		} else {
+			avg := (*profile.AvgResponseTimeHours*float64(profile.TotalPRsSubmitted-1) + responseHours) / float64(profile.TotalPRsSubmitted)
+			profile.AvgResponseTimeHours = &avg
+		}
+	}
+	profile.LastInteraction = &now
+
+	return db.UpsertRepoProfile(profile)
+}
+
+// ShouldSkipRepo returns true when a repo's profile indicates it is not worth
+// attempting: blacklisted, in cooldown, or has a low merge rate with enough
+// data to be statistically meaningful (>= minSamples submitted PRs).
+func (db *DB) ShouldSkipRepo(repo string, mergeRateThreshold float64, minSamples int) (bool, string, error) {
+	profile, err := db.GetRepoProfile(repo)
+	if err != nil {
+		return false, "", fmt.Errorf("get repo profile: %w", err)
+	}
+	if profile == nil {
+		return false, "", nil
+	}
+	if profile.Blacklisted {
+		reason := profile.BlacklistReason
+		if reason == "" {
+			reason = "blacklisted in repo_profiles"
+		}
+		return true, reason, nil
+	}
+	if profile.CooldownUntil != nil && time.Now().Before(*profile.CooldownUntil) {
+		return true, fmt.Sprintf("in cooldown until %s", profile.CooldownUntil.Format(time.RFC3339)), nil
+	}
+	if profile.TotalPRsSubmitted >= minSamples && profile.MergeRate < mergeRateThreshold {
+		return true, fmt.Sprintf("low merge rate %.0f%% (%d/%d PRs)",
+			profile.MergeRate*100, profile.TotalMerged, profile.TotalPRsSubmitted), nil
+	}
+	return false, "", nil
+}

--- a/internal/db/repo_profiles.go
+++ b/internal/db/repo_profiles.go
@@ -148,13 +148,22 @@ func (db *DB) UpsertRepoProfile(p *models.RepoProfile) error {
 // overlapping loop executions), the second call is a no-op. If the profile update
 // fails after the flag is set, the flag is reset so the next cycle can retry.
 func (db *DB) RecordPROutcome(prID int64, repo string, merged bool, responseHours float64) error {
-	// Atomically claim the right to record this outcome. If outcome_recorded is
-	// already 1 (set by a prior call), affected rows will be 0 → skip.
+	// Wrap the claim and profile upsert in a single transaction so that a
+	// process crash between the two statements rolls both back automatically.
+	// On rollback, outcome_recorded stays 0 and the next loop cycle can retry.
+	tx, err := db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin tx for pr %d: %w", prID, err)
+	}
+	defer tx.Rollback() //nolint:errcheck — no-op after Commit; rolls back on any error path
+
+	// Claim the right to record this outcome. If outcome_recorded is already 1
+	// (set by a prior committed run), affected rows will be 0 → skip.
 	claimQ := fmt.Sprintf(
 		`UPDATE pull_requests SET outcome_recorded = 1 WHERE id = %s AND outcome_recorded = 0`,
 		db.placeholder(1),
 	)
-	res, err := db.Exec(claimQ, prID)
+	res, err := tx.Exec(claimQ, prID)
 	if err != nil {
 		return fmt.Errorf("claim outcome_recorded for pr %d: %w", prID, err)
 	}
@@ -163,7 +172,7 @@ func (db *DB) RecordPROutcome(prID int64, repo string, merged bool, responseHour
 		return fmt.Errorf("rows affected for pr %d: %w", prID, err)
 	}
 	if affected == 0 {
-		// Already recorded by a previous run — idempotent skip.
+		// Already recorded by a previous committed run — idempotent skip.
 		return nil
 	}
 
@@ -176,8 +185,7 @@ func (db *DB) RecordPROutcome(prID int64, repo string, merged bool, responseHour
 	}
 	mergeRate := float64(mergedInc) // merge_rate for a brand-new row (1 PR total)
 
-	// Single atomic upsert: increment counters and recompute merge_rate in-database.
-	// Using excluded.* to reference the INSERT values inside ON CONFLICT DO UPDATE.
+	// Increment counters and recompute merge_rate in-database.
 	profileQ := fmt.Sprintf(`
 		INSERT INTO repo_profiles (
 			repo, total_prs_submitted, total_merged, total_rejected,
@@ -198,14 +206,12 @@ func (db *DB) RecordPROutcome(prID int64, repo string, merged bool, responseHour
 		db.placeholder(5), // now (last_interaction)
 		db.placeholder(6), // now (updated_at)
 	)
-	if _, err := db.Exec(profileQ, repo, mergedInc, rejectedInc, mergeRate, now, now); err != nil {
-		// Reset the flag so the next feedback cycle can retry.
-		resetQ := fmt.Sprintf(
-			`UPDATE pull_requests SET outcome_recorded = 0 WHERE id = %s`,
-			db.placeholder(1),
-		)
-		db.Exec(resetQ, prID) //nolint:errcheck — best-effort reset; original error takes priority
+	if _, err := tx.Exec(profileQ, repo, mergedInc, rejectedInc, mergeRate, now, now); err != nil {
 		return fmt.Errorf("record PR outcome: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit PR outcome for pr %d: %w", prID, err)
 	}
 
 	// Update running average response time separately (best-effort; not used in

--- a/internal/db/repo_profiles.go
+++ b/internal/db/repo_profiles.go
@@ -143,11 +143,31 @@ func (db *DB) UpsertRepoProfile(p *models.RepoProfile) error {
 // merged=true means the PR was merged; merged=false means it was closed/rejected.
 // responseHours is the time from PR creation to the terminal event (may be 0 if unknown).
 //
-// Counters are incremented atomically in a single SQL statement to prevent lost
-// updates when multiple workers process PRs concurrently.
-func (db *DB) RecordPROutcome(repo string, merged bool, responseHours float64) error {
-	now := time.Now()
+// Idempotency: the outcome_recorded flag on the pull_requests row is set atomically
+// before touching repo_profiles. If called twice for the same PR (parallel runners,
+// overlapping loop executions), the second call is a no-op. If the profile update
+// fails after the flag is set, the flag is reset so the next cycle can retry.
+func (db *DB) RecordPROutcome(prID int64, repo string, merged bool, responseHours float64) error {
+	// Atomically claim the right to record this outcome. If outcome_recorded is
+	// already 1 (set by a prior call), affected rows will be 0 → skip.
+	claimQ := fmt.Sprintf(
+		`UPDATE pull_requests SET outcome_recorded = 1 WHERE id = %s AND outcome_recorded = 0`,
+		db.placeholder(1),
+	)
+	res, err := db.Exec(claimQ, prID)
+	if err != nil {
+		return fmt.Errorf("claim outcome_recorded for pr %d: %w", prID, err)
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("rows affected for pr %d: %w", prID, err)
+	}
+	if affected == 0 {
+		// Already recorded by a previous run — idempotent skip.
+		return nil
+	}
 
+	now := time.Now()
 	var mergedInc, rejectedInc int
 	if merged {
 		mergedInc = 1
@@ -158,7 +178,7 @@ func (db *DB) RecordPROutcome(repo string, merged bool, responseHours float64) e
 
 	// Single atomic upsert: increment counters and recompute merge_rate in-database.
 	// Using excluded.* to reference the INSERT values inside ON CONFLICT DO UPDATE.
-	query := fmt.Sprintf(`
+	profileQ := fmt.Sprintf(`
 		INSERT INTO repo_profiles (
 			repo, total_prs_submitted, total_merged, total_rejected,
 			merge_rate, last_interaction, updated_at
@@ -178,7 +198,13 @@ func (db *DB) RecordPROutcome(repo string, merged bool, responseHours float64) e
 		db.placeholder(5), // now (last_interaction)
 		db.placeholder(6), // now (updated_at)
 	)
-	if _, err := db.Exec(query, repo, mergedInc, rejectedInc, mergeRate, now, now); err != nil {
+	if _, err := db.Exec(profileQ, repo, mergedInc, rejectedInc, mergeRate, now, now); err != nil {
+		// Reset the flag so the next feedback cycle can retry.
+		resetQ := fmt.Sprintf(
+			`UPDATE pull_requests SET outcome_recorded = 0 WHERE id = %s`,
+			db.placeholder(1),
+		)
+		db.Exec(resetQ, prID) //nolint:errcheck — best-effort reset; original error takes priority
 		return fmt.Errorf("record PR outcome: %w", err)
 	}
 

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -36,9 +36,10 @@ type PRReviewComment struct {
 
 // PRInfo bundles state + reviews from a single gh call.
 type PRInfo struct {
-	State   string     `json:"state"`
-	IsDraft bool       `json:"isDraft"`
-	Reviews []PRReview `json:"reviews"`
+	State     string     `json:"state"`
+	IsDraft   bool       `json:"isDraft"`
+	Reviews   []PRReview `json:"reviews"`
+	CreatedAt string     `json:"createdAt"` // RFC3339, authoritative GitHub PR open time
 }
 
 // GetPRInfo fetches state and reviews in one gh call to avoid rate limiting.
@@ -46,7 +47,7 @@ func (c *Client) GetPRInfo(ctx context.Context, repo string, prNum int) (*PRInfo
 	cmd := exec.CommandContext(ctx, "gh", "pr", "view",
 		fmt.Sprintf("%d", prNum),
 		"-R", repo,
-		"--json", "state,isDraft,reviews")
+		"--json", "state,isDraft,reviews,createdAt")
 
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
@@ -57,9 +58,10 @@ func (c *Client) GetPRInfo(ctx context.Context, repo string, prNum int) (*PRInfo
 
 	// Parse with nested author object
 	var raw struct {
-		State   string `json:"state"`
-		IsDraft bool   `json:"isDraft"`
-		Reviews []struct {
+		State     string `json:"state"`
+		IsDraft   bool   `json:"isDraft"`
+		CreatedAt string `json:"createdAt"`
+		Reviews   []struct {
 			Author struct {
 				Login string `json:"login"`
 			} `json:"author"`
@@ -72,7 +74,7 @@ func (c *Client) GetPRInfo(ctx context.Context, repo string, prNum int) (*PRInfo
 		return nil, fmt.Errorf("parse PR info: %w", err)
 	}
 
-	info := &PRInfo{State: raw.State, IsDraft: raw.IsDraft}
+	info := &PRInfo{State: raw.State, IsDraft: raw.IsDraft, CreatedAt: raw.CreatedAt}
 	for _, r := range raw.Reviews {
 		info.Reviews = append(info.Reviews, PRReview{
 			Author:      r.Author.Login,
@@ -351,7 +353,7 @@ func (c *Client) MarkPRReady(ctx context.Context, repo string, prNum int) error 
 
 // GitHubPR represents an open PR discovered from GitHub.
 type GitHubPR struct {
-	Repo       string `json:"repo"`       // owner/repo
+	Repo       string `json:"repo"` // owner/repo
 	Number     int    `json:"number"`
 	Title      string `json:"title"`
 	Body       string `json:"body"`

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -40,6 +40,8 @@ type PRInfo struct {
 	IsDraft   bool       `json:"isDraft"`
 	Reviews   []PRReview `json:"reviews"`
 	CreatedAt string     `json:"createdAt"` // RFC3339, authoritative GitHub PR open time
+	MergedAt  string     `json:"mergedAt"`  // RFC3339, set when state=MERGED
+	ClosedAt  string     `json:"closedAt"`  // RFC3339, set when state=CLOSED or MERGED
 }
 
 // GetPRInfo fetches state and reviews in one gh call to avoid rate limiting.
@@ -47,7 +49,7 @@ func (c *Client) GetPRInfo(ctx context.Context, repo string, prNum int) (*PRInfo
 	cmd := exec.CommandContext(ctx, "gh", "pr", "view",
 		fmt.Sprintf("%d", prNum),
 		"-R", repo,
-		"--json", "state,isDraft,reviews,createdAt")
+		"--json", "state,isDraft,reviews,createdAt,mergedAt,closedAt")
 
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
@@ -61,6 +63,8 @@ func (c *Client) GetPRInfo(ctx context.Context, repo string, prNum int) (*PRInfo
 		State     string `json:"state"`
 		IsDraft   bool   `json:"isDraft"`
 		CreatedAt string `json:"createdAt"`
+		MergedAt  string `json:"mergedAt"`
+		ClosedAt  string `json:"closedAt"`
 		Reviews   []struct {
 			Author struct {
 				Login string `json:"login"`
@@ -74,7 +78,7 @@ func (c *Client) GetPRInfo(ctx context.Context, repo string, prNum int) (*PRInfo
 		return nil, fmt.Errorf("parse PR info: %w", err)
 	}
 
-	info := &PRInfo{State: raw.State, IsDraft: raw.IsDraft, CreatedAt: raw.CreatedAt}
+	info := &PRInfo{State: raw.State, IsDraft: raw.IsDraft, CreatedAt: raw.CreatedAt, MergedAt: raw.MergedAt, ClosedAt: raw.ClosedAt}
 	for _, r := range raw.Reviews {
 		info.Reviews = append(info.Reviews, PRReview{
 			Author:      r.Author.Login,

--- a/internal/pipeline/feedback.go
+++ b/internal/pipeline/feedback.go
@@ -33,15 +33,23 @@ func (p *Pipeline) ProcessPR(ctx context.Context, pr *models.PullRequest) error 
 	// Terminal state transitions from GitHub
 	switch prInfo.State {
 	case "MERGED":
-		p.db.UpdatePRStatus(pr.ID, models.PRStatusMerged)
-		p.db.RecordPROutcome(prRepo, true, time.Since(pr.CreatedAt).Hours())
+		if err := p.db.UpdatePRStatus(pr.ID, models.PRStatusMerged); err != nil {
+			return fmt.Errorf("update PR status to merged: %w", err)
+		}
+		if err := p.db.RecordPROutcome(prRepo, true, time.Since(pr.CreatedAt).Hours()); err != nil {
+			log.WithError(err).Warn("failed to record merged PR outcome")
+		}
 		p.extractAndStoreLessons(ctx, pr, prRepo, prInfo)
 		p.cleanupWorkspace(pr)
 		log.WithField("pr", pr.PRURL).Info("PR merged")
 		return nil
 	case "CLOSED":
-		p.db.UpdatePRStatus(pr.ID, models.PRStatusClosed)
-		p.db.RecordPROutcome(prRepo, false, time.Since(pr.CreatedAt).Hours())
+		if err := p.db.UpdatePRStatus(pr.ID, models.PRStatusClosed); err != nil {
+			return fmt.Errorf("update PR status to closed: %w", err)
+		}
+		if err := p.db.RecordPROutcome(prRepo, false, time.Since(pr.CreatedAt).Hours()); err != nil {
+			log.WithError(err).Warn("failed to record closed PR outcome")
+		}
 		p.extractAndStoreLessons(ctx, pr, prRepo, prInfo)
 		p.cleanupWorkspace(pr)
 		log.WithField("pr", pr.PRURL).Info("PR closed")

--- a/internal/pipeline/feedback.go
+++ b/internal/pipeline/feedback.go
@@ -31,12 +31,13 @@ func (p *Pipeline) ProcessPR(ctx context.Context, pr *models.PullRequest) error 
 	}
 
 	// Terminal state transitions from GitHub
+	responseHours := prResponseHours(prInfo.CreatedAt, pr.CreatedAt)
 	switch prInfo.State {
 	case "MERGED":
 		if err := p.db.UpdatePRStatus(pr.ID, models.PRStatusMerged); err != nil {
 			return fmt.Errorf("update PR status to merged: %w", err)
 		}
-		if err := p.db.RecordPROutcome(pr.ID, prRepo, true, time.Since(pr.CreatedAt).Hours()); err != nil {
+		if err := p.db.RecordPROutcome(pr.ID, prRepo, true, responseHours); err != nil {
 			log.WithError(err).Warn("failed to record merged PR outcome")
 		}
 		p.extractAndStoreLessons(ctx, pr, prRepo, prInfo)
@@ -47,7 +48,7 @@ func (p *Pipeline) ProcessPR(ctx context.Context, pr *models.PullRequest) error 
 		if err := p.db.UpdatePRStatus(pr.ID, models.PRStatusClosed); err != nil {
 			return fmt.Errorf("update PR status to closed: %w", err)
 		}
-		if err := p.db.RecordPROutcome(pr.ID, prRepo, false, time.Since(pr.CreatedAt).Hours()); err != nil {
+		if err := p.db.RecordPROutcome(pr.ID, prRepo, false, responseHours); err != nil {
 			log.WithError(err).Warn("failed to record closed PR outcome")
 		}
 		p.extractAndStoreLessons(ctx, pr, prRepo, prInfo)
@@ -544,6 +545,19 @@ func (p *Pipeline) shouldAutoClose(pr *models.PullRequest, prInfo *ghclient.PRIn
 	}
 
 	return true
+}
+
+// prResponseHours returns hours from the GitHub PR open time to now.
+// ghCreatedAt is the RFC3339 string from GitHub (authoritative). fallback is the
+// local DB CreatedAt, used only when ghCreatedAt is empty or unparseable (e.g.
+// for PRs synced via EnsurePRWithIssue where CreatedAt was set to time.Now()).
+func prResponseHours(ghCreatedAt string, fallback time.Time) float64 {
+	if ghCreatedAt != "" {
+		if t, err := time.Parse(time.RFC3339, ghCreatedAt); err == nil {
+			return time.Since(t).Hours()
+		}
+	}
+	return time.Since(fallback).Hours()
 }
 
 // repoFromPRURL extracts "owner/repo" from a GitHub PR URL.

--- a/internal/pipeline/feedback.go
+++ b/internal/pipeline/feedback.go
@@ -34,22 +34,26 @@ func (p *Pipeline) ProcessPR(ctx context.Context, pr *models.PullRequest) error 
 	responseHours := prResponseHours(prInfo.CreatedAt, pr.CreatedAt)
 	switch prInfo.State {
 	case "MERGED":
+		// Record outcome first; if it fails return an error so the PR stays open
+		// in the DB and the next loop cycle can retry (outcome_recorded flag is
+		// reset by the transaction rollback in RecordPROutcome on failure).
+		if err := p.db.RecordPROutcome(pr.ID, prRepo, true, responseHours); err != nil {
+			return fmt.Errorf("record merged PR outcome: %w", err)
+		}
 		if err := p.db.UpdatePRStatus(pr.ID, models.PRStatusMerged); err != nil {
 			return fmt.Errorf("update PR status to merged: %w", err)
-		}
-		if err := p.db.RecordPROutcome(pr.ID, prRepo, true, responseHours); err != nil {
-			log.WithError(err).Warn("failed to record merged PR outcome")
 		}
 		p.extractAndStoreLessons(ctx, pr, prRepo, prInfo)
 		p.cleanupWorkspace(pr)
 		log.WithField("pr", pr.PRURL).Info("PR merged")
 		return nil
 	case "CLOSED":
+		// Same retry-safe ordering as MERGED above.
+		if err := p.db.RecordPROutcome(pr.ID, prRepo, false, responseHours); err != nil {
+			return fmt.Errorf("record closed PR outcome: %w", err)
+		}
 		if err := p.db.UpdatePRStatus(pr.ID, models.PRStatusClosed); err != nil {
 			return fmt.Errorf("update PR status to closed: %w", err)
-		}
-		if err := p.db.RecordPROutcome(pr.ID, prRepo, false, responseHours); err != nil {
-			log.WithError(err).Warn("failed to record closed PR outcome")
 		}
 		p.extractAndStoreLessons(ctx, pr, prRepo, prInfo)
 		p.cleanupWorkspace(pr)
@@ -70,6 +74,9 @@ func (p *Pipeline) ProcessPR(ctx context.Context, pr *models.PullRequest) error 
 			log.WithError(err).Warn("failed to auto-close stale PR")
 		} else {
 			p.db.UpdatePRStatus(pr.ID, models.PRStatusClosed)
+			if err := p.db.RecordPROutcome(pr.ID, prRepo, false, responseHours); err != nil {
+				log.WithError(err).Warn("failed to record stale auto-close outcome")
+			}
 		}
 		return nil
 	}
@@ -131,6 +138,9 @@ func (p *Pipeline) handleDraft(ctx context.Context, pr *models.PullRequest, prRe
 				log.WithError(err).Warn("failed to auto-close CI-failed PR")
 			} else {
 				p.db.UpdatePRStatus(pr.ID, models.PRStatusClosed)
+				if err := p.db.RecordPROutcome(pr.ID, prRepo, false, prResponseHours(prInfo.CreatedAt, pr.CreatedAt)); err != nil {
+					log.WithError(err).Warn("failed to record CI auto-close outcome")
+				}
 			}
 			return nil
 		}

--- a/internal/pipeline/feedback.go
+++ b/internal/pipeline/feedback.go
@@ -36,7 +36,7 @@ func (p *Pipeline) ProcessPR(ctx context.Context, pr *models.PullRequest) error 
 		if err := p.db.UpdatePRStatus(pr.ID, models.PRStatusMerged); err != nil {
 			return fmt.Errorf("update PR status to merged: %w", err)
 		}
-		if err := p.db.RecordPROutcome(prRepo, true, time.Since(pr.CreatedAt).Hours()); err != nil {
+		if err := p.db.RecordPROutcome(pr.ID, prRepo, true, time.Since(pr.CreatedAt).Hours()); err != nil {
 			log.WithError(err).Warn("failed to record merged PR outcome")
 		}
 		p.extractAndStoreLessons(ctx, pr, prRepo, prInfo)
@@ -47,7 +47,7 @@ func (p *Pipeline) ProcessPR(ctx context.Context, pr *models.PullRequest) error 
 		if err := p.db.UpdatePRStatus(pr.ID, models.PRStatusClosed); err != nil {
 			return fmt.Errorf("update PR status to closed: %w", err)
 		}
-		if err := p.db.RecordPROutcome(prRepo, false, time.Since(pr.CreatedAt).Hours()); err != nil {
+		if err := p.db.RecordPROutcome(pr.ID, prRepo, false, time.Since(pr.CreatedAt).Hours()); err != nil {
 			log.WithError(err).Warn("failed to record closed PR outcome")
 		}
 		p.extractAndStoreLessons(ctx, pr, prRepo, prInfo)

--- a/internal/pipeline/feedback.go
+++ b/internal/pipeline/feedback.go
@@ -34,12 +34,14 @@ func (p *Pipeline) ProcessPR(ctx context.Context, pr *models.PullRequest) error 
 	switch prInfo.State {
 	case "MERGED":
 		p.db.UpdatePRStatus(pr.ID, models.PRStatusMerged)
+		p.db.RecordPROutcome(prRepo, true, time.Since(pr.CreatedAt).Hours())
 		p.extractAndStoreLessons(ctx, pr, prRepo, prInfo)
 		p.cleanupWorkspace(pr)
 		log.WithField("pr", pr.PRURL).Info("PR merged")
 		return nil
 	case "CLOSED":
 		p.db.UpdatePRStatus(pr.ID, models.PRStatusClosed)
+		p.db.RecordPROutcome(prRepo, false, time.Since(pr.CreatedAt).Hours())
 		p.extractAndStoreLessons(ctx, pr, prRepo, prInfo)
 		p.cleanupWorkspace(pr)
 		log.WithField("pr", pr.PRURL).Info("PR closed")
@@ -477,19 +479,19 @@ func (p *Pipeline) buildResponderCtx(
 	}
 
 	return map[string]any{
-		"Repo":                 issue.Repo,
-		"IssueNumber":          issue.IssueNumber,
-		"IssueTitle":           issue.Title,
-		"IssueBody":            issue.Body,
+		"Repo":                  issue.Repo,
+		"IssueNumber":           issue.IssueNumber,
+		"IssueTitle":            issue.Title,
+		"IssueBody":             issue.Body,
 		"OriginalIssueComments": p.fetchOriginalIssueComments(issue),
-		"PRNumber":             pr.PRNumber,
-		"PRURL":                pr.PRURL,
-		"BranchName":           pr.BranchName,
-		"FeedbackRound":        pr.FeedbackRound + 1,
-		"Reviews":              reviewsText,
-		"InlineComments":       commentsText,
-		"IssueComments":        issueCommentsText,
-		"Rules":                p.ruleLoader.FormatForPrompt("responder"),
+		"PRNumber":              pr.PRNumber,
+		"PRURL":                 pr.PRURL,
+		"BranchName":            pr.BranchName,
+		"FeedbackRound":         pr.FeedbackRound + 1,
+		"Reviews":               reviewsText,
+		"InlineComments":        commentsText,
+		"IssueComments":         issueCommentsText,
+		"Rules":                 p.ruleLoader.FormatForPrompt("responder"),
 	}
 }
 

--- a/internal/pipeline/feedback.go
+++ b/internal/pipeline/feedback.go
@@ -31,13 +31,11 @@ func (p *Pipeline) ProcessPR(ctx context.Context, pr *models.PullRequest) error 
 	}
 
 	// Terminal state transitions from GitHub
-	responseHours := prResponseHours(prInfo.CreatedAt, pr.CreatedAt)
 	switch prInfo.State {
 	case "MERGED":
-		// Record outcome first; if it fails return an error so the PR stays open
-		// in the DB and the next loop cycle can retry (outcome_recorded flag is
-		// reset by the transaction rollback in RecordPROutcome on failure).
-		if err := p.db.RecordPROutcome(pr.ID, prRepo, true, responseHours); err != nil {
+		// Use the authoritative GitHub merge timestamp so polling delay does not
+		// inflate the measured response time.
+		if err := p.db.RecordPROutcome(pr.ID, prRepo, true, prResponseHours(prInfo.CreatedAt, prInfo.MergedAt, pr.CreatedAt)); err != nil {
 			return fmt.Errorf("record merged PR outcome: %w", err)
 		}
 		if err := p.db.UpdatePRStatus(pr.ID, models.PRStatusMerged); err != nil {
@@ -48,8 +46,8 @@ func (p *Pipeline) ProcessPR(ctx context.Context, pr *models.PullRequest) error 
 		log.WithField("pr", pr.PRURL).Info("PR merged")
 		return nil
 	case "CLOSED":
-		// Same retry-safe ordering as MERGED above.
-		if err := p.db.RecordPROutcome(pr.ID, prRepo, false, responseHours); err != nil {
+		// Use closedAt so response time reflects creation→close, not creation→poll.
+		if err := p.db.RecordPROutcome(pr.ID, prRepo, false, prResponseHours(prInfo.CreatedAt, prInfo.ClosedAt, pr.CreatedAt)); err != nil {
 			return fmt.Errorf("record closed PR outcome: %w", err)
 		}
 		if err := p.db.UpdatePRStatus(pr.ID, models.PRStatusClosed); err != nil {
@@ -73,9 +71,14 @@ func (p *Pipeline) ProcessPR(ctx context.Context, pr *models.PullRequest) error 
 		if err := p.gh.ClosePR(ctx, prRepo, pr.PRNumber, "Closing due to extended inactivity. Happy to reopen if there's still interest."); err != nil {
 			log.WithError(err).Warn("failed to auto-close stale PR")
 		} else {
-			p.db.UpdatePRStatus(pr.ID, models.PRStatusClosed)
-			if err := p.db.RecordPROutcome(pr.ID, prRepo, false, responseHours); err != nil {
+			// Record outcome before setting terminal status so that a transient
+			// DB failure here leaves the PR as open; the next loop cycle sees
+			// GitHub state=CLOSED and retries via the terminal-state handler.
+			// terminalAt is empty: we just triggered the close so time.Now()≈close time.
+			if err := p.db.RecordPROutcome(pr.ID, prRepo, false, prResponseHours(prInfo.CreatedAt, "", pr.CreatedAt)); err != nil {
 				log.WithError(err).Warn("failed to record stale auto-close outcome")
+			} else {
+				p.db.UpdatePRStatus(pr.ID, models.PRStatusClosed)
 			}
 		}
 		return nil
@@ -137,9 +140,12 @@ func (p *Pipeline) handleDraft(ctx context.Context, pr *models.PullRequest, prRe
 			if err := p.gh.ClosePR(ctx, prRepo, pr.PRNumber, "Closing: CI failures remain unresolved after multiple attempts."); err != nil {
 				log.WithError(err).Warn("failed to auto-close CI-failed PR")
 			} else {
-				p.db.UpdatePRStatus(pr.ID, models.PRStatusClosed)
-				if err := p.db.RecordPROutcome(pr.ID, prRepo, false, prResponseHours(prInfo.CreatedAt, pr.CreatedAt)); err != nil {
+				// Record outcome before setting terminal status (same retry-safe
+				// ordering as the stale auto-close path above).
+				if err := p.db.RecordPROutcome(pr.ID, prRepo, false, prResponseHours(prInfo.CreatedAt, "", pr.CreatedAt)); err != nil {
 					log.WithError(err).Warn("failed to record CI auto-close outcome")
+				} else {
+					p.db.UpdatePRStatus(pr.ID, models.PRStatusClosed)
 				}
 			}
 			return nil
@@ -557,14 +563,17 @@ func (p *Pipeline) shouldAutoClose(pr *models.PullRequest, prInfo *ghclient.PRIn
 	return true
 }
 
-// prResponseHours returns hours from the GitHub PR open time to now.
-// ghCreatedAt is the RFC3339 string from GitHub (authoritative). fallback is the
-// local DB CreatedAt, used only when ghCreatedAt is empty or unparseable (e.g.
-// for PRs synced via EnsurePRWithIssue where CreatedAt was set to time.Now()).
-func prResponseHours(ghCreatedAt string, fallback time.Time) float64 {
-	if ghCreatedAt != "" {
-		if t, err := time.Parse(time.RFC3339, ghCreatedAt); err == nil {
-			return time.Since(t).Hours()
+// prResponseHours returns hours from PR creation to the terminal event.
+// createdAt and terminalAt are RFC3339 strings from GitHub. When both parse
+// successfully the result is terminalAt−createdAt, which is immune to polling
+// delays. If terminalAt is empty or unparseable (e.g. auto-close paths where
+// we just issued the close ourselves), falls back to time.Since(fallback).
+func prResponseHours(createdAt, terminalAt string, fallback time.Time) float64 {
+	if createdAt != "" && terminalAt != "" {
+		created, err1 := time.Parse(time.RFC3339, createdAt)
+		terminal, err2 := time.Parse(time.RFC3339, terminalAt)
+		if err1 == nil && err2 == nil && !terminal.Before(created) {
+			return terminal.Sub(created).Hours()
 		}
 	}
 	return time.Since(fallback).Hours()

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -17,20 +17,20 @@ const (
 
 	// V2 pipeline statuses
 	IssueStatusAnalyzing   IssueStatus = "analyzing"   // Analyst agent running
-	IssueStatusEngineering IssueStatus = "engineering"  // Engineer agent running
-	IssueStatusReviewing   IssueStatus = "reviewing"    // Reviewer agent running
-	IssueStatusRework      IssueStatus = "rework"       // Engineer reworking after review
-	IssueStatusSubmitting  IssueStatus = "submitting"   // Submitter agent running
+	IssueStatusEngineering IssueStatus = "engineering" // Engineer agent running
+	IssueStatusReviewing   IssueStatus = "reviewing"   // Reviewer agent running
+	IssueStatusRework      IssueStatus = "rework"      // Engineer reworking after review
+	IssueStatusSubmitting  IssueStatus = "submitting"  // Submitter agent running
 )
 
 // PRStatus represents the status of a pull request
 type PRStatus string
 
 const (
-	PRStatusDraft      PRStatus = "draft" // Draft PR, waiting for CI
-	PRStatusOpen       PRStatus = "open"  // Ready for review, checking feedback
-	PRStatusMerged     PRStatus = "merged"
-	PRStatusClosed     PRStatus = "closed"
+	PRStatusDraft          PRStatus = "draft" // Draft PR, waiting for CI
+	PRStatusOpen           PRStatus = "open"  // Ready for review, checking feedback
+	PRStatusMerged         PRStatus = "merged"
+	PRStatusClosed         PRStatus = "closed"
 	PRStatusResponding     PRStatus = "responding"
 	PRStatusNeedsAttention PRStatus = "needs_attention" // Requires manual action (e.g. CLA signing)
 )
@@ -39,16 +39,16 @@ const (
 type FailureReason string
 
 const (
-	FailureReasonTimeout          FailureReason = "timeout"
-	FailureReasonNoChanges        FailureReason = "no_changes"
-	FailureReasonTestsFailed      FailureReason = "tests_failed"
-	FailureReasonCIFailed         FailureReason = "ci_failed"
-	FailureReasonCloneFailed      FailureReason = "clone_failed"
-	FailureReasonPRFailed         FailureReason = "pr_failed"
-	FailureReasonComplexityHigh   FailureReason = "complexity_too_high"
-	FailureReasonAlreadyHasPR     FailureReason = "already_has_pr"
-	FailureReasonAlreadyFixed     FailureReason = "already_fixed"
-	FailureReasonUnknown          FailureReason = "unknown"
+	FailureReasonTimeout        FailureReason = "timeout"
+	FailureReasonNoChanges      FailureReason = "no_changes"
+	FailureReasonTestsFailed    FailureReason = "tests_failed"
+	FailureReasonCIFailed       FailureReason = "ci_failed"
+	FailureReasonCloneFailed    FailureReason = "clone_failed"
+	FailureReasonPRFailed       FailureReason = "pr_failed"
+	FailureReasonComplexityHigh FailureReason = "complexity_too_high"
+	FailureReasonAlreadyHasPR   FailureReason = "already_has_pr"
+	FailureReasonAlreadyFixed   FailureReason = "already_fixed"
+	FailureReasonUnknown        FailureReason = "unknown"
 )
 
 // Issue represents a discovered GitHub issue
@@ -85,22 +85,22 @@ func (r FailureReason) IsRetryable() bool {
 
 // PullRequest represents a created pull request
 type PullRequest struct {
-	ID                 int64      `db:"id" json:"id"`
-	IssueID            int64      `db:"issue_id" json:"issue_id"`
-	PRURL              string     `db:"pr_url" json:"pr_url"`
-	PRNumber           int        `db:"pr_number" json:"pr_number"`
-	BranchName         string     `db:"branch_name" json:"branch_name"`
-	Status             PRStatus   `db:"status" json:"status"`
-	CIStatus           string     `db:"ci_status" json:"ci_status"`
-	RetryCount         int        `db:"retry_count" json:"retry_count"`
-	MergedAt           *time.Time `db:"merged_at" json:"merged_at,omitempty"`
-	ClosedAt           *time.Time `db:"closed_at" json:"closed_at,omitempty"`
-	ReviewCommentCount int        `db:"review_comment_count" json:"review_comment_count"`
-	FirstReviewAt      *time.Time `db:"first_review_at" json:"first_review_at,omitempty"`
-	CreatedAt            time.Time  `db:"created_at" json:"created_at"`
-	UpdatedAt            time.Time  `db:"updated_at" json:"updated_at"`
-	LastFeedbackCheckAt  *time.Time `db:"last_feedback_check_at" json:"last_feedback_check_at,omitempty"`
-	FeedbackRound        int        `db:"feedback_round" json:"feedback_round"`
+	ID                  int64      `db:"id" json:"id"`
+	IssueID             int64      `db:"issue_id" json:"issue_id"`
+	PRURL               string     `db:"pr_url" json:"pr_url"`
+	PRNumber            int        `db:"pr_number" json:"pr_number"`
+	BranchName          string     `db:"branch_name" json:"branch_name"`
+	Status              PRStatus   `db:"status" json:"status"`
+	CIStatus            string     `db:"ci_status" json:"ci_status"`
+	RetryCount          int        `db:"retry_count" json:"retry_count"`
+	MergedAt            *time.Time `db:"merged_at" json:"merged_at,omitempty"`
+	ClosedAt            *time.Time `db:"closed_at" json:"closed_at,omitempty"`
+	ReviewCommentCount  int        `db:"review_comment_count" json:"review_comment_count"`
+	FirstReviewAt       *time.Time `db:"first_review_at" json:"first_review_at,omitempty"`
+	CreatedAt           time.Time  `db:"created_at" json:"created_at"`
+	UpdatedAt           time.Time  `db:"updated_at" json:"updated_at"`
+	LastFeedbackCheckAt *time.Time `db:"last_feedback_check_at" json:"last_feedback_check_at,omitempty"`
+	FeedbackRound       int        `db:"feedback_round" json:"feedback_round"`
 }
 
 // TimeToMerge returns the duration from PR creation to merge
@@ -179,22 +179,22 @@ type IssueMetrics struct {
 
 // DailyStats holds daily aggregated statistics
 type DailyStats struct {
-	ID                     int64     `db:"id"`
-	Date                   string    `db:"date"` // YYYY-MM-DD
-	IssuesDiscovered       int       `db:"issues_discovered"`
-	IssuesAttempted        int       `db:"issues_attempted"`
-	IssuesSolved           int       `db:"issues_solved"`
-	PRsCreated             int       `db:"prs_created"`
-	PRsMerged              int       `db:"prs_merged"`
-	PRsClosed              int       `db:"prs_closed"`
-	AvgSolveTimeSeconds    *float64  `db:"avg_solve_time_seconds"`
-	AvgAttemptsPerIssue    *float64  `db:"avg_attempts_per_issue"`
-	FirstAttemptSuccessRate *float64 `db:"first_attempt_success_rate"`
-	OverallSuccessRate     *float64  `db:"overall_success_rate"`
-	StatsByLanguage        string    `db:"stats_by_language"`     // JSON
-	StatsByRepo            string    `db:"stats_by_repo"`         // JSON
-	FailureReasonsCount    string    `db:"failure_reasons_count"` // JSON
-	CreatedAt              time.Time `db:"created_at"`
+	ID                      int64     `db:"id"`
+	Date                    string    `db:"date"` // YYYY-MM-DD
+	IssuesDiscovered        int       `db:"issues_discovered"`
+	IssuesAttempted         int       `db:"issues_attempted"`
+	IssuesSolved            int       `db:"issues_solved"`
+	PRsCreated              int       `db:"prs_created"`
+	PRsMerged               int       `db:"prs_merged"`
+	PRsClosed               int       `db:"prs_closed"`
+	AvgSolveTimeSeconds     *float64  `db:"avg_solve_time_seconds"`
+	AvgAttemptsPerIssue     *float64  `db:"avg_attempts_per_issue"`
+	FirstAttemptSuccessRate *float64  `db:"first_attempt_success_rate"`
+	OverallSuccessRate      *float64  `db:"overall_success_rate"`
+	StatsByLanguage         string    `db:"stats_by_language"`     // JSON
+	StatsByRepo             string    `db:"stats_by_repo"`         // JSON
+	FailureReasonsCount     string    `db:"failure_reasons_count"` // JSON
+	CreatedAt               time.Time `db:"created_at"`
 }
 
 // RepoMetrics holds aggregated metrics per repository
@@ -249,14 +249,14 @@ type LanguageMetrics struct {
 
 // PRMetrics holds PR-related aggregate statistics
 type PRMetrics struct {
-	TotalPRs           int     `json:"total_prs"`
-	OpenPRs            int     `json:"open_prs"`
-	MergedPRs          int     `json:"merged_prs"`
-	ClosedPRs          int     `json:"closed_prs"`
-	MergeRate          float64 `json:"merge_rate"`
-	AvgTimeToMerge     float64 `json:"avg_time_to_merge_hours"`
+	TotalPRs             int     `json:"total_prs"`
+	OpenPRs              int     `json:"open_prs"`
+	MergedPRs            int     `json:"merged_prs"`
+	ClosedPRs            int     `json:"closed_prs"`
+	MergeRate            float64 `json:"merge_rate"`
+	AvgTimeToMerge       float64 `json:"avg_time_to_merge_hours"`
 	AvgTimeToFirstReview float64 `json:"avg_time_to_first_review_hours"`
-	AvgReviewComments  float64 `json:"avg_review_comments"`
+	AvgReviewComments    float64 `json:"avg_review_comments"`
 }
 
 // BlacklistEntry represents a blacklisted repository
@@ -273,29 +273,48 @@ type ReviewLesson struct {
 	ID            int64     `db:"id" json:"id"`
 	PRID          int64     `db:"pr_id" json:"pr_id"`
 	Repo          string    `db:"repo" json:"repo"`
-	Category      string    `db:"category" json:"category"`           // testing, style, scope, docs, ci, logic
-	Lesson        string    `db:"lesson" json:"lesson"`               // extracted actionable lesson
+	Category      string    `db:"category" json:"category"`             // testing, style, scope, docs, ci, logic
+	Lesson        string    `db:"lesson" json:"lesson"`                 // extracted actionable lesson
 	SourceComment string    `db:"source_comment" json:"source_comment"` // original reviewer text
 	Reviewer      string    `db:"reviewer" json:"reviewer"`
 	CreatedAt     time.Time `db:"created_at" json:"created_at"`
 }
 
+// RepoProfile stores per-repository learning data used by the scout phase.
+type RepoProfile struct {
+	Repo                 string     `db:"repo" json:"repo"`
+	TotalPRsSubmitted    int        `db:"total_prs_submitted" json:"total_prs_submitted"`
+	TotalMerged          int        `db:"total_merged" json:"total_merged"`
+	TotalRejected        int        `db:"total_rejected" json:"total_rejected"`
+	MergeRate            float64    `db:"merge_rate" json:"merge_rate"`
+	AvgResponseTimeHours *float64   `db:"avg_response_time_hours" json:"avg_response_time_hours,omitempty"`
+	RequiresCLA          bool       `db:"requires_cla" json:"requires_cla"`
+	RequiresAssignment   bool       `db:"requires_assignment" json:"requires_assignment"`
+	PreferredPRSize      string     `db:"preferred_pr_size" json:"preferred_pr_size,omitempty"`
+	Blacklisted          bool       `db:"blacklisted" json:"blacklisted"`
+	BlacklistReason      string     `db:"blacklist_reason" json:"blacklist_reason,omitempty"`
+	CooldownUntil        *time.Time `db:"cooldown_until" json:"cooldown_until,omitempty"`
+	StrategyNotes        string     `db:"strategy_notes" json:"strategy_notes,omitempty"`
+	LastInteraction      *time.Time `db:"last_interaction" json:"last_interaction,omitempty"`
+	UpdatedAt            time.Time  `db:"updated_at" json:"updated_at"`
+}
+
 // PipelineEvent records a single agent invocation in the pipeline.
 type PipelineEvent struct {
-	ID               int64      `db:"id" json:"id"`
-	IssueID          int64      `db:"issue_id" json:"issue_id"`
-	PRID             *int64     `db:"pr_id" json:"pr_id,omitempty"`
-	Repo             string     `db:"repo" json:"repo"`
-	IssueNumber      int        `db:"issue_number" json:"issue_number"`
-	Stage            string     `db:"stage" json:"stage"`
-	Round            int        `db:"round" json:"round"`
-	StartedAt        time.Time  `db:"started_at" json:"started_at"`
-	CompletedAt      *time.Time `db:"completed_at" json:"completed_at,omitempty"`
-	DurationSeconds  float64    `db:"duration_seconds" json:"duration_seconds"`
-	OutputSummary    string     `db:"output_summary" json:"output_summary"`
-	Verdict          string     `db:"verdict" json:"verdict"`
-	Success          bool       `db:"success" json:"success"`
-	ErrorMessage     string     `db:"error_message" json:"error_message,omitempty"`
-	OutcomeLabel     string     `db:"outcome_label" json:"outcome_label,omitempty"`
-	CreatedAt        time.Time  `db:"created_at" json:"created_at"`
+	ID              int64      `db:"id" json:"id"`
+	IssueID         int64      `db:"issue_id" json:"issue_id"`
+	PRID            *int64     `db:"pr_id" json:"pr_id,omitempty"`
+	Repo            string     `db:"repo" json:"repo"`
+	IssueNumber     int        `db:"issue_number" json:"issue_number"`
+	Stage           string     `db:"stage" json:"stage"`
+	Round           int        `db:"round" json:"round"`
+	StartedAt       time.Time  `db:"started_at" json:"started_at"`
+	CompletedAt     *time.Time `db:"completed_at" json:"completed_at,omitempty"`
+	DurationSeconds float64    `db:"duration_seconds" json:"duration_seconds"`
+	OutputSummary   string     `db:"output_summary" json:"output_summary"`
+	Verdict         string     `db:"verdict" json:"verdict"`
+	Success         bool       `db:"success" json:"success"`
+	ErrorMessage    string     `db:"error_message" json:"error_message,omitempty"`
+	OutcomeLabel    string     `db:"outcome_label" json:"outcome_label,omitempty"`
+	CreatedAt       time.Time  `db:"created_at" json:"created_at"`
 }


### PR DESCRIPTION
## Summary

Closes #14

- **Schema**: New `repo_profiles` table (both SQLite and PostgreSQL) storing merge rate, avg response time, CLA/assignment requirements, blacklist status, cooldown, and strategy notes per repository
- **Methods**: All DB logic in new `internal/db/repo_profiles.go` (kept `db.go` from growing past its 1300-line existing size): `GetRepoProfile`, `UpsertRepoProfile`, `RecordPROutcome`, `ShouldSkipRepo`, `MigrateRepoProfiles`
- **Scout integration**: `cmd_discover.go` now calls `ShouldSkipRepo(repo, threshold=0.1, minSamples=3)` — repos with <10% merge rate after ≥3 submitted PRs are skipped automatically
- **Auto-update**: `pipeline/feedback.go` calls `RecordPROutcome` when a PR reaches terminal state (MERGED/CLOSED), keeping per-repo stats current without manual intervention

## Test plan

- [x] `gofmt -w .` — no changes
- [x] `go vet ./...` — clean
- [x] `go build ./...` — clean
- [x] `go test ./...` — all existing tests pass