### PR TITLE
refactor: deduplicate synthesized rules (closes #13)

### DIFF
--- a/cmd/auto-contributor/main.go
+++ b/cmd/auto-contributor/main.go
@@ -23,8 +23,10 @@ var (
 )
 
 func main() {
-	// Load .env file if exists (ignore error if not found)
-	_ = godotenv.Load()
+	// Load .env file if it exists; absence is not an error.
+	if err := godotenv.Load(); err != nil {
+		log.Debug("no .env file, relying on environment variables")
+	}
 
 	rootCmd := &cobra.Command{
 		Use:   "auto-contributor",

--- a/cmd/auto-contributor/main.go
+++ b/cmd/auto-contributor/main.go
@@ -24,7 +24,13 @@ var (
 
 func main() {
 	// Load .env file if it exists; absence is not an error.
+	// Any other failure (parse error, permission denied) must abort early to
+	// prevent silently broken env config from causing auth/runtime failures later.
 	if err := godotenv.Load(); err != nil {
+		if !os.IsNotExist(err) {
+			fmt.Fprintf(os.Stderr, "fatal: failed to load .env file: %v\n", err)
+			os.Exit(1)
+		}
 		log.Debug("no .env file, relying on environment variables")
 	}
 

--- a/internal/pipeline/synthesizer.go
+++ b/internal/pipeline/synthesizer.go
@@ -121,6 +121,9 @@ type applyResult struct {
 func (p *Pipeline) applySynthesisResult(stage string, result *SynthesizerResult) applyResult {
 	var applied applyResult
 	rulesDir := p.ruleLoader.RulesDir()
+	// batchAccepted tracks rules written in this call so intra-batch semantic
+	// duplicates are caught before the loader is reloaded.
+	var batchAccepted []*rules.Rule
 
 	// Write new rules (validate first)
 	for _, nr := range result.NewRules {
@@ -144,6 +147,14 @@ func (p *Pipeline) applySynthesisResult(stage string, result *SynthesizerResult)
 			log.WithFields(Fields{"rule": nr.ID, "existingMatch": matchID}).Info("skipping semantically duplicate rule")
 			continue
 		}
+		// Also check rules accepted earlier in this batch: the loader snapshot is
+		// not updated until Reload() runs after this function returns, so without
+		// this check two semantically equivalent rules in the same LLM response
+		// would both pass HasSemanticMatch and both be written.
+		if match, matchID := p.ruleLoader.HasSemanticMatchAmong(nr.ID, nr.Tags, stage, batchAccepted); match {
+			log.WithFields(Fields{"rule": nr.ID, "batchMatch": matchID}).Info("skipping semantically duplicate rule (batch-internal)")
+			continue
+		}
 
 		rule := &rules.Rule{
 			ID:              nr.ID,
@@ -163,6 +174,7 @@ func (p *Pipeline) applySynthesisResult(stage string, result *SynthesizerResult)
 			log.WithFields(Fields{"rule": nr.ID, "error": err}).Warn("failed to write synthesized rule")
 			continue
 		}
+		batchAccepted = append(batchAccepted, rule)
 		applied.newCount++
 	}
 

--- a/internal/pipeline/synthesizer.go
+++ b/internal/pipeline/synthesizer.go
@@ -136,6 +136,13 @@ func (p *Pipeline) applySynthesisResult(stage string, result *SynthesizerResult)
 		if nr.ID == "" || nr.Body == "" {
 			continue
 		}
+		// Reject IDs that contain path separators or dot-dot sequences; WriteRule
+		// uses the ID as a filename component and an unsafe value could escape the
+		// rules/{stage} directory via path traversal.
+		if strings.ContainsAny(nr.ID, "/\\") || strings.Contains(nr.ID, "..") {
+			log.WithFields(Fields{"rule": nr.ID}).Warn("skipping rule with unsafe ID")
+			continue
+		}
 		// Don't overwrite existing rules (exact ID match)
 		if p.ruleLoader.ByID(nr.ID) != nil {
 			continue

--- a/internal/pipeline/synthesizer.go
+++ b/internal/pipeline/synthesizer.go
@@ -137,8 +137,10 @@ func (p *Pipeline) applySynthesisResult(stage string, result *SynthesizerResult)
 		if p.ruleLoader.ByID(nr.ID) != nil {
 			continue
 		}
-		// Skip semantically duplicate rules to prevent rule explosion
-		if match, matchID := p.ruleLoader.HasSemanticMatch(nr.ID, nr.Tags, nr.Stage); match {
+		// Skip semantically duplicate rules to prevent rule explosion.
+		// Use the trusted function-arg `stage` instead of nr.Stage (model output) to
+		// ensure dedup always runs against the correct stage's rule set.
+		if match, matchID := p.ruleLoader.HasSemanticMatch(nr.ID, nr.Tags, stage); match {
 			log.WithFields(Fields{"rule": nr.ID, "existingMatch": matchID}).Info("skipping semantically duplicate rule")
 			continue
 		}

--- a/internal/pipeline/synthesizer.go
+++ b/internal/pipeline/synthesizer.go
@@ -3,6 +3,7 @@ package pipeline
 import (
 	"context"
 	"fmt"
+	"math"
 	"strings"
 	"time"
 
@@ -95,6 +96,7 @@ func (p *Pipeline) synthesizeForStage(ctx context.Context, stage string, events 
 		"Stage":           stage,
 		"EventsText":      eventsText,
 		"ExistingRules":   existingRules,
+		"ExistingRuleIDs": p.ruleLoader.IDSummaryForStage(stage),
 		"TotalEvents":     len(events),
 		"MergedCount":     merged,
 		"RejectedCount":   rejected,
@@ -131,8 +133,13 @@ func (p *Pipeline) applySynthesisResult(stage string, result *SynthesizerResult)
 		if nr.ID == "" || nr.Body == "" {
 			continue
 		}
-		// Don't overwrite existing rules
+		// Don't overwrite existing rules (exact ID match)
 		if p.ruleLoader.ByID(nr.ID) != nil {
+			continue
+		}
+		// Skip semantically duplicate rules to prevent rule explosion
+		if match, matchID := p.ruleLoader.HasSemanticMatch(nr.ID, nr.Tags, nr.Stage); match {
+			log.WithFields(Fields{"rule": nr.ID, "existingMatch": matchID}).Debug("skipping semantically duplicate rule")
 			continue
 		}
 
@@ -140,7 +147,7 @@ func (p *Pipeline) applySynthesisResult(stage string, result *SynthesizerResult)
 			ID:              nr.ID,
 			Stage:           nr.Stage,
 			Severity:        nr.Severity,
-			Confidence:      nr.Confidence,
+			Confidence:      normalizeNewRuleConfidence(nr.Confidence),
 			Source:          "synthesized",
 			CreatedAt:       time.Now().Format("2006-01-02"),
 			LastValidatedAt: time.Now().Format("2006-01-02"),
@@ -216,6 +223,17 @@ func (p *Pipeline) applyDecay() {
 			log.WithFields(Fields{"rule": r.ID, "error": err}).Warn("failed to apply decay")
 		}
 	}
+}
+
+// normalizeNewRuleConfidence rounds confidence to the nearest 0.1 in [0.3, 0.9].
+// This prevents new rules from inheriting degraded floating-point values from existing ones.
+func normalizeNewRuleConfidence(c float64) float64 {
+	if c < 0.3 {
+		c = 0.5
+	} else if c > 0.9 {
+		c = 0.9
+	}
+	return math.Round(c*10) / 10
 }
 
 func formatEventsForSynthesis(events []*models.PipelineEvent) string {

--- a/internal/pipeline/synthesizer.go
+++ b/internal/pipeline/synthesizer.go
@@ -139,7 +139,7 @@ func (p *Pipeline) applySynthesisResult(stage string, result *SynthesizerResult)
 		}
 		// Skip semantically duplicate rules to prevent rule explosion
 		if match, matchID := p.ruleLoader.HasSemanticMatch(nr.ID, nr.Tags, nr.Stage); match {
-			log.WithFields(Fields{"rule": nr.ID, "existingMatch": matchID}).Debug("skipping semantically duplicate rule")
+			log.WithFields(Fields{"rule": nr.ID, "existingMatch": matchID}).Info("skipping semantically duplicate rule")
 			continue
 		}
 

--- a/internal/pipeline/synthesizer.go
+++ b/internal/pipeline/synthesizer.go
@@ -158,7 +158,7 @@ func (p *Pipeline) applySynthesisResult(stage string, result *SynthesizerResult)
 
 		rule := &rules.Rule{
 			ID:              nr.ID,
-			Stage:           nr.Stage,
+			Stage:           stage, // use validated stage arg, not model-emitted nr.Stage
 			Severity:        nr.Severity,
 			Confidence:      normalizeNewRuleConfidence(nr.Confidence),
 			Source:          "synthesized",

--- a/internal/rules/loader.go
+++ b/internal/rules/loader.go
@@ -276,6 +276,13 @@ func (rl *RuleLoader) IDSummaryForStage(stage string) string {
 		if r.Stage != stage && r.Stage != "global" {
 			continue
 		}
+		// Exclude low-confidence/decayed rules from the dedup hint list.
+		// HasSemanticMatch and ForStage already ignore these rules at runtime, so
+		// including them here would incorrectly tell the LLM "this rule exists —
+		// don't recreate it", permanently blocking fresh replacements for stale rules.
+		if r.Confidence < MinConfidenceForInjection {
+			continue
+		}
 		if sb.Len() >= maxIDSummaryBytes {
 			omitted++
 			continue

--- a/internal/rules/loader.go
+++ b/internal/rules/loader.go
@@ -283,20 +283,28 @@ func (rl *RuleLoader) IDSummaryForStage(stage string) string {
 		if r.Confidence < MinConfidenceForInjection {
 			continue
 		}
-		if sb.Len() >= maxIDSummaryBytes {
+		// Build the entry first so we can measure its exact byte size before
+		// committing to the output buffer. This prevents a single oversized
+		// rule from pushing sb past maxIDSummaryBytes after the pre-check.
+		var entry strings.Builder
+		entry.WriteString(r.ID)
+		if r.Condition != "" {
+			cond := r.Condition
+			// Truncate by rune count, not byte count, to avoid splitting a
+			// multi-byte UTF-8 codepoint mid-sequence (Issue 2).
+			if runes := []rune(cond); len(runes) > maxConditionLen {
+				cond = string(runes[:maxConditionLen]) + "…"
+			}
+			entry.WriteString(": ")
+			entry.WriteString(cond)
+		}
+		entry.WriteByte('\n')
+		entryStr := entry.String()
+		if sb.Len()+len(entryStr) > maxIDSummaryBytes {
 			omitted++
 			continue
 		}
-		sb.WriteString(r.ID)
-		if r.Condition != "" {
-			cond := r.Condition
-			if len(cond) > maxConditionLen {
-				cond = cond[:maxConditionLen] + "…"
-			}
-			sb.WriteString(": ")
-			sb.WriteString(cond)
-		}
-		sb.WriteByte('\n')
+		sb.WriteString(entryStr)
 	}
 	if omitted > 0 {
 		fmt.Fprintf(&sb, "(%d more rules omitted — see rules/ directory for full list)\n", omitted)

--- a/internal/rules/loader.go
+++ b/internal/rules/loader.go
@@ -179,3 +179,87 @@ func (rl *RuleLoader) ByID(id string) *Rule {
 	}
 	return nil
 }
+
+// HasSemanticMatch returns true if an existing rule for the given stage is semantically
+// similar to the proposed rule based on keyword and tag overlap (threshold: 2 shared tokens).
+// The second return value is the ID of the matching rule, or "" if none.
+func (rl *RuleLoader) HasSemanticMatch(id string, tags []string, stage string) (bool, string) {
+	newKW := ruleKeywords(id, tags)
+
+	rl.mu.RLock()
+	defer rl.mu.RUnlock()
+
+	for _, r := range rl.rules {
+		if r.Stage != stage && r.Stage != "global" {
+			continue
+		}
+		if sharedKeywords(newKW, ruleKeywords(r.ID, r.Tags)) >= 2 {
+			return true, r.ID
+		}
+	}
+	return false, ""
+}
+
+// IDSummaryForStage returns a compact newline-separated "id: condition" list for all rules
+// matching the given stage (and global). Used to provide deduplication context to the synthesizer.
+func (rl *RuleLoader) IDSummaryForStage(stage string) string {
+	rl.mu.RLock()
+	defer rl.mu.RUnlock()
+
+	var sb strings.Builder
+	for _, r := range rl.rules {
+		if r.Stage != stage && r.Stage != "global" {
+			continue
+		}
+		sb.WriteString(r.ID)
+		if r.Condition != "" {
+			sb.WriteString(": ")
+			sb.WriteString(r.Condition)
+		}
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+// ruleKeywords extracts meaningful tokens from a rule ID and its tags, dropping stop words.
+func ruleKeywords(id string, tags []string) []string {
+	stop := map[string]bool{
+		"and": true, "or": true, "the": true, "for": true, "in": true,
+		"to": true, "a": true, "of": true, "with": true, "on": true,
+		"is": true, "not": true, "no": true, "per": true,
+	}
+	seen := map[string]bool{}
+	var kw []string
+	for _, p := range strings.Split(id, "-") {
+		p = strings.ToLower(p)
+		if p != "" && !stop[p] && !seen[p] {
+			kw = append(kw, p)
+			seen[p] = true
+		}
+	}
+	for _, t := range tags {
+		t = strings.ToLower(t)
+		if t != "" && !stop[t] && !seen[t] {
+			kw = append(kw, t)
+			seen[t] = true
+		}
+	}
+	return kw
+}
+
+// sharedKeywords counts distinct keywords that appear in both slices.
+func sharedKeywords(a, b []string) int {
+	setA := make(map[string]bool, len(a))
+	for _, x := range a {
+		setA[x] = true
+	}
+	count := 0
+	seen := make(map[string]bool)
+	for _, x := range b {
+		if setA[x] && !seen[x] {
+			count++
+			seen[x] = true
+		}
+	}
+	return count
+}

--- a/internal/rules/loader.go
+++ b/internal/rules/loader.go
@@ -14,6 +14,14 @@ import (
 const MinConfidenceForInjection = 0.3
 const MaxPromptChars = 2000
 
+// maxIDSummaryBytes caps the total byte size of the ExistingRuleIDs payload injected
+// into the synthesizer prompt, which is passed via -p argv. Keeping it well below
+// typical OS ARG_MAX (128 KB per argument on Linux) prevents "argument list too long" failures.
+const maxIDSummaryBytes = 4096
+
+// maxConditionLen caps the per-rule condition snippet included in IDSummaryForStage.
+const maxConditionLen = 80
+
 // RuleLoader reads and caches rules from the rules/ directory tree.
 type RuleLoader struct {
 	rulesDir string
@@ -181,10 +189,17 @@ func (rl *RuleLoader) ByID(id string) *Rule {
 }
 
 // HasSemanticMatch returns true if an existing rule for the given stage is semantically
-// similar to the proposed rule based on keyword and tag overlap (threshold: 2 shared tokens).
+// similar to the proposed rule based on keyword and tag overlap.
+//
+// Match criteria: shared tokens ≥ 2 AND shared/min(|A|,|B|) ≥ 0.5.
+// The ratio guard prevents high-frequency but low-signal tokens (e.g. "ci", "tests")
+// from triggering false-positive suppression of distinct new rules.
 // The second return value is the ID of the matching rule, or "" if none.
 func (rl *RuleLoader) HasSemanticMatch(id string, tags []string, stage string) (bool, string) {
 	newKW := ruleKeywords(id, tags)
+	if len(newKW) < 2 {
+		return false, ""
+	}
 
 	rl.mu.RLock()
 	defer rl.mu.RUnlock()
@@ -193,7 +208,17 @@ func (rl *RuleLoader) HasSemanticMatch(id string, tags []string, stage string) (
 		if r.Stage != stage && r.Stage != "global" {
 			continue
 		}
-		if sharedKeywords(newKW, ruleKeywords(r.ID, r.Tags)) >= 2 {
+		existKW := ruleKeywords(r.ID, r.Tags)
+		if len(existKW) < 2 {
+			continue
+		}
+		shared := sharedKeywords(newKW, existKW)
+		minLen := len(newKW)
+		if len(existKW) < minLen {
+			minLen = len(existKW)
+		}
+		// Both conditions must hold: enough absolute overlap AND enough relative overlap.
+		if shared >= 2 && float64(shared)/float64(minLen) >= 0.5 {
 			return true, r.ID
 		}
 	}
@@ -202,21 +227,37 @@ func (rl *RuleLoader) HasSemanticMatch(id string, tags []string, stage string) (
 
 // IDSummaryForStage returns a compact newline-separated "id: condition" list for all rules
 // matching the given stage (and global). Used to provide deduplication context to the synthesizer.
+//
+// Output is capped at maxIDSummaryBytes to stay well within OS ARG_MAX when the result
+// is embedded in the synthesizer prompt passed via -p argv. Each condition snippet is also
+// truncated to maxConditionLen characters.
 func (rl *RuleLoader) IDSummaryForStage(stage string) string {
 	rl.mu.RLock()
 	defer rl.mu.RUnlock()
 
 	var sb strings.Builder
+	omitted := 0
 	for _, r := range rl.rules {
 		if r.Stage != stage && r.Stage != "global" {
 			continue
 		}
+		if sb.Len() >= maxIDSummaryBytes {
+			omitted++
+			continue
+		}
 		sb.WriteString(r.ID)
 		if r.Condition != "" {
+			cond := r.Condition
+			if len(cond) > maxConditionLen {
+				cond = cond[:maxConditionLen] + "…"
+			}
 			sb.WriteString(": ")
-			sb.WriteString(r.Condition)
+			sb.WriteString(cond)
 		}
 		sb.WriteByte('\n')
+	}
+	if omitted > 0 {
+		fmt.Fprintf(&sb, "(%d more rules omitted — see rules/ directory for full list)\n", omitted)
 	}
 	return sb.String()
 }
@@ -227,6 +268,10 @@ func ruleKeywords(id string, tags []string) []string {
 		"and": true, "or": true, "the": true, "for": true, "in": true,
 		"to": true, "a": true, "of": true, "with": true, "on": true,
 		"is": true, "not": true, "no": true, "per": true,
+		// domain-specific high-frequency tokens that appear in many rules but
+		// do not distinguish rule semantics; without these, two rules sharing
+		// only "ci"+"tests" would falsely trigger semantic-duplicate suppression.
+		"ci": true, "test": true, "tests": true,
 	}
 	seen := map[string]bool{}
 	var kw []string

--- a/internal/rules/loader.go
+++ b/internal/rules/loader.go
@@ -230,6 +230,36 @@ func (rl *RuleLoader) HasSemanticMatch(id string, tags []string, stage string) (
 	return false, ""
 }
 
+// HasSemanticMatchAmong checks whether any rule in the provided candidates slice is
+// semantically similar to the proposed rule. It applies the same match criteria as
+// HasSemanticMatch (shared tokens ≥ 2 AND ratio ≥ 0.5) but against a caller-supplied
+// list rather than the loader's disk snapshot. Use this to detect duplicates within a
+// synthesis batch before the loader is reloaded.
+func (rl *RuleLoader) HasSemanticMatchAmong(id string, tags []string, stage string, candidates []*Rule) (bool, string) {
+	newKW := ruleKeywords(id, tags)
+	if len(newKW) < 2 {
+		return false, ""
+	}
+	for _, r := range candidates {
+		if r.Stage != stage && r.Stage != "global" {
+			continue
+		}
+		existKW := ruleKeywords(r.ID, r.Tags)
+		if len(existKW) < 2 {
+			continue
+		}
+		shared := sharedKeywords(newKW, existKW)
+		minLen := len(newKW)
+		if len(existKW) < minLen {
+			minLen = len(existKW)
+		}
+		if shared >= 2 && float64(shared)/float64(minLen) >= 0.5 {
+			return true, r.ID
+		}
+	}
+	return false, ""
+}
+
 // IDSummaryForStage returns a compact newline-separated "id: condition" list for all rules
 // matching the given stage (and global). Used to provide deduplication context to the synthesizer.
 //

--- a/internal/rules/loader.go
+++ b/internal/rules/loader.go
@@ -208,6 +208,11 @@ func (rl *RuleLoader) HasSemanticMatch(id string, tags []string, stage string) (
 		if r.Stage != stage && r.Stage != "global" {
 			continue
 		}
+		// Exclude rules below the injection threshold: stale/decayed rules should
+		// not permanently block creation of fresh replacements.
+		if r.Confidence < MinConfidenceForInjection {
+			continue
+		}
 		existKW := ruleKeywords(r.ID, r.Tags)
 		if len(existKW) < 2 {
 			continue

--- a/internal/rules/writer.go
+++ b/internal/rules/writer.go
@@ -20,6 +20,12 @@ var fileMu sync.Mutex
 
 // WriteRule writes a Rule to a YAML file in rules/{stage}/ directory.
 func WriteRule(rulesDir string, rule *Rule) error {
+	// Defense-in-depth: reject IDs that could escape the rules/{stage} directory
+	// via path traversal (e.g. "../../../etc/passwd" or absolute paths).
+	if rule.ID == "" || strings.ContainsAny(rule.ID, "/\\") || strings.Contains(rule.ID, "..") || filepath.Base(rule.ID) != rule.ID {
+		return fmt.Errorf("unsafe rule ID %q", rule.ID)
+	}
+
 	dir := filepath.Join(rulesDir, rule.Stage)
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return fmt.Errorf("create dir %s: %w", dir, err)

--- a/prompts/synthesizer.md
+++ b/prompts/synthesizer.md
@@ -21,6 +21,20 @@ that will improve future contributions.
 - Auto-closed (no response): {{ .AutoClosedCount }}
 - Success rate: {{ .SuccessRate }}%
 
+## Existing Rule IDs (Deduplication Reference)
+
+The following rules already exist for this stage. **Before creating any new rule, verify it is not
+semantically equivalent to one of these:**
+
+{{ .ExistingRuleIDs }}
+
+**Deduplication rules (CRITICAL):**
+- If a new pattern is already covered by an existing rule (same condition, same guidance, or overlapping
+  keywords), do NOT create a new rule. Instead add the existing rule to `updated_rules` to adjust confidence.
+- Use clean confidence values for new rules: `0.5`, `0.6`, `0.7`, `0.8`, or `0.9`.
+  Never copy floating-point artifacts such as `0.5019165` from existing data.
+- Default confidence for a brand-new, unvalidated rule: `0.5`.
+
 ## Analysis Tasks
 
 ### 1. Pattern Detection


### PR DESCRIPTION
## Summary

Fixes #13 — the synthesizer was creating semantic duplicates every cycle, growing the rule set from ~10 to 169+ rules without bound.

### Root causes addressed

1. **No semantic deduplication**: `applySynthesisResult` only checked exact rule ID matches. A rule about "skip unresponsive repos" could spawn multiple variants (`skip-unresponsive-repos`, `repo-rejection-timeout`, `unresponsive-maintainers`, …) with different IDs but identical intent.

2. **Confidence contamination**: New synthesized rules inherited decayed float values from existing rules (e.g. `0.5019165`), causing them to be "born half-broken".

### Changes

| File | Change |
|---|---|
| `internal/rules/loader.go` | Add `HasSemanticMatch(id, tags, stage)` — keyword/tag overlap check (threshold: 2 shared tokens); add `IDSummaryForStage(stage)` for compact prompt injection |
| `internal/pipeline/synthesizer.go` | Skip new rules with semantic match; normalize new-rule confidence to nearest 0.1 via `normalizeNewRuleConfidence`; pass `ExistingRuleIDs` to synthesizer template |
| `prompts/synthesizer.md` | Inject `{{ .ExistingRuleIDs }}` block; require clean confidence values (default 0.5); explicit deduplication instructions |
| `cmd/auto-contributor/main.go` | Fix GO-01: handle `godotenv.Load` error instead of discarding with `_` |

### How deduplication works

```
HasSemanticMatch("skip-no-response-repos", ["scout","timeout"], "scout")
  → extractKeywords: ["skip", "response", "repos", "scout", "timeout"]
  → compare against existing rule "skip-unresponsive-repos": ["skip", "unresponsive", "repos"]
  → shared tokens: {"skip", "repos"} = 2 ≥ threshold → DUPLICATE, skip
```

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (all existing tests including `internal/rules` loader tests)
- [x] `gofmt -w .` applied