### PR TITLE
feat: trajectory replay (experience replay) for pipeline

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -114,6 +114,7 @@ func (db *DB) Migrate() error {
 	if err := db.MigrateRepoProfiles(); err != nil {
 		return err
 	}
+	db.MigrateTrajectories()
 
 	return nil
 }

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -110,11 +110,13 @@ func (db *DB) Migrate() error {
 	db.runMigrations()
 	db.MigrateLessons()
 	db.MigrateEvents()
-	// Table-level migration: propagate errors so startup fails fast on DDL failure.
+	// Table-level migrations: propagate errors so startup fails fast on DDL failure.
 	if err := db.MigrateRepoProfiles(); err != nil {
 		return err
 	}
-	db.MigrateTrajectories()
+	if err := db.MigrateTrajectories(); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/internal/db/trajectories.go
+++ b/internal/db/trajectories.go
@@ -11,9 +11,10 @@ import (
 // MigrateTrajectories creates the trajectories table for experience replay.
 // issue_id is intentionally NOT unique: multiple attempts (retries, separate PRs)
 // for the same issue are stored as separate rows so no history is overwritten.
-func (db *DB) MigrateTrajectories() {
+// Returns an error if any DDL step fails so the caller can abort startup.
+func (db *DB) MigrateTrajectories() error {
 	if db.IsPostgres() {
-		db.Exec(`
+		if _, err := db.Exec(`
 			CREATE TABLE IF NOT EXISTS trajectories (
 				id SERIAL PRIMARY KEY,
 				issue_id INTEGER NOT NULL,
@@ -32,16 +33,26 @@ func (db *DB) MigrateTrajectories() {
 				success INTEGER DEFAULT 0,
 				created_at TIMESTAMP DEFAULT NOW(),
 				updated_at TIMESTAMP DEFAULT NOW()
-			)`)
-		db.Exec(`CREATE INDEX IF NOT EXISTS idx_trajectories_issue ON trajectories(issue_id)`)
-		db.Exec(`CREATE INDEX IF NOT EXISTS idx_trajectories_outcome ON trajectories(outcome_label)`)
-		db.Exec(`CREATE INDEX IF NOT EXISTS idx_trajectories_success ON trajectories(success)`)
+			)`); err != nil {
+			return fmt.Errorf("create trajectories table: %w", err)
+		}
+		if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_trajectories_issue ON trajectories(issue_id)`); err != nil {
+			return fmt.Errorf("create idx_trajectories_issue: %w", err)
+		}
+		if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_trajectories_outcome ON trajectories(outcome_label)`); err != nil {
+			return fmt.Errorf("create idx_trajectories_outcome: %w", err)
+		}
+		if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_trajectories_success ON trajectories(success)`); err != nil {
+			return fmt.Errorf("create idx_trajectories_success: %w", err)
+		}
 		// Drop the old unique index if it exists (created by earlier schema versions).
-		db.Exec(`DROP INDEX IF EXISTS idx_trajectories_issue_unique`)
+		if _, err := db.Exec(`DROP INDEX IF EXISTS idx_trajectories_issue_unique`); err != nil {
+			return fmt.Errorf("drop idx_trajectories_issue_unique: %w", err)
+		}
 		// Add pr_number column to existing tables (idempotent: error is ignored if already present).
 		db.Exec(`ALTER TABLE trajectories ADD COLUMN IF NOT EXISTS pr_number INTEGER NOT NULL DEFAULT 0`)
 	} else {
-		db.Exec(`
+		if _, err := db.Exec(`
 			CREATE TABLE IF NOT EXISTS trajectories (
 				id INTEGER PRIMARY KEY AUTOINCREMENT,
 				issue_id INTEGER NOT NULL,
@@ -60,10 +71,18 @@ func (db *DB) MigrateTrajectories() {
 				success INTEGER DEFAULT 0,
 				created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
 				updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
-			)`)
-		db.Exec(`CREATE INDEX IF NOT EXISTS idx_trajectories_issue ON trajectories(issue_id)`)
-		db.Exec(`CREATE INDEX IF NOT EXISTS idx_trajectories_outcome ON trajectories(outcome_label)`)
-		db.Exec(`CREATE INDEX IF NOT EXISTS idx_trajectories_success ON trajectories(success)`)
+			)`); err != nil {
+			return fmt.Errorf("create trajectories table: %w", err)
+		}
+		if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_trajectories_issue ON trajectories(issue_id)`); err != nil {
+			return fmt.Errorf("create idx_trajectories_issue: %w", err)
+		}
+		if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_trajectories_outcome ON trajectories(outcome_label)`); err != nil {
+			return fmt.Errorf("create idx_trajectories_outcome: %w", err)
+		}
+		if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_trajectories_success ON trajectories(success)`); err != nil {
+			return fmt.Errorf("create idx_trajectories_success: %w", err)
+		}
 		// Drop the old named unique index if it exists (created by earlier schema versions).
 		db.Exec(`DROP INDEX IF EXISTS idx_trajectories_issue_unique`)
 		// Add pr_number column to existing SQLite tables; error is silently ignored if already present.
@@ -76,39 +95,77 @@ func (db *DB) MigrateTrajectories() {
 			`SELECT sql FROM sqlite_master WHERE type='table' AND name='trajectories'`,
 		).Scan(&oldSQL); err == nil {
 			if regexp.MustCompile(`(?i)\bissue_id\b[^,\n)]*\bUNIQUE\b`).MatchString(oldSQL) {
-				db.Exec(`CREATE TABLE IF NOT EXISTS trajectories_new (
-					id INTEGER PRIMARY KEY AUTOINCREMENT,
-					issue_id INTEGER NOT NULL,
-					pr_number INTEGER NOT NULL DEFAULT 0,
-					repo TEXT NOT NULL,
-					issue_number INTEGER NOT NULL,
-					issue_title TEXT NOT NULL,
-					issue_body TEXT,
-					keywords TEXT,
-					scout_verdict TEXT,
-					scout_approach TEXT,
-					analyst_plan TEXT,
-					review_rounds INTEGER DEFAULT 0,
-					review_summary TEXT,
-					outcome_label TEXT,
-					success INTEGER DEFAULT 0,
-					created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-					updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
-				)`)
-				db.Exec(`INSERT INTO trajectories_new
-					SELECT id, issue_id, pr_number, repo, issue_number, issue_title, issue_body,
-						keywords, scout_verdict, scout_approach, analyst_plan, review_rounds,
-						review_summary, outcome_label, success, created_at, updated_at
-					FROM trajectories`)
-				db.Exec(`DROP TABLE trajectories`)
-				db.Exec(`ALTER TABLE trajectories_new RENAME TO trajectories`)
-				// Rebuild indexes after table recreation.
-				db.Exec(`CREATE INDEX IF NOT EXISTS idx_trajectories_issue ON trajectories(issue_id)`)
-				db.Exec(`CREATE INDEX IF NOT EXISTS idx_trajectories_outcome ON trajectories(outcome_label)`)
-				db.Exec(`CREATE INDEX IF NOT EXISTS idx_trajectories_success ON trajectories(success)`)
+				if err := db.rebuildTrajectoriesTable(); err != nil {
+					return fmt.Errorf("rebuild trajectories table: %w", err)
+				}
 			}
 		}
 	}
+	return nil
+}
+
+// rebuildTrajectoriesTable recreates the trajectories table inside a transaction
+// to remove any legacy column-level UNIQUE constraint on issue_id.
+// The transaction ensures the original table is never dropped unless the data
+// copy succeeds, preventing irreversible data loss on failure.
+func (db *DB) rebuildTrajectoriesTable() error {
+	tx, err := db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin transaction: %w", err)
+	}
+	defer func() {
+		if err != nil {
+			tx.Rollback() //nolint:errcheck
+		}
+	}()
+
+	if _, err = tx.Exec(`CREATE TABLE IF NOT EXISTS trajectories_new (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		issue_id INTEGER NOT NULL,
+		pr_number INTEGER NOT NULL DEFAULT 0,
+		repo TEXT NOT NULL,
+		issue_number INTEGER NOT NULL,
+		issue_title TEXT NOT NULL,
+		issue_body TEXT,
+		keywords TEXT,
+		scout_verdict TEXT,
+		scout_approach TEXT,
+		analyst_plan TEXT,
+		review_rounds INTEGER DEFAULT 0,
+		review_summary TEXT,
+		outcome_label TEXT,
+		success INTEGER DEFAULT 0,
+		created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+		updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+	)`); err != nil {
+		return fmt.Errorf("create trajectories_new: %w", err)
+	}
+
+	if _, err = tx.Exec(`INSERT INTO trajectories_new
+		SELECT id, issue_id, pr_number, repo, issue_number, issue_title, issue_body,
+			keywords, scout_verdict, scout_approach, analyst_plan, review_rounds,
+			review_summary, outcome_label, success, created_at, updated_at
+		FROM trajectories`); err != nil {
+		return fmt.Errorf("copy trajectories data: %w", err)
+	}
+
+	if _, err = tx.Exec(`DROP TABLE trajectories`); err != nil {
+		return fmt.Errorf("drop old trajectories: %w", err)
+	}
+
+	if _, err = tx.Exec(`ALTER TABLE trajectories_new RENAME TO trajectories`); err != nil {
+		return fmt.Errorf("rename trajectories_new: %w", err)
+	}
+
+	if err = tx.Commit(); err != nil {
+		return fmt.Errorf("commit trajectories rebuild: %w", err)
+	}
+
+	// Rebuild indexes after table recreation (outside transaction; non-fatal if they already exist).
+	db.Exec(`CREATE INDEX IF NOT EXISTS idx_trajectories_issue ON trajectories(issue_id)`)
+	db.Exec(`CREATE INDEX IF NOT EXISTS idx_trajectories_outcome ON trajectories(outcome_label)`)
+	db.Exec(`CREATE INDEX IF NOT EXISTS idx_trajectories_success ON trajectories(success)`)
+	return nil
 }
 
 // SaveTrajectory inserts a new trajectory record for this attempt.

--- a/internal/db/trajectories.go
+++ b/internal/db/trajectories.go
@@ -16,6 +16,7 @@ func (db *DB) MigrateTrajectories() {
 			CREATE TABLE IF NOT EXISTS trajectories (
 				id SERIAL PRIMARY KEY,
 				issue_id INTEGER NOT NULL,
+				pr_number INTEGER NOT NULL DEFAULT 0,
 				repo TEXT NOT NULL,
 				issue_number INTEGER NOT NULL,
 				issue_title TEXT NOT NULL,
@@ -36,11 +37,14 @@ func (db *DB) MigrateTrajectories() {
 		db.Exec(`CREATE INDEX IF NOT EXISTS idx_trajectories_success ON trajectories(success)`)
 		// Drop the old unique index if it exists (created by earlier schema versions).
 		db.Exec(`DROP INDEX IF EXISTS idx_trajectories_issue_unique`)
+		// Add pr_number column to existing tables (idempotent: error is ignored if already present).
+		db.Exec(`ALTER TABLE trajectories ADD COLUMN IF NOT EXISTS pr_number INTEGER NOT NULL DEFAULT 0`)
 	} else {
 		db.Exec(`
 			CREATE TABLE IF NOT EXISTS trajectories (
 				id INTEGER PRIMARY KEY AUTOINCREMENT,
 				issue_id INTEGER NOT NULL,
+				pr_number INTEGER NOT NULL DEFAULT 0,
 				repo TEXT NOT NULL,
 				issue_number INTEGER NOT NULL,
 				issue_title TEXT NOT NULL,
@@ -59,6 +63,8 @@ func (db *DB) MigrateTrajectories() {
 		db.Exec(`CREATE INDEX IF NOT EXISTS idx_trajectories_issue ON trajectories(issue_id)`)
 		db.Exec(`CREATE INDEX IF NOT EXISTS idx_trajectories_outcome ON trajectories(outcome_label)`)
 		db.Exec(`CREATE INDEX IF NOT EXISTS idx_trajectories_success ON trajectories(success)`)
+		// Add pr_number column to existing SQLite tables; error is silently ignored if already present.
+		db.Exec(`ALTER TABLE trajectories ADD COLUMN pr_number INTEGER NOT NULL DEFAULT 0`)
 	}
 }
 
@@ -75,12 +81,12 @@ func (db *DB) SaveTrajectory(t *models.Trajectory) error {
 	if db.IsPostgres() {
 		query := `
 			INSERT INTO trajectories
-				(issue_id, repo, issue_number, issue_title, issue_body, keywords,
+				(issue_id, pr_number, repo, issue_number, issue_title, issue_body, keywords,
 				 scout_verdict, scout_approach, analyst_plan, review_rounds,
 				 review_summary, outcome_label, success, created_at, updated_at)
-			VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)`
+			VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16)`
 		_, err := db.Exec(query,
-			t.IssueID, t.Repo, t.IssueNumber, t.IssueTitle, t.IssueBody,
+			t.IssueID, t.PRNumber, t.Repo, t.IssueNumber, t.IssueTitle, t.IssueBody,
 			t.Keywords, t.ScoutVerdict, t.ScoutApproach, t.AnalystPlan,
 			t.ReviewRounds, t.ReviewSummary, t.OutcomeLabel, successInt, now, now,
 		)
@@ -89,45 +95,49 @@ func (db *DB) SaveTrajectory(t *models.Trajectory) error {
 
 	query := `
 		INSERT INTO trajectories
-			(issue_id, repo, issue_number, issue_title, issue_body, keywords,
+			(issue_id, pr_number, repo, issue_number, issue_title, issue_body, keywords,
 			 scout_verdict, scout_approach, analyst_plan, review_rounds,
 			 review_summary, outcome_label, success, created_at, updated_at)
-		VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`
+		VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`
 	_, err := db.Exec(query,
-		t.IssueID, t.Repo, t.IssueNumber, t.IssueTitle, t.IssueBody,
+		t.IssueID, t.PRNumber, t.Repo, t.IssueNumber, t.IssueTitle, t.IssueBody,
 		t.Keywords, t.ScoutVerdict, t.ScoutApproach, t.AnalystPlan,
 		t.ReviewRounds, t.ReviewSummary, t.OutcomeLabel, successInt, now, now,
 	)
 	return err
 }
 
-// UpdateTrajectoryOutcome sets the outcome label and success flag on the most recent
-// trajectory row for the given issue. Targeting the latest row avoids a race between
-// concurrent PR closures for the same issue overwriting each other's outcome.
-func (db *DB) UpdateTrajectoryOutcome(issueID int64, outcomeLabel string, success bool) error {
+// UpdateTrajectoryOutcome sets the outcome label and success flag on the trajectory row
+// that matches both issueID and prNumber. When prNumber > 0 the update is scoped to
+// the exact PR, preventing an older PR closure from overwriting a newer trajectory's outcome.
+// When prNumber == 0 (no PR was created) we fall back to the most-recent row for the issue.
+func (db *DB) UpdateTrajectoryOutcome(issueID int64, prNumber int, outcomeLabel string, success bool) error {
 	successInt := 0
 	if success {
 		successInt = 1
 	}
+	now := time.Now()
 	var query string
-	if db.IsPostgres() {
-		query = `
-			UPDATE trajectories
-			SET outcome_label = $1, success = $2, updated_at = $3
-			WHERE id = (
-				SELECT id FROM trajectories WHERE issue_id = $4
-				ORDER BY created_at DESC LIMIT 1
-			)`
-	} else {
-		query = `
-			UPDATE trajectories
-			SET outcome_label = ?, success = ?, updated_at = ?
-			WHERE id = (
-				SELECT id FROM trajectories WHERE issue_id = ?
-				ORDER BY created_at DESC LIMIT 1
-			)`
+	if prNumber > 0 {
+		if db.IsPostgres() {
+			query = `UPDATE trajectories SET outcome_label = $1, success = $2, updated_at = $3
+				WHERE issue_id = $4 AND pr_number = $5`
+		} else {
+			query = `UPDATE trajectories SET outcome_label = ?, success = ?, updated_at = ?
+				WHERE issue_id = ? AND pr_number = ?`
+		}
+		_, err := db.Exec(query, outcomeLabel, successInt, now, issueID, prNumber)
+		return err
 	}
-	_, err := db.Exec(query, outcomeLabel, successInt, time.Now(), issueID)
+	// Fallback: no PR number available — update the most-recent row for this issue.
+	if db.IsPostgres() {
+		query = `UPDATE trajectories SET outcome_label = $1, success = $2, updated_at = $3
+			WHERE id = (SELECT id FROM trajectories WHERE issue_id = $4 ORDER BY created_at DESC LIMIT 1)`
+	} else {
+		query = `UPDATE trajectories SET outcome_label = ?, success = ?, updated_at = ?
+			WHERE id = (SELECT id FROM trajectories WHERE issue_id = ? ORDER BY created_at DESC LIMIT 1)`
+	}
+	_, err := db.Exec(query, outcomeLabel, successInt, now, issueID)
 	return err
 }
 

--- a/internal/db/trajectories.go
+++ b/internal/db/trajectories.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"fmt"
+	"regexp"
 	"time"
 
 	"github.com/majiayu000/auto-contributor/pkg/models"
@@ -63,10 +64,50 @@ func (db *DB) MigrateTrajectories() {
 		db.Exec(`CREATE INDEX IF NOT EXISTS idx_trajectories_issue ON trajectories(issue_id)`)
 		db.Exec(`CREATE INDEX IF NOT EXISTS idx_trajectories_outcome ON trajectories(outcome_label)`)
 		db.Exec(`CREATE INDEX IF NOT EXISTS idx_trajectories_success ON trajectories(success)`)
-		// Drop the old unique index if it exists (created by earlier schema versions).
+		// Drop the old named unique index if it exists (created by earlier schema versions).
 		db.Exec(`DROP INDEX IF EXISTS idx_trajectories_issue_unique`)
 		// Add pr_number column to existing SQLite tables; error is silently ignored if already present.
 		db.Exec(`ALTER TABLE trajectories ADD COLUMN pr_number INTEGER NOT NULL DEFAULT 0`)
+		// Fix inline `issue_id UNIQUE` constraint from older schema versions.
+		// SQLite cannot remove a column-level constraint via ALTER TABLE; the table must be recreated.
+		// We first ensure pr_number exists (above), then check the stored DDL and recreate if needed.
+		var oldSQL string
+		if err := db.QueryRow(
+			`SELECT sql FROM sqlite_master WHERE type='table' AND name='trajectories'`,
+		).Scan(&oldSQL); err == nil {
+			if regexp.MustCompile(`(?i)\bissue_id\b[^,\n)]*\bUNIQUE\b`).MatchString(oldSQL) {
+				db.Exec(`CREATE TABLE IF NOT EXISTS trajectories_new (
+					id INTEGER PRIMARY KEY AUTOINCREMENT,
+					issue_id INTEGER NOT NULL,
+					pr_number INTEGER NOT NULL DEFAULT 0,
+					repo TEXT NOT NULL,
+					issue_number INTEGER NOT NULL,
+					issue_title TEXT NOT NULL,
+					issue_body TEXT,
+					keywords TEXT,
+					scout_verdict TEXT,
+					scout_approach TEXT,
+					analyst_plan TEXT,
+					review_rounds INTEGER DEFAULT 0,
+					review_summary TEXT,
+					outcome_label TEXT,
+					success INTEGER DEFAULT 0,
+					created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+					updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+				)`)
+				db.Exec(`INSERT INTO trajectories_new
+					SELECT id, issue_id, pr_number, repo, issue_number, issue_title, issue_body,
+						keywords, scout_verdict, scout_approach, analyst_plan, review_rounds,
+						review_summary, outcome_label, success, created_at, updated_at
+					FROM trajectories`)
+				db.Exec(`DROP TABLE trajectories`)
+				db.Exec(`ALTER TABLE trajectories_new RENAME TO trajectories`)
+				// Rebuild indexes after table recreation.
+				db.Exec(`CREATE INDEX IF NOT EXISTS idx_trajectories_issue ON trajectories(issue_id)`)
+				db.Exec(`CREATE INDEX IF NOT EXISTS idx_trajectories_outcome ON trajectories(outcome_label)`)
+				db.Exec(`CREATE INDEX IF NOT EXISTS idx_trajectories_success ON trajectories(success)`)
+			}
+		}
 	}
 }
 

--- a/internal/db/trajectories.go
+++ b/internal/db/trajectories.go
@@ -63,6 +63,8 @@ func (db *DB) MigrateTrajectories() {
 		db.Exec(`CREATE INDEX IF NOT EXISTS idx_trajectories_issue ON trajectories(issue_id)`)
 		db.Exec(`CREATE INDEX IF NOT EXISTS idx_trajectories_outcome ON trajectories(outcome_label)`)
 		db.Exec(`CREATE INDEX IF NOT EXISTS idx_trajectories_success ON trajectories(success)`)
+		// Drop the old unique index if it exists (created by earlier schema versions).
+		db.Exec(`DROP INDEX IF EXISTS idx_trajectories_issue_unique`)
 		// Add pr_number column to existing SQLite tables; error is silently ignored if already present.
 		db.Exec(`ALTER TABLE trajectories ADD COLUMN pr_number INTEGER NOT NULL DEFAULT 0`)
 	}

--- a/internal/db/trajectories.go
+++ b/internal/db/trajectories.go
@@ -8,6 +8,8 @@ import (
 )
 
 // MigrateTrajectories creates the trajectories table for experience replay.
+// issue_id is intentionally NOT unique: multiple attempts (retries, separate PRs)
+// for the same issue are stored as separate rows so no history is overwritten.
 func (db *DB) MigrateTrajectories() {
 	if db.IsPostgres() {
 		db.Exec(`
@@ -32,12 +34,13 @@ func (db *DB) MigrateTrajectories() {
 		db.Exec(`CREATE INDEX IF NOT EXISTS idx_trajectories_issue ON trajectories(issue_id)`)
 		db.Exec(`CREATE INDEX IF NOT EXISTS idx_trajectories_outcome ON trajectories(outcome_label)`)
 		db.Exec(`CREATE INDEX IF NOT EXISTS idx_trajectories_success ON trajectories(success)`)
-		db.Exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_trajectories_issue_unique ON trajectories(issue_id)`)
+		// Drop the old unique index if it exists (created by earlier schema versions).
+		db.Exec(`DROP INDEX IF EXISTS idx_trajectories_issue_unique`)
 	} else {
 		db.Exec(`
 			CREATE TABLE IF NOT EXISTS trajectories (
 				id INTEGER PRIMARY KEY AUTOINCREMENT,
-				issue_id INTEGER NOT NULL UNIQUE,
+				issue_id INTEGER NOT NULL,
 				repo TEXT NOT NULL,
 				issue_number INTEGER NOT NULL,
 				issue_title TEXT NOT NULL,
@@ -53,12 +56,15 @@ func (db *DB) MigrateTrajectories() {
 				created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
 				updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
 			)`)
+		db.Exec(`CREATE INDEX IF NOT EXISTS idx_trajectories_issue ON trajectories(issue_id)`)
 		db.Exec(`CREATE INDEX IF NOT EXISTS idx_trajectories_outcome ON trajectories(outcome_label)`)
 		db.Exec(`CREATE INDEX IF NOT EXISTS idx_trajectories_success ON trajectories(success)`)
 	}
 }
 
-// SaveTrajectory inserts or replaces a trajectory record.
+// SaveTrajectory inserts a new trajectory record for this attempt.
+// Each call always creates a new row so that retries and multiple PR attempts
+// for the same issue are preserved independently (no overwrite).
 func (db *DB) SaveTrajectory(t *models.Trajectory) error {
 	successInt := 0
 	if t.Success {
@@ -72,17 +78,7 @@ func (db *DB) SaveTrajectory(t *models.Trajectory) error {
 				(issue_id, repo, issue_number, issue_title, issue_body, keywords,
 				 scout_verdict, scout_approach, analyst_plan, review_rounds,
 				 review_summary, outcome_label, success, created_at, updated_at)
-			VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)
-			ON CONFLICT (issue_id) DO UPDATE SET
-				keywords = EXCLUDED.keywords,
-				scout_verdict = EXCLUDED.scout_verdict,
-				scout_approach = EXCLUDED.scout_approach,
-				analyst_plan = EXCLUDED.analyst_plan,
-				review_rounds = EXCLUDED.review_rounds,
-				review_summary = EXCLUDED.review_summary,
-				outcome_label = EXCLUDED.outcome_label,
-				success = EXCLUDED.success,
-				updated_at = EXCLUDED.updated_at`
+			VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)`
 		_, err := db.Exec(query,
 			t.IssueID, t.Repo, t.IssueNumber, t.IssueTitle, t.IssueBody,
 			t.Keywords, t.ScoutVerdict, t.ScoutApproach, t.AnalystPlan,
@@ -91,9 +87,8 @@ func (db *DB) SaveTrajectory(t *models.Trajectory) error {
 		return err
 	}
 
-	// SQLite: use INSERT OR REPLACE
 	query := `
-		INSERT OR REPLACE INTO trajectories
+		INSERT INTO trajectories
 			(issue_id, repo, issue_number, issue_title, issue_body, keywords,
 			 scout_verdict, scout_approach, analyst_plan, review_rounds,
 			 review_summary, outcome_label, success, created_at, updated_at)
@@ -106,18 +101,32 @@ func (db *DB) SaveTrajectory(t *models.Trajectory) error {
 	return err
 }
 
-// UpdateTrajectoryOutcome sets the outcome label and success flag for a trajectory.
+// UpdateTrajectoryOutcome sets the outcome label and success flag on the most recent
+// trajectory row for the given issue. Targeting the latest row avoids a race between
+// concurrent PR closures for the same issue overwriting each other's outcome.
 func (db *DB) UpdateTrajectoryOutcome(issueID int64, outcomeLabel string, success bool) error {
 	successInt := 0
 	if success {
 		successInt = 1
 	}
-	query := fmt.Sprintf(`
-		UPDATE trajectories
-		SET outcome_label = %s, success = %s, updated_at = %s
-		WHERE issue_id = %s`,
-		db.placeholder(1), db.placeholder(2), db.placeholder(3), db.placeholder(4),
-	)
+	var query string
+	if db.IsPostgres() {
+		query = `
+			UPDATE trajectories
+			SET outcome_label = $1, success = $2, updated_at = $3
+			WHERE id = (
+				SELECT id FROM trajectories WHERE issue_id = $4
+				ORDER BY created_at DESC LIMIT 1
+			)`
+	} else {
+		query = `
+			UPDATE trajectories
+			SET outcome_label = ?, success = ?, updated_at = ?
+			WHERE id = (
+				SELECT id FROM trajectories WHERE issue_id = ?
+				ORDER BY created_at DESC LIMIT 1
+			)`
+	}
 	_, err := db.Exec(query, outcomeLabel, successInt, time.Now(), issueID)
 	return err
 }
@@ -166,6 +175,7 @@ func (db *DB) GetRecentTrajectories(limit int) ([]*models.Trajectory, error) {
 func scanTrajectories(rows interface {
 	Next() bool
 	Scan(...any) error
+	Err() error
 }) ([]*models.Trajectory, error) {
 	var trajectories []*models.Trajectory
 	for rows.Next() {
@@ -182,6 +192,9 @@ func scanTrajectories(rows interface {
 		}
 		t.Success = successInt != 0
 		trajectories = append(trajectories, t)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
 	return trajectories, nil
 }

--- a/internal/db/trajectories.go
+++ b/internal/db/trajectories.go
@@ -1,0 +1,187 @@
+package db
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/majiayu000/auto-contributor/pkg/models"
+)
+
+// MigrateTrajectories creates the trajectories table for experience replay.
+func (db *DB) MigrateTrajectories() {
+	if db.IsPostgres() {
+		db.Exec(`
+			CREATE TABLE IF NOT EXISTS trajectories (
+				id SERIAL PRIMARY KEY,
+				issue_id INTEGER NOT NULL,
+				repo TEXT NOT NULL,
+				issue_number INTEGER NOT NULL,
+				issue_title TEXT NOT NULL,
+				issue_body TEXT,
+				keywords TEXT,
+				scout_verdict TEXT,
+				scout_approach TEXT,
+				analyst_plan TEXT,
+				review_rounds INTEGER DEFAULT 0,
+				review_summary TEXT,
+				outcome_label TEXT,
+				success INTEGER DEFAULT 0,
+				created_at TIMESTAMP DEFAULT NOW(),
+				updated_at TIMESTAMP DEFAULT NOW()
+			)`)
+		db.Exec(`CREATE INDEX IF NOT EXISTS idx_trajectories_issue ON trajectories(issue_id)`)
+		db.Exec(`CREATE INDEX IF NOT EXISTS idx_trajectories_outcome ON trajectories(outcome_label)`)
+		db.Exec(`CREATE INDEX IF NOT EXISTS idx_trajectories_success ON trajectories(success)`)
+		db.Exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_trajectories_issue_unique ON trajectories(issue_id)`)
+	} else {
+		db.Exec(`
+			CREATE TABLE IF NOT EXISTS trajectories (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				issue_id INTEGER NOT NULL UNIQUE,
+				repo TEXT NOT NULL,
+				issue_number INTEGER NOT NULL,
+				issue_title TEXT NOT NULL,
+				issue_body TEXT,
+				keywords TEXT,
+				scout_verdict TEXT,
+				scout_approach TEXT,
+				analyst_plan TEXT,
+				review_rounds INTEGER DEFAULT 0,
+				review_summary TEXT,
+				outcome_label TEXT,
+				success INTEGER DEFAULT 0,
+				created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+				updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+			)`)
+		db.Exec(`CREATE INDEX IF NOT EXISTS idx_trajectories_outcome ON trajectories(outcome_label)`)
+		db.Exec(`CREATE INDEX IF NOT EXISTS idx_trajectories_success ON trajectories(success)`)
+	}
+}
+
+// SaveTrajectory inserts or replaces a trajectory record.
+func (db *DB) SaveTrajectory(t *models.Trajectory) error {
+	successInt := 0
+	if t.Success {
+		successInt = 1
+	}
+	now := time.Now()
+
+	if db.IsPostgres() {
+		query := `
+			INSERT INTO trajectories
+				(issue_id, repo, issue_number, issue_title, issue_body, keywords,
+				 scout_verdict, scout_approach, analyst_plan, review_rounds,
+				 review_summary, outcome_label, success, created_at, updated_at)
+			VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)
+			ON CONFLICT (issue_id) DO UPDATE SET
+				keywords = EXCLUDED.keywords,
+				scout_verdict = EXCLUDED.scout_verdict,
+				scout_approach = EXCLUDED.scout_approach,
+				analyst_plan = EXCLUDED.analyst_plan,
+				review_rounds = EXCLUDED.review_rounds,
+				review_summary = EXCLUDED.review_summary,
+				outcome_label = EXCLUDED.outcome_label,
+				success = EXCLUDED.success,
+				updated_at = EXCLUDED.updated_at`
+		_, err := db.Exec(query,
+			t.IssueID, t.Repo, t.IssueNumber, t.IssueTitle, t.IssueBody,
+			t.Keywords, t.ScoutVerdict, t.ScoutApproach, t.AnalystPlan,
+			t.ReviewRounds, t.ReviewSummary, t.OutcomeLabel, successInt, now, now,
+		)
+		return err
+	}
+
+	// SQLite: use INSERT OR REPLACE
+	query := `
+		INSERT OR REPLACE INTO trajectories
+			(issue_id, repo, issue_number, issue_title, issue_body, keywords,
+			 scout_verdict, scout_approach, analyst_plan, review_rounds,
+			 review_summary, outcome_label, success, created_at, updated_at)
+		VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`
+	_, err := db.Exec(query,
+		t.IssueID, t.Repo, t.IssueNumber, t.IssueTitle, t.IssueBody,
+		t.Keywords, t.ScoutVerdict, t.ScoutApproach, t.AnalystPlan,
+		t.ReviewRounds, t.ReviewSummary, t.OutcomeLabel, successInt, now, now,
+	)
+	return err
+}
+
+// UpdateTrajectoryOutcome sets the outcome label and success flag for a trajectory.
+func (db *DB) UpdateTrajectoryOutcome(issueID int64, outcomeLabel string, success bool) error {
+	successInt := 0
+	if success {
+		successInt = 1
+	}
+	query := fmt.Sprintf(`
+		UPDATE trajectories
+		SET outcome_label = %s, success = %s, updated_at = %s
+		WHERE issue_id = %s`,
+		db.placeholder(1), db.placeholder(2), db.placeholder(3), db.placeholder(4),
+	)
+	_, err := db.Exec(query, outcomeLabel, successInt, time.Now(), issueID)
+	return err
+}
+
+// GetSuccessfulTrajectories returns recent successful trajectories for experience replay.
+func (db *DB) GetSuccessfulTrajectories(limit int) ([]*models.Trajectory, error) {
+	query := fmt.Sprintf(`
+		SELECT id, issue_id, repo, issue_number, issue_title, issue_body,
+			COALESCE(keywords,''), COALESCE(scout_verdict,''), COALESCE(scout_approach,''),
+			COALESCE(analyst_plan,''), review_rounds, COALESCE(review_summary,''),
+			COALESCE(outcome_label,''), success, created_at, updated_at
+		FROM trajectories
+		WHERE success = 1
+		ORDER BY updated_at DESC
+		LIMIT %s`,
+		db.placeholder(1),
+	)
+	rows, err := db.Query(query, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanTrajectories(rows)
+}
+
+// GetRecentTrajectories returns recent trajectories regardless of outcome.
+func (db *DB) GetRecentTrajectories(limit int) ([]*models.Trajectory, error) {
+	query := fmt.Sprintf(`
+		SELECT id, issue_id, repo, issue_number, issue_title, issue_body,
+			COALESCE(keywords,''), COALESCE(scout_verdict,''), COALESCE(scout_approach,''),
+			COALESCE(analyst_plan,''), review_rounds, COALESCE(review_summary,''),
+			COALESCE(outcome_label,''), success, created_at, updated_at
+		FROM trajectories
+		ORDER BY updated_at DESC
+		LIMIT %s`,
+		db.placeholder(1),
+	)
+	rows, err := db.Query(query, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanTrajectories(rows)
+}
+
+func scanTrajectories(rows interface {
+	Next() bool
+	Scan(...any) error
+}) ([]*models.Trajectory, error) {
+	var trajectories []*models.Trajectory
+	for rows.Next() {
+		t := &models.Trajectory{}
+		var successInt int
+		err := rows.Scan(
+			&t.ID, &t.IssueID, &t.Repo, &t.IssueNumber, &t.IssueTitle, &t.IssueBody,
+			&t.Keywords, &t.ScoutVerdict, &t.ScoutApproach, &t.AnalystPlan,
+			&t.ReviewRounds, &t.ReviewSummary, &t.OutcomeLabel, &successInt,
+			&t.CreatedAt, &t.UpdatedAt,
+		)
+		if err != nil {
+			return nil, err
+		}
+		t.Success = successInt != 0
+		trajectories = append(trajectories, t)
+	}
+	return trajectories, nil
+}

--- a/internal/db/trajectories.go
+++ b/internal/db/trajectories.go
@@ -3,6 +3,7 @@ package db
 import (
 	"fmt"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/majiayu000/auto-contributor/pkg/models"
@@ -49,8 +50,10 @@ func (db *DB) MigrateTrajectories() error {
 		if _, err := db.Exec(`DROP INDEX IF EXISTS idx_trajectories_issue_unique`); err != nil {
 			return fmt.Errorf("drop idx_trajectories_issue_unique: %w", err)
 		}
-		// Add pr_number column to existing tables (idempotent: error is ignored if already present).
-		db.Exec(`ALTER TABLE trajectories ADD COLUMN IF NOT EXISTS pr_number INTEGER NOT NULL DEFAULT 0`)
+		// Add pr_number column to existing tables; IF NOT EXISTS makes this idempotent.
+		if _, err := db.Exec(`ALTER TABLE trajectories ADD COLUMN IF NOT EXISTS pr_number INTEGER NOT NULL DEFAULT 0`); err != nil {
+			return fmt.Errorf("add pr_number column: %w", err)
+		}
 	} else {
 		if _, err := db.Exec(`
 			CREATE TABLE IF NOT EXISTS trajectories (
@@ -85,8 +88,12 @@ func (db *DB) MigrateTrajectories() error {
 		}
 		// Drop the old named unique index if it exists (created by earlier schema versions).
 		db.Exec(`DROP INDEX IF EXISTS idx_trajectories_issue_unique`)
-		// Add pr_number column to existing SQLite tables; error is silently ignored if already present.
-		db.Exec(`ALTER TABLE trajectories ADD COLUMN pr_number INTEGER NOT NULL DEFAULT 0`)
+		// Add pr_number column to existing SQLite tables; "duplicate column name" means already present.
+		if _, err := db.Exec(`ALTER TABLE trajectories ADD COLUMN pr_number INTEGER NOT NULL DEFAULT 0`); err != nil {
+			if !strings.Contains(err.Error(), "duplicate column name") {
+				return fmt.Errorf("add pr_number column: %w", err)
+			}
+		}
 		// Fix inline `issue_id UNIQUE` constraint from older schema versions.
 		// SQLite cannot remove a column-level constraint via ALTER TABLE; the table must be recreated.
 		// We first ensure pr_number exists (above), then check the stored DDL and recreate if needed.
@@ -226,8 +233,18 @@ func (db *DB) UpdateTrajectoryOutcome(issueID int64, prNumber int, outcomeLabel 
 			query = `UPDATE trajectories SET outcome_label = ?, success = ?, updated_at = ?
 				WHERE issue_id = ? AND pr_number = ?`
 		}
-		_, err := db.Exec(query, outcomeLabel, successInt, now, issueID, prNumber)
-		return err
+		result, err := db.Exec(query, outcomeLabel, successInt, now, issueID, prNumber)
+		if err != nil {
+			return err
+		}
+		n, err := result.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("rows affected: %w", err)
+		}
+		if n == 0 {
+			return fmt.Errorf("no trajectory row found for issue_id=%d pr_number=%d", issueID, prNumber)
+		}
+		return nil
 	}
 	// Fallback: no PR number available — update the most-recent row for this issue.
 	if db.IsPostgres() {
@@ -237,8 +254,18 @@ func (db *DB) UpdateTrajectoryOutcome(issueID int64, prNumber int, outcomeLabel 
 		query = `UPDATE trajectories SET outcome_label = ?, success = ?, updated_at = ?
 			WHERE id = (SELECT id FROM trajectories WHERE issue_id = ? ORDER BY created_at DESC LIMIT 1)`
 	}
-	_, err := db.Exec(query, outcomeLabel, successInt, now, issueID)
-	return err
+	result, err := db.Exec(query, outcomeLabel, successInt, now, issueID)
+	if err != nil {
+		return err
+	}
+	n, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("rows affected: %w", err)
+	}
+	if n == 0 {
+		return fmt.Errorf("no trajectory row found for issue_id=%d", issueID)
+	}
+	return nil
 }
 
 // GetSuccessfulTrajectories returns recent successful trajectories for experience replay.

--- a/internal/pipeline/agents.go
+++ b/internal/pipeline/agents.go
@@ -100,6 +100,11 @@ func (p *Pipeline) buildEngineerCtx(issue *models.Issue, analyst *AnalystResult,
 		ctx["PastLessons"] = formatLessonsForPrompt(lessons)
 	}
 
+	// Inject similar successful trajectories as few-shot examples
+	if trajs := p.getSimilarTrajectories(issue, 3); len(trajs) > 0 {
+		ctx["SimilarTrajectories"] = formatTrajectoriesForPrompt(trajs)
+	}
+
 	ctx["Rules"] = p.ruleLoader.FormatForPrompt("engineer")
 	return ctx
 }
@@ -169,8 +174,10 @@ func (p *Pipeline) runSubmitter(ctx context.Context, issue *models.Issue, worksp
 
 // --- Engineer ⇄ Reviewer loop ---
 
-func (p *Pipeline) engineerReviewLoop(ctx context.Context, issue *models.Issue, workspace string, analyst *AnalystResult) error {
+// engineerReviewLoopWithStats runs the engineer/reviewer loop and returns (rounds completed, last review summary, error).
+func (p *Pipeline) engineerReviewLoopWithStats(ctx context.Context, issue *models.Issue, workspace string, analyst *AnalystResult) (int, string, error) {
 	var lastReview *CodeReviewResult
+	lastSummary := ""
 
 	for round := 1; round <= p.maxReview; round++ {
 		// Engineer
@@ -184,7 +191,7 @@ func (p *Pipeline) engineerReviewLoop(ctx context.Context, issue *models.Issue, 
 		if err != nil {
 			p.recordEvent(issue, nil, "engineer", round, engStart, "", false, "", err.Error())
 			p.markFailed(issue, "engineer_failed", err.Error())
-			return err
+			return round, lastSummary, err
 		}
 
 		fixComplete := containsMarker(raw, "FIX_COMPLETE")
@@ -209,8 +216,9 @@ func (p *Pipeline) engineerReviewLoop(ctx context.Context, issue *models.Issue, 
 			log.WithError(err).Warn("reviewer parse error, treating as approve")
 			review.Verdict = "approve"
 		}
-		reviewSummary, _ := json.Marshal(map[string]any{"verdict": review.Verdict, "confidence": review.Confidence, "issues": len(review.IssuesFound)})
-		p.recordEvent(issue, nil, "reviewer", round, revStart, review.Verdict, review.Verdict == "approve", string(reviewSummary), "")
+		reviewSummaryJSON, _ := json.Marshal(map[string]any{"verdict": review.Verdict, "confidence": review.Confidence, "issues": len(review.IssuesFound)})
+		lastSummary = review.Summary
+		p.recordEvent(issue, nil, "reviewer", round, revStart, review.Verdict, review.Verdict == "approve", string(reviewSummaryJSON), "")
 
 		p.logReview(issue, &review, round)
 
@@ -220,7 +228,7 @@ func (p *Pipeline) engineerReviewLoop(ctx context.Context, issue *models.Issue, 
 				"issue": issue.IssueNumber,
 				"round": round,
 			}).Info("review approved")
-			return nil
+			return round, lastSummary, nil
 		}
 
 		// Rework needed
@@ -231,7 +239,7 @@ func (p *Pipeline) engineerReviewLoop(ctx context.Context, issue *models.Issue, 
 
 		if round == p.maxReview {
 			p.markAbandoned(issue, fmt.Sprintf("max review rounds (%d) exceeded", p.maxReview))
-			return fmt.Errorf("max review rounds exceeded for %s#%d", issue.Repo, issue.IssueNumber)
+			return round, lastSummary, fmt.Errorf("max review rounds exceeded for %s#%d", issue.Repo, issue.IssueNumber)
 		}
 
 		log.WithFields(Fields{
@@ -241,5 +249,5 @@ func (p *Pipeline) engineerReviewLoop(ctx context.Context, issue *models.Issue, 
 		}).Info("rework required")
 	}
 
-	return nil
+	return p.maxReview, lastSummary, nil
 }

--- a/internal/pipeline/lessons.go
+++ b/internal/pipeline/lessons.go
@@ -236,7 +236,7 @@ func (p *Pipeline) extractAndStoreLessons(ctx context.Context, pr *models.PullRe
 
 	// Update trajectory outcome so experience replay knows which trajectories succeeded
 	success := label == OutcomeMerged
-	if err := p.db.UpdateTrajectoryOutcome(pr.IssueID, label, success); err != nil {
+	if err := p.db.UpdateTrajectoryOutcome(pr.IssueID, pr.PRNumber, label, success); err != nil {
 		log.WithFields(Fields{"error": err, "pr": pr.PRURL}).Warn("failed to update trajectory outcome")
 	}
 }

--- a/internal/pipeline/lessons.go
+++ b/internal/pipeline/lessons.go
@@ -233,6 +233,12 @@ func (p *Pipeline) extractAndStoreLessons(ctx context.Context, pr *models.PullRe
 	if label == OutcomeMerged {
 		p.stampRuleValidation(pr)
 	}
+
+	// Update trajectory outcome so experience replay knows which trajectories succeeded
+	success := label == OutcomeMerged
+	if err := p.db.UpdateTrajectoryOutcome(pr.IssueID, label, success); err != nil {
+		log.WithFields(Fields{"error": err, "pr": pr.PRURL}).Warn("failed to update trajectory outcome")
+	}
 }
 
 // stampRuleValidation sets last_validated_at on all synthesized rules for the pipeline

--- a/internal/pipeline/lessons.go
+++ b/internal/pipeline/lessons.go
@@ -179,53 +179,20 @@ func isBot(author string) bool {
 // extractAndStoreLessons fetches reviews/comments for a PR and stores lessons in DB.
 // Called when a PR reaches terminal state (merged/closed) so we learn from the feedback.
 func (p *Pipeline) extractAndStoreLessons(ctx context.Context, pr *models.PullRequest, prRepo string, prInfo *ghclient.PRInfo) {
-	// Issue-level comments are needed for both lesson extraction and outcome
-	// classification, so fetch them unconditionally before any guard.
+	// Fetch issue-level comments first: needed for both outcome classification and lesson extraction.
 	issueComments, _ := p.gh.GetPRIssueComments(ctx, prRepo, pr.PRNumber)
 
-	// Only extract lessons when none have been stored for this PR. Do NOT return
-	// early here — outcome labeling and merge-stamping must always run so that a
-	// PR first seen as CLOSED still gets its rules stamped when later merged.
-	count, _ := p.db.CountLessonsByPR(pr.ID)
-	if count == 0 {
-		// Get inline review comments
-		comments, err := p.gh.GetPRReviewComments(ctx, prRepo, pr.PRNumber)
-		if err != nil {
-			log.WithError(err).WithField("pr", pr.PRURL).Warn("failed to fetch comments for lesson extraction")
-			comments = nil
-		}
-
-		lessons := extractLessons(pr, prRepo, prInfo.Reviews, comments)
-
-		// Also extract from issue comments when PR was closed without merge
-		if prInfo.State == "CLOSED" {
-			lessons = append(lessons, extractLessonsFromIssueComments(pr, prRepo, issueComments)...)
-		}
-
-		saved := 0
-		for _, l := range lessons {
-			if err := p.db.SaveReviewLesson(l); err != nil {
-				log.WithError(err).Warn("failed to save review lesson")
-				continue
-			}
-			saved++
-		}
-
-		if saved > 0 {
-			log.WithFields(Fields{
-				"pr":      pr.PRURL,
-				"lessons": saved,
-			}).Info("extracted review lessons")
-		}
-	}
-
-	// Label all pipeline events for this PR/issue with the outcome.
-	// Always runs regardless of whether lessons were already extracted.
+	// Always update outcome and label events unconditionally — a transient DB error on a prior
+	// call must not permanently stall outcome tracking even when lessons were already saved.
 	label := ClassifyOutcome(prInfo, issueComments, pr)
 	if err := p.db.LabelEventsByIssue(pr.IssueID, label); err != nil {
 		log.WithFields(Fields{"error": err}).Warn("failed to label pipeline events")
 	} else {
 		log.WithFields(Fields{"pr": pr.PRURL, "outcome": label}).Info("labeled pipeline events")
+	}
+	success := label == OutcomeMerged
+	if err := p.db.UpdateTrajectoryOutcome(pr.IssueID, pr.PRNumber, label, success); err != nil {
+		log.WithFields(Fields{"error": err, "pr": pr.PRURL}).Warn("failed to update trajectory outcome")
 	}
 
 	// Stamp last_validated_at on synthesized rules when a PR merges.
@@ -234,10 +201,40 @@ func (p *Pipeline) extractAndStoreLessons(ctx context.Context, pr *models.PullRe
 		p.stampRuleValidation(pr)
 	}
 
-	// Update trajectory outcome so experience replay knows which trajectories succeeded
-	success := label == OutcomeMerged
-	if err := p.db.UpdateTrajectoryOutcome(pr.IssueID, pr.PRNumber, label, success); err != nil {
-		log.WithFields(Fields{"error": err, "pr": pr.PRURL}).Warn("failed to update trajectory outcome")
+	// Skip lesson extraction if we already have lessons for this PR.
+	count, _ := p.db.CountLessonsByPR(pr.ID)
+	if count > 0 {
+		return
+	}
+
+	// Get inline review comments
+	comments, err := p.gh.GetPRReviewComments(ctx, prRepo, pr.PRNumber)
+	if err != nil {
+		log.WithError(err).WithField("pr", pr.PRURL).Warn("failed to fetch comments for lesson extraction")
+		comments = nil
+	}
+
+	lessons := extractLessons(pr, prRepo, prInfo.Reviews, comments)
+
+	// Also extract from issue comments when PR was closed without merge
+	if prInfo.State == "CLOSED" {
+		lessons = append(lessons, extractLessonsFromIssueComments(pr, prRepo, issueComments)...)
+	}
+
+	saved := 0
+	for _, l := range lessons {
+		if err := p.db.SaveReviewLesson(l); err != nil {
+			log.WithError(err).Warn("failed to save review lesson")
+			continue
+		}
+		saved++
+	}
+
+	if saved > 0 {
+		log.WithFields(Fields{
+			"pr":      pr.PRURL,
+			"lessons": saved,
+		}).Info("extracted review lessons")
 	}
 }
 

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -79,6 +79,14 @@ func New(cfg *config.Config, database *db.DB, gh *ghclient.Client, promptsDir st
 	}, nil
 }
 
+// saveTrajectory persists an experience-replay trajectory. Non-fatal on error.
+func (p *Pipeline) saveTrajectory(issue *models.Issue, scout *ScoutResult, analyst *AnalystResult, reviewRounds int, reviewSummary string) {
+	t := buildTrajectory(issue, scout, analyst, reviewRounds, reviewSummary)
+	if err := p.db.SaveTrajectory(t); err != nil {
+		log.WithFields(Fields{"error": err, "issue": issue.IssueNumber}).Warn("failed to save trajectory")
+	}
+}
+
 // recordEvent records a pipeline event for learning. Non-fatal on error.
 func (p *Pipeline) recordEvent(issue *models.Issue, prID *int64, stage string, round int, startedAt time.Time, verdict string, success bool, outputSummary string, errMsg string) {
 	now := time.Now()
@@ -162,8 +170,10 @@ func (p *Pipeline) ProcessIssue(ctx context.Context, issue *models.Issue) error 
 	}
 
 	// Stage 3+4: Engineer ⇄ Reviewer loop
-	if err := p.engineerReviewLoop(ctx, issue, workspace, analyst); err != nil {
-		return err
+	reviewRounds, reviewSummary, loopErr := p.engineerReviewLoopWithStats(ctx, issue, workspace, analyst)
+	if loopErr != nil {
+		p.saveTrajectory(issue, scout, analyst, reviewRounds, "")
+		return loopErr
 	}
 
 	// Stage 5: Submitter
@@ -199,6 +209,9 @@ func (p *Pipeline) ProcessIssue(ctx context.Context, issue *models.Issue) error 
 	if err := p.db.UpdateIssueStatus(issue.ID, models.IssueStatusCompleted, ""); err != nil {
 		log.WithError(err).Warn("update status to completed")
 	}
+
+	// Save trajectory for experience replay (outcome will be updated when PR merges/closes)
+	p.saveTrajectory(issue, scout, analyst, reviewRounds, reviewSummary)
 
 	log.WithFields(Fields{
 		"repo":   issue.Repo,

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -80,8 +80,9 @@ func New(cfg *config.Config, database *db.DB, gh *ghclient.Client, promptsDir st
 }
 
 // saveTrajectory persists an experience-replay trajectory. Non-fatal on error.
-func (p *Pipeline) saveTrajectory(issue *models.Issue, scout *ScoutResult, analyst *AnalystResult, reviewRounds int, reviewSummary string) {
-	t := buildTrajectory(issue, scout, analyst, reviewRounds, reviewSummary)
+// prNumber is the GitHub PR number for this attempt; pass 0 when no PR was created.
+func (p *Pipeline) saveTrajectory(issue *models.Issue, scout *ScoutResult, analyst *AnalystResult, reviewRounds int, reviewSummary string, prNumber int) {
+	t := buildTrajectory(issue, scout, analyst, reviewRounds, reviewSummary, prNumber)
 	if err := p.db.SaveTrajectory(t); err != nil {
 		log.WithFields(Fields{"error": err, "issue": issue.IssueNumber}).Warn("failed to save trajectory")
 	}
@@ -172,7 +173,7 @@ func (p *Pipeline) ProcessIssue(ctx context.Context, issue *models.Issue) error 
 	// Stage 3+4: Engineer ⇄ Reviewer loop
 	reviewRounds, reviewSummary, loopErr := p.engineerReviewLoopWithStats(ctx, issue, workspace, analyst)
 	if loopErr != nil {
-		p.saveTrajectory(issue, scout, analyst, reviewRounds, "")
+		p.saveTrajectory(issue, scout, analyst, reviewRounds, reviewSummary, 0)
 		return loopErr
 	}
 
@@ -211,7 +212,7 @@ func (p *Pipeline) ProcessIssue(ctx context.Context, issue *models.Issue) error 
 	}
 
 	// Save trajectory for experience replay (outcome will be updated when PR merges/closes)
-	p.saveTrajectory(issue, scout, analyst, reviewRounds, reviewSummary)
+	p.saveTrajectory(issue, scout, analyst, reviewRounds, reviewSummary, submit.PRNumber)
 
 	log.WithFields(Fields{
 		"repo":   issue.Repo,

--- a/internal/pipeline/trajectory.go
+++ b/internal/pipeline/trajectory.go
@@ -1,0 +1,212 @@
+package pipeline
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/majiayu000/auto-contributor/pkg/models"
+)
+
+// stopWords is a minimal set of common English words to exclude from keyword extraction.
+var stopWords = map[string]bool{
+	"a": true, "an": true, "the": true, "and": true, "or": true, "but": true,
+	"in": true, "on": true, "at": true, "to": true, "for": true, "of": true,
+	"with": true, "by": true, "from": true, "is": true, "are": true, "was": true,
+	"be": true, "been": true, "it": true, "its": true, "this": true, "that": true,
+	"as": true, "not": true, "no": true, "can": true, "we": true, "i": true,
+	"if": true, "so": true, "do": true, "get": true, "when": true, "how": true,
+	"use": true, "used": true, "using": true, "into": true, "have": true,
+	"has": true, "had": true, "will": true, "would": true, "should": true,
+	"could": true, "may": true, "might": true, "which": true, "what": true,
+	"also": true, "more": true, "than": true, "then": true, "up": true,
+	"out": true, "after": true, "before": true, "all": true, "each": true,
+	"just": true, "any": true, "some": true, "about": true, "like": true,
+	"see": true, "new": true, "go": true, "make": true, "set": true,
+}
+
+// extractKeywords tokenizes title + body into a deduplicated sorted keyword list.
+// Tokens shorter than 3 chars or in stopWords are skipped.
+func extractKeywords(title, body string) string {
+	combined := strings.ToLower(title + " " + body)
+
+	seen := make(map[string]bool)
+	var tokens []string
+
+	start := -1
+	for i := 0; i <= len(combined); i++ {
+		ch := byte(0)
+		if i < len(combined) {
+			ch = combined[i]
+		}
+		isAlnum := (ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9')
+		if isAlnum {
+			if start < 0 {
+				start = i
+			}
+		} else {
+			if start >= 0 {
+				tok := combined[start:i]
+				start = -1
+				if len(tok) >= 3 && !stopWords[tok] && !seen[tok] {
+					seen[tok] = true
+					tokens = append(tokens, tok)
+				}
+			}
+		}
+	}
+	sort.Strings(tokens)
+	return strings.Join(tokens, " ")
+}
+
+// jaccardSimilarity returns the Jaccard similarity between two space-separated keyword strings.
+// Returns a value in [0, 1].
+func jaccardSimilarity(a, b string) float64 {
+	if a == "" || b == "" {
+		return 0
+	}
+	setA := make(map[string]bool)
+	for _, tok := range strings.Fields(a) {
+		setA[tok] = true
+	}
+	intersection := 0
+	union := len(setA)
+	for _, tok := range strings.Fields(b) {
+		if setA[tok] {
+			intersection++
+		} else {
+			union++
+		}
+	}
+	if union == 0 {
+		return 0
+	}
+	return float64(intersection) / float64(union)
+}
+
+// rankTrajectories returns up to limit trajectories sorted by descending Jaccard similarity
+// to queryKeywords. Only trajectories with similarity > 0 are returned.
+func rankTrajectories(candidates []*models.Trajectory, queryKeywords string, limit int) []*models.Trajectory {
+	type scored struct {
+		t     *models.Trajectory
+		score float64
+	}
+	var ranked []scored
+	for _, t := range candidates {
+		s := jaccardSimilarity(queryKeywords, t.Keywords)
+		if s > 0 {
+			ranked = append(ranked, scored{t, s})
+		}
+	}
+	sort.Slice(ranked, func(i, j int) bool {
+		return ranked[i].score > ranked[j].score
+	})
+	if len(ranked) > limit {
+		ranked = ranked[:limit]
+	}
+	result := make([]*models.Trajectory, len(ranked))
+	for i, r := range ranked {
+		result[i] = r.t
+	}
+	return result
+}
+
+// getSimilarTrajectories retrieves the top-k successful trajectories most similar to the given issue.
+func (p *Pipeline) getSimilarTrajectories(issue *models.Issue, k int) []*models.Trajectory {
+	candidates, err := p.db.GetSuccessfulTrajectories(100)
+	if err != nil || len(candidates) == 0 {
+		return nil
+	}
+	queryKeywords := extractKeywords(issue.Title, issue.Body)
+	return rankTrajectories(candidates, queryKeywords, k)
+}
+
+// buildTrajectory constructs a Trajectory record from pipeline stage results.
+func buildTrajectory(
+	issue *models.Issue,
+	scout *ScoutResult,
+	analyst *AnalystResult,
+	reviewRounds int,
+	reviewSummary string,
+) *models.Trajectory {
+	keywords := extractKeywords(issue.Title, issue.Body)
+
+	var analystPlanJSON string
+	if analyst != nil {
+		b, _ := json.Marshal(analyst.FixPlan)
+		analystPlanJSON = string(b)
+	}
+
+	t := &models.Trajectory{
+		IssueID:       issue.ID,
+		Repo:          issue.Repo,
+		IssueNumber:   issue.IssueNumber,
+		IssueTitle:    issue.Title,
+		IssueBody:     truncate(issue.Body, 1000),
+		Keywords:      keywords,
+		ReviewRounds:  reviewRounds,
+		ReviewSummary: truncate(reviewSummary, 500),
+		AnalystPlan:   analystPlanJSON,
+	}
+
+	if scout != nil {
+		t.ScoutVerdict = scout.Verdict
+		t.ScoutApproach = scout.SuggestedApproach
+	}
+
+	return t
+}
+
+// formatTrajectoriesForPrompt formats similar trajectories as few-shot examples for agent prompts.
+// Successful trajectories are labeled as positive examples; failed ones as negative.
+func formatTrajectoriesForPrompt(trajectories []*models.Trajectory) string {
+	if len(trajectories) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	b.WriteString("## Similar Past Trajectories (Experience Replay)\n\n")
+	b.WriteString("The following trajectories from similar issues may guide your approach:\n\n")
+
+	for i, t := range trajectories {
+		label := "SUCCESS"
+		if !t.Success {
+			label = "FAILED"
+			if t.OutcomeLabel != "" {
+				label = fmt.Sprintf("FAILED (%s)", t.OutcomeLabel)
+			}
+		}
+
+		fmt.Fprintf(&b, "### Trajectory %d [%s] — %s#%d\n", i+1, label, t.Repo, t.IssueNumber)
+		fmt.Fprintf(&b, "**Issue:** %s\n", t.IssueTitle)
+
+		if t.ScoutApproach != "" {
+			fmt.Fprintf(&b, "**Approach taken:** %s\n", t.ScoutApproach)
+		}
+
+		if t.AnalystPlan != "" {
+			var plan FixPlan
+			if err := json.Unmarshal([]byte(t.AnalystPlan), &plan); err == nil {
+				if plan.Description != "" {
+					fmt.Fprintf(&b, "**Fix plan:** %s\n", plan.Description)
+				}
+				if len(plan.FilesToModify) > 0 {
+					fmt.Fprintf(&b, "**Files modified:** %s\n", strings.Join(plan.FilesToModify, ", "))
+				}
+			}
+		}
+
+		if t.ReviewRounds > 0 {
+			fmt.Fprintf(&b, "**Review rounds:** %d\n", t.ReviewRounds)
+		}
+
+		if t.ReviewSummary != "" {
+			fmt.Fprintf(&b, "**Review summary:** %s\n", t.ReviewSummary)
+		}
+
+		b.WriteString("\n")
+	}
+
+	return b.String()
+}

--- a/internal/pipeline/trajectory.go
+++ b/internal/pipeline/trajectory.go
@@ -12,8 +12,17 @@ import (
 	"github.com/majiayu000/auto-contributor/pkg/models"
 )
 
-// roleMarkerRE matches prompt-injection role markers case-insensitively.
-var roleMarkerRE = regexp.MustCompile(`(?i)(SYSTEM|ASSISTANT|USER|HUMAN|AI):|<\|im_start\|>|<\|im_end\|>`)
+// roleMarkerRE matches prompt-injection role markers case-insensitively, including:
+//   - role prefixes with optional surrounding whitespace before the colon (e.g. "SYSTEM :", "user:")
+//   - ChatML token-style delimiters (<|im_start|>, <|im_end|>)
+//   - XML-style role tags (e.g. <system>, </assistant>, <user role="...">)
+//   - common imperative jailbreak phrases ("ignore [all] previous instructions")
+var roleMarkerRE = regexp.MustCompile(
+	`(?i)(?:SYSTEM|ASSISTANT|USER|HUMAN|AI)\s*:` +
+		`|<\|im_start\|>|<\|im_end\|>` +
+		`|</?(?:system|assistant|user|human|ai)(?:\s[^>]*)?>` +
+		`|ignore\s+(?:all\s+)?(?:previous|prior|above)\s+instructions?`,
+)
 
 // sanitizeForPrompt strips characters and patterns from user-controlled text that could
 // be used to inject instructions into an LLM prompt. It collapses newlines to spaces

--- a/internal/pipeline/trajectory.go
+++ b/internal/pipeline/trajectory.go
@@ -5,9 +5,40 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/majiayu000/auto-contributor/pkg/models"
 )
+
+// sanitizeForPrompt strips characters and patterns from user-controlled text that could
+// be used to inject instructions into an LLM prompt. It collapses newlines to spaces
+// and removes sequences that look like markdown headings or role markers.
+func sanitizeForPrompt(s string) string {
+	// Replace newlines/tabs with a space so multi-line content cannot introduce
+	// new prompt sections.
+	s = strings.NewReplacer("\r\n", " ", "\n", " ", "\r", " ", "\t", " ").Replace(s)
+
+	// Remove markdown heading markers (###, ##, #) that could introduce fake sections.
+	for strings.Contains(s, "##") || strings.HasPrefix(strings.TrimSpace(s), "#") {
+		s = strings.ReplaceAll(s, "##", "")
+		if strings.HasPrefix(strings.TrimSpace(s), "#") {
+			s = strings.TrimLeft(s, "#")
+		}
+	}
+
+	// Remove common role-marker prefixes used in prompt injection.
+	for _, prefix := range []string{"SYSTEM:", "ASSISTANT:", "USER:", "HUMAN:", "AI:", "<|im_start|>", "<|im_end|>"} {
+		s = strings.ReplaceAll(s, prefix, "")
+	}
+
+	// Collapse multiple spaces.
+	for strings.Contains(s, "  ") {
+		s = strings.ReplaceAll(s, "  ", " ")
+	}
+
+	return strings.TrimSpace(s)
+}
 
 // stopWords is a minimal set of common English words to exclude from keyword extraction.
 var stopWords = map[string]bool{
@@ -27,35 +58,43 @@ var stopWords = map[string]bool{
 }
 
 // extractKeywords tokenizes title + body into a deduplicated sorted keyword list.
-// Tokens shorter than 3 chars or in stopWords are skipped.
+// Tokens shorter than 3 runes or in stopWords are skipped.
+// Uses unicode-aware letter/digit detection so non-ASCII issue text is handled correctly.
 func extractKeywords(title, body string) string {
 	combined := strings.ToLower(title + " " + body)
 
 	seen := make(map[string]bool)
 	var tokens []string
 
-	start := -1
-	for i := 0; i <= len(combined); i++ {
-		ch := byte(0)
-		if i < len(combined) {
-			ch = combined[i]
-		}
-		isAlnum := (ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9')
+	inWord := false
+	wordStart := 0
+	for i, r := range combined {
+		isAlnum := unicode.IsLetter(r) || unicode.IsDigit(r)
 		if isAlnum {
-			if start < 0 {
-				start = i
+			if !inWord {
+				inWord = true
+				wordStart = i
 			}
 		} else {
-			if start >= 0 {
-				tok := combined[start:i]
-				start = -1
-				if len(tok) >= 3 && !stopWords[tok] && !seen[tok] {
+			if inWord {
+				tok := combined[wordStart:i]
+				inWord = false
+				if utf8.RuneCountInString(tok) >= 3 && !stopWords[tok] && !seen[tok] {
 					seen[tok] = true
 					tokens = append(tokens, tok)
 				}
 			}
 		}
 	}
+	// Handle word at end of string
+	if inWord {
+		tok := combined[wordStart:]
+		if utf8.RuneCountInString(tok) >= 3 && !stopWords[tok] && !seen[tok] {
+			seen[tok] = true
+			tokens = append(tokens, tok)
+		}
+	}
+
 	sort.Strings(tokens)
 	return strings.Join(tokens, " ")
 }
@@ -178,31 +217,31 @@ func formatTrajectoriesForPrompt(trajectories []*models.Trajectory) string {
 			}
 		}
 
-		fmt.Fprintf(&b, "### Trajectory %d [%s] — %s#%d\n", i+1, label, t.Repo, t.IssueNumber)
-		fmt.Fprintf(&b, "**Issue:** %s\n", t.IssueTitle)
+		fmt.Fprintf(&b, "Trajectory %d [%s] - %s#%d\n", i+1, label, sanitizeForPrompt(t.Repo), t.IssueNumber)
+		fmt.Fprintf(&b, "Issue: %s\n", sanitizeForPrompt(t.IssueTitle))
 
 		if t.ScoutApproach != "" {
-			fmt.Fprintf(&b, "**Approach taken:** %s\n", t.ScoutApproach)
+			fmt.Fprintf(&b, "Approach taken: %s\n", sanitizeForPrompt(t.ScoutApproach))
 		}
 
 		if t.AnalystPlan != "" {
 			var plan FixPlan
 			if err := json.Unmarshal([]byte(t.AnalystPlan), &plan); err == nil {
 				if plan.Description != "" {
-					fmt.Fprintf(&b, "**Fix plan:** %s\n", plan.Description)
+					fmt.Fprintf(&b, "Fix plan: %s\n", sanitizeForPrompt(plan.Description))
 				}
 				if len(plan.FilesToModify) > 0 {
-					fmt.Fprintf(&b, "**Files modified:** %s\n", strings.Join(plan.FilesToModify, ", "))
+					fmt.Fprintf(&b, "Files modified: %s\n", strings.Join(plan.FilesToModify, ", "))
 				}
 			}
 		}
 
 		if t.ReviewRounds > 0 {
-			fmt.Fprintf(&b, "**Review rounds:** %d\n", t.ReviewRounds)
+			fmt.Fprintf(&b, "Review rounds: %d\n", t.ReviewRounds)
 		}
 
 		if t.ReviewSummary != "" {
-			fmt.Fprintf(&b, "**Review summary:** %s\n", t.ReviewSummary)
+			fmt.Fprintf(&b, "Review summary: %s\n", sanitizeForPrompt(t.ReviewSummary))
 		}
 
 		b.WriteString("\n")

--- a/internal/pipeline/trajectory.go
+++ b/internal/pipeline/trajectory.go
@@ -3,6 +3,7 @@ package pipeline
 import (
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 	"unicode"
@@ -10,6 +11,9 @@ import (
 
 	"github.com/majiayu000/auto-contributor/pkg/models"
 )
+
+// roleMarkerRE matches prompt-injection role markers case-insensitively.
+var roleMarkerRE = regexp.MustCompile(`(?i)(SYSTEM|ASSISTANT|USER|HUMAN|AI):|<\|im_start\|>|<\|im_end\|>`)
 
 // sanitizeForPrompt strips characters and patterns from user-controlled text that could
 // be used to inject instructions into an LLM prompt. It collapses newlines to spaces
@@ -31,10 +35,8 @@ func sanitizeForPrompt(s string) string {
 		}
 	}
 
-	// Remove common role-marker prefixes used in prompt injection.
-	for _, prefix := range []string{"SYSTEM:", "ASSISTANT:", "USER:", "HUMAN:", "AI:", "<|im_start|>", "<|im_end|>"} {
-		s = strings.ReplaceAll(s, prefix, "")
-	}
+	// Remove common role-marker prefixes used in prompt injection (case-insensitive).
+	s = roleMarkerRE.ReplaceAllString(s, "")
 
 	// Collapse multiple spaces.
 	for strings.Contains(s, "  ") {
@@ -228,18 +230,22 @@ func formatTrajectoriesForPrompt(trajectories []*models.Trajectory) string {
 		fmt.Fprintf(&b, "Issue: %s\n", sanitizeForPrompt(t.IssueTitle))
 
 		if t.ScoutApproach != "" {
-			fmt.Fprintf(&b, "Approach taken: %s\n", sanitizeForPrompt(t.ScoutApproach))
+			fmt.Fprintf(&b, "Approach taken: %s\n", sanitizeForPrompt(truncate(t.ScoutApproach, 300)))
 		}
 
 		if t.AnalystPlan != "" {
 			var plan FixPlan
 			if err := json.Unmarshal([]byte(t.AnalystPlan), &plan); err == nil {
 				if plan.Description != "" {
-					fmt.Fprintf(&b, "Fix plan: %s\n", sanitizeForPrompt(plan.Description))
+					fmt.Fprintf(&b, "Fix plan: %s\n", sanitizeForPrompt(truncate(plan.Description, 300)))
 				}
 				if len(plan.FilesToModify) > 0 {
-					sanitizedFiles := make([]string, len(plan.FilesToModify))
-					for i, f := range plan.FilesToModify {
+					files := plan.FilesToModify
+					if len(files) > 10 {
+						files = files[:10]
+					}
+					sanitizedFiles := make([]string, len(files))
+					for i, f := range files {
 						sanitizedFiles[i] = sanitizeForPrompt(f)
 					}
 					fmt.Fprintf(&b, "Files modified: %s\n", strings.Join(sanitizedFiles, ", "))

--- a/internal/pipeline/trajectory.go
+++ b/internal/pipeline/trajectory.go
@@ -20,10 +20,14 @@ func sanitizeForPrompt(s string) string {
 	s = strings.NewReplacer("\r\n", " ", "\n", " ", "\r", " ", "\t", " ").Replace(s)
 
 	// Remove markdown heading markers (###, ##, #) that could introduce fake sections.
+	// NOTE: trimmed is computed inside the loop so the condition and mutation operate on
+	// the same value; using TrimLeft on the un-trimmed string would skip leading whitespace
+	// and leave s unchanged when the string starts with spaces, causing an infinite loop.
 	for strings.Contains(s, "##") || strings.HasPrefix(strings.TrimSpace(s), "#") {
 		s = strings.ReplaceAll(s, "##", "")
-		if strings.HasPrefix(strings.TrimSpace(s), "#") {
-			s = strings.TrimLeft(s, "#")
+		trimmed := strings.TrimSpace(s)
+		if strings.HasPrefix(trimmed, "#") {
+			s = strings.TrimLeft(trimmed, "#")
 		}
 	}
 
@@ -162,12 +166,14 @@ func (p *Pipeline) getSimilarTrajectories(issue *models.Issue, k int) []*models.
 }
 
 // buildTrajectory constructs a Trajectory record from pipeline stage results.
+// prNumber is the GitHub PR number created for this attempt; pass 0 if no PR was opened.
 func buildTrajectory(
 	issue *models.Issue,
 	scout *ScoutResult,
 	analyst *AnalystResult,
 	reviewRounds int,
 	reviewSummary string,
+	prNumber int,
 ) *models.Trajectory {
 	keywords := extractKeywords(issue.Title, issue.Body)
 
@@ -179,6 +185,7 @@ func buildTrajectory(
 
 	t := &models.Trajectory{
 		IssueID:       issue.ID,
+		PRNumber:      prNumber,
 		Repo:          issue.Repo,
 		IssueNumber:   issue.IssueNumber,
 		IssueTitle:    issue.Title,
@@ -231,7 +238,11 @@ func formatTrajectoriesForPrompt(trajectories []*models.Trajectory) string {
 					fmt.Fprintf(&b, "Fix plan: %s\n", sanitizeForPrompt(plan.Description))
 				}
 				if len(plan.FilesToModify) > 0 {
-					fmt.Fprintf(&b, "Files modified: %s\n", strings.Join(plan.FilesToModify, ", "))
+					sanitizedFiles := make([]string, len(plan.FilesToModify))
+					for i, f := range plan.FilesToModify {
+						sanitizedFiles[i] = sanitizeForPrompt(f)
+					}
+					fmt.Fprintf(&b, "Files modified: %s\n", strings.Join(sanitizedFiles, ", "))
 				}
 			}
 		}

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -299,6 +299,28 @@ type RepoProfile struct {
 	UpdatedAt            time.Time  `db:"updated_at" json:"updated_at"`
 }
 
+// Trajectory stores a complete pipeline execution path for experience replay.
+// Each record represents one issue processing attempt with its full execution context,
+// enabling future similar issues to benefit from past experience (SWE-Replay / AgentHER pattern).
+type Trajectory struct {
+	ID            int64     `db:"id" json:"id"`
+	IssueID       int64     `db:"issue_id" json:"issue_id"`
+	Repo          string    `db:"repo" json:"repo"`
+	IssueNumber   int       `db:"issue_number" json:"issue_number"`
+	IssueTitle    string    `db:"issue_title" json:"issue_title"`
+	IssueBody     string    `db:"issue_body" json:"issue_body"`
+	Keywords      string    `db:"keywords" json:"keywords"` // space-separated tokens for similarity
+	ScoutVerdict  string    `db:"scout_verdict" json:"scout_verdict"`
+	ScoutApproach string    `db:"scout_approach" json:"scout_approach"`
+	AnalystPlan   string    `db:"analyst_plan" json:"analyst_plan"` // JSON of FixPlan
+	ReviewRounds  int       `db:"review_rounds" json:"review_rounds"`
+	ReviewSummary string    `db:"review_summary" json:"review_summary"`
+	OutcomeLabel  string    `db:"outcome_label" json:"outcome_label"` // merged, rejected_*, etc.
+	Success       bool      `db:"success" json:"success"`
+	CreatedAt     time.Time `db:"created_at" json:"created_at"`
+	UpdatedAt     time.Time `db:"updated_at" json:"updated_at"`
+}
+
 // PipelineEvent records a single agent invocation in the pipeline.
 type PipelineEvent struct {
 	ID              int64      `db:"id" json:"id"`

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -305,6 +305,7 @@ type RepoProfile struct {
 type Trajectory struct {
 	ID            int64     `db:"id" json:"id"`
 	IssueID       int64     `db:"issue_id" json:"issue_id"`
+	PRNumber      int       `db:"pr_number" json:"pr_number"` // GitHub PR number; 0 if no PR was created
 	Repo          string    `db:"repo" json:"repo"`
 	IssueNumber   int       `db:"issue_number" json:"issue_number"`
 	IssueTitle    string    `db:"issue_title" json:"issue_title"`

--- a/prompts/engineer.md
+++ b/prompts/engineer.md
@@ -39,6 +39,10 @@ Do NOT repeat the same mistakes. Focus on fixing exactly what the reviewer flagg
 {{ .PastLessons }}
 {{ end }}
 
+{{ if .SimilarTrajectories }}
+{{ .SimilarTrajectories }}
+{{ end }}
+
 ## Implementation Rules
 
 1. **Minimal fix only** — change ONLY what's necessary to fix the issue


### PR DESCRIPTION
## Summary

Implements experience replay for the auto-contributor pipeline as described in issue #19 (SWE-Replay / AgentHER pattern):

- **Trajectory storage**: every completed pipeline run saves a `Trajectory` record capturing the scout approach, analyst fix plan, review rounds, and keywords extracted from the issue
- **Keyword-based similarity**: issues are tokenised (stop-word filtered) and indexed as a keyword string; Jaccard similarity ranks candidate trajectories at query time — no new dependencies required
- **Few-shot injection**: the top-3 most similar *successful* trajectories are formatted as `## Similar Past Trajectories` and injected into the engineer prompt context via `SimilarTrajectories`
- **Outcome labelling**: when a PR merges or closes, `UpdateTrajectoryOutcome` stamps the trajectory with the outcome label (`merged`, `rejected_scope`, etc.) and a `success` flag so the replay pool stays accurate
- **AgentHER-compatible**: failed trajectories are stored with `success=false` and their outcome label, ready for negative-example injection in a future iteration

## Files changed

| File | Change |
|---|---|
| `pkg/models/models.go` | Add `Trajectory` struct |
| `internal/db/trajectories.go` | New — migration, save, update-outcome, retrieval helpers |
| `internal/db/db.go` | Wire `MigrateTrajectories()` into startup |
| `internal/pipeline/trajectory.go` | New — keyword extraction, Jaccard ranking, prompt formatting, `getSimilarTrajectories` |
| `internal/pipeline/pipeline.go` | Save trajectory on success/failure; use `engineerReviewLoopWithStats` |
| `internal/pipeline/agents.go` | Rename loop → `engineerReviewLoopWithStats` (returns rounds+summary); inject `SimilarTrajectories` into engineer context |
| `internal/pipeline/lessons.go` | Call `UpdateTrajectoryOutcome` at PR terminal state |

## Test plan

- [x] `gofmt -w .` — no diff
- [x] `go vet ./...` — clean
- [x] `go build ./...` — clean
- [x] `go test ./...` — all tests pass

Closes #19