### PR TITLE
feat: add Q-value utility tracking for rules (MemRL, issue #15)

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -109,8 +109,10 @@ func (db *DB) Migrate() error {
 	// Column-level migrations intentionally ignore errors (column may already exist).
 	db.runMigrations()
 	db.MigrateLessons()
-	db.MigrateEvents()
-	// Table-level migrations: propagate errors so startup fails fast on DDL failure.
+	if err := db.MigrateEvents(); err != nil {
+		return fmt.Errorf("migrate events: %w", err)
+	}
+	// Table-level migration: propagate errors so startup fails fast on DDL failure.
 	if err := db.MigrateRepoProfiles(); err != nil {
 		return err
 	}

--- a/internal/db/events.go
+++ b/internal/db/events.go
@@ -7,6 +7,19 @@ import (
 	"github.com/majiayu000/auto-contributor/pkg/models"
 )
 
+// migrateEventsV2 adds the experiences_used column to the pipeline_events table.
+// Safe to call on both new and existing databases; errors are ignored if the column already exists.
+func (db *DB) migrateEventsV2() {
+	var stmt string
+	if db.IsPostgres() {
+		stmt = `ALTER TABLE pipeline_events ADD COLUMN IF NOT EXISTS experiences_used TEXT`
+	} else {
+		stmt = `ALTER TABLE pipeline_events ADD COLUMN experiences_used TEXT`
+	}
+	// Ignore errors: SQLite will fail if the column already exists; that's fine.
+	db.Exec(stmt) //nolint:errcheck
+}
+
 // MigrateEvents creates the pipeline_events table.
 func (db *DB) MigrateEvents() error {
 	var schema string
@@ -28,6 +41,7 @@ func (db *DB) MigrateEvents() error {
 			success INTEGER DEFAULT 0,
 			error_message TEXT,
 			outcome_label TEXT,
+			experiences_used TEXT,
 			created_at TIMESTAMP DEFAULT NOW()
 		);
 		CREATE INDEX IF NOT EXISTS idx_events_issue ON pipeline_events(issue_id);
@@ -53,6 +67,7 @@ func (db *DB) MigrateEvents() error {
 			success INTEGER DEFAULT 0,
 			error_message TEXT,
 			outcome_label TEXT,
+			experiences_used TEXT,
 			created_at DATETIME DEFAULT CURRENT_TIMESTAMP
 		);
 		CREATE INDEX IF NOT EXISTS idx_events_issue ON pipeline_events(issue_id);
@@ -61,8 +76,12 @@ func (db *DB) MigrateEvents() error {
 		CREATE INDEX IF NOT EXISTS idx_events_outcome ON pipeline_events(outcome_label);
 		`
 	}
-	_, err := db.Exec(schema)
-	return err
+	if _, err := db.Exec(schema); err != nil {
+		return err
+	}
+	// Add experiences_used column to existing databases (idempotent, errors ignored).
+	db.migrateEventsV2()
+	return nil
 }
 
 // RecordEvent inserts a pipeline event.
@@ -70,13 +89,13 @@ func (db *DB) RecordEvent(event *models.PipelineEvent) error {
 	query := fmt.Sprintf(`
 		INSERT INTO pipeline_events (issue_id, pr_id, repo, issue_number, stage, round,
 			started_at, completed_at, duration_seconds, output_summary, verdict,
-			success, error_message)
-		VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+			success, error_message, experiences_used)
+		VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
 	`,
 		db.placeholder(1), db.placeholder(2), db.placeholder(3), db.placeholder(4),
 		db.placeholder(5), db.placeholder(6), db.placeholder(7), db.placeholder(8),
 		db.placeholder(9), db.placeholder(10), db.placeholder(11), db.placeholder(12),
-		db.placeholder(13),
+		db.placeholder(13), db.placeholder(14),
 	)
 
 	successInt := 0
@@ -88,7 +107,7 @@ func (db *DB) RecordEvent(event *models.PipelineEvent) error {
 		event.IssueID, event.PRID, event.Repo, event.IssueNumber,
 		event.Stage, event.Round, event.StartedAt, event.CompletedAt,
 		event.DurationSeconds, event.OutputSummary, event.Verdict,
-		successInt, event.ErrorMessage,
+		successInt, event.ErrorMessage, event.ExperiencesUsed,
 	)
 	return err
 }
@@ -98,7 +117,7 @@ func (db *DB) GetEventsByIssue(issueID int64) ([]*models.PipelineEvent, error) {
 	query := fmt.Sprintf(`
 		SELECT id, issue_id, pr_id, repo, issue_number, stage, round,
 			started_at, completed_at, duration_seconds, output_summary, verdict,
-			success, error_message, outcome_label, created_at
+			success, error_message, outcome_label, experiences_used, created_at
 		FROM pipeline_events
 		WHERE issue_id = %s
 		ORDER BY created_at ASC
@@ -118,7 +137,7 @@ func (db *DB) GetEventsByStage(stage string, limit int) ([]*models.PipelineEvent
 	query := fmt.Sprintf(`
 		SELECT id, issue_id, pr_id, repo, issue_number, stage, round,
 			started_at, completed_at, duration_seconds, output_summary, verdict,
-			success, error_message, outcome_label, created_at
+			success, error_message, outcome_label, experiences_used, created_at
 		FROM pipeline_events
 		WHERE stage = %s
 		ORDER BY created_at DESC
@@ -139,7 +158,7 @@ func (db *DB) GetLabeledEventsByStage(stage string, limit int) ([]*models.Pipeli
 	query := fmt.Sprintf(`
 		SELECT id, issue_id, pr_id, repo, issue_number, stage, round,
 			started_at, completed_at, duration_seconds, output_summary, verdict,
-			success, error_message, outcome_label, created_at
+			success, error_message, outcome_label, experiences_used, created_at
 		FROM pipeline_events
 		WHERE stage = %s AND outcome_label IS NOT NULL AND outcome_label != ''
 		ORDER BY created_at DESC
@@ -183,11 +202,12 @@ func scanEvents(rows interface {
 		var completedAt *time.Time
 		var prID *int64
 		var outcomeLabel *string
+		var experiencesUsed *string
 		err := rows.Scan(
 			&e.ID, &e.IssueID, &prID, &e.Repo, &e.IssueNumber,
 			&e.Stage, &e.Round, &e.StartedAt, &completedAt,
 			&e.DurationSeconds, &e.OutputSummary, &e.Verdict,
-			&e.Success, &e.ErrorMessage, &outcomeLabel, &e.CreatedAt,
+			&e.Success, &e.ErrorMessage, &outcomeLabel, &experiencesUsed, &e.CreatedAt,
 		)
 		if err != nil {
 			return nil, err
@@ -196,6 +216,9 @@ func scanEvents(rows interface {
 		e.CompletedAt = completedAt
 		if outcomeLabel != nil {
 			e.OutcomeLabel = *outcomeLabel
+		}
+		if experiencesUsed != nil {
+			e.ExperiencesUsed = *experiencesUsed
 		}
 		events = append(events, e)
 	}

--- a/internal/db/events.go
+++ b/internal/db/events.go
@@ -2,22 +2,29 @@ package db
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/majiayu000/auto-contributor/pkg/models"
 )
 
 // migrateEventsV2 adds the experiences_used column to the pipeline_events table.
-// Safe to call on both new and existing databases; errors are ignored if the column already exists.
-func (db *DB) migrateEventsV2() {
+// Returns nil if the column already exists (SQLite "duplicate column" error is suppressed).
+// All other errors (locked DB, read-only FS, etc.) are propagated so callers know the
+// column may be missing and subsequent reads/writes of experiences_used would fail.
+func (db *DB) migrateEventsV2() error {
 	var stmt string
 	if db.IsPostgres() {
+		// IF NOT EXISTS is supported by Postgres — never errors.
 		stmt = `ALTER TABLE pipeline_events ADD COLUMN IF NOT EXISTS experiences_used TEXT`
 	} else {
 		stmt = `ALTER TABLE pipeline_events ADD COLUMN experiences_used TEXT`
 	}
-	// Ignore errors: SQLite will fail if the column already exists; that's fine.
-	db.Exec(stmt) //nolint:errcheck
+	_, err := db.Exec(stmt)
+	if err != nil && strings.Contains(err.Error(), "duplicate column") {
+		return nil // column already exists — idempotent, not an error
+	}
+	return err
 }
 
 // MigrateEvents creates the pipeline_events table.
@@ -79,8 +86,10 @@ func (db *DB) MigrateEvents() error {
 	if _, err := db.Exec(schema); err != nil {
 		return err
 	}
-	// Add experiences_used column to existing databases (idempotent, errors ignored).
-	db.migrateEventsV2()
+	// Add experiences_used column to existing databases (idempotent).
+	if err := db.migrateEventsV2(); err != nil {
+		return fmt.Errorf("migrateEventsV2: %w", err)
+	}
 	return nil
 }
 

--- a/internal/pipeline/agents.go
+++ b/internal/pipeline/agents.go
@@ -179,7 +179,7 @@ func (p *Pipeline) runSubmitter(ctx context.Context, issue *models.Issue, worksp
 // --- Critic ---
 
 func (p *Pipeline) runCritic(ctx context.Context, issue *models.Issue, workspace string, analyst *AnalystResult, round int) (*CriticResult, error) {
-	criticRules := p.ruleLoader.IDsForStage("critic")
+	criticRules := p.ruleLoader.IDsForPrompt("critic")
 	planJSON, _ := json.MarshalIndent(analyst.FixPlan, "", "  ")
 
 	tmplCtx := map[string]any{
@@ -229,8 +229,8 @@ func (p *Pipeline) criticLoop(ctx context.Context, issue *models.Issue, workspac
 		return err
 	}
 	for round := 1; round <= p.maxCriticRounds; round++ {
-		engineerRules := p.ruleLoader.IDsForStage("engineer")
-		reviewerRules := p.ruleLoader.IDsForStage("reviewer")
+		engineerRules := p.ruleLoader.IDsForPrompt("engineer")
+		reviewerRules := p.ruleLoader.IDsForPrompt("reviewer")
 		if err := p.db.UpdateIssueStatus(issue.ID, models.IssueStatusReviewing, ""); err != nil {
 			log.WithError(err).Warn("update status to reviewing (critic)")
 		}

--- a/internal/pipeline/agents.go
+++ b/internal/pipeline/agents.go
@@ -13,7 +13,7 @@ import (
 // --- Scout ---
 
 func (p *Pipeline) runScout(ctx context.Context, issue *models.Issue) (*ScoutResult, error) {
-	stageRules := p.ruleLoader.IDsForStage("scout")
+	stageRules := p.ruleLoader.IDsForPrompt("scout")
 	tmplCtx := map[string]any{
 		"Repo":        issue.Repo,
 		"IssueNumber": issue.IssueNumber,
@@ -42,7 +42,7 @@ func (p *Pipeline) runScout(ctx context.Context, issue *models.Issue) (*ScoutRes
 // --- Analyst ---
 
 func (p *Pipeline) runAnalyst(ctx context.Context, issue *models.Issue, workspace string, scout *ScoutResult) (*AnalystResult, error) {
-	stageRules := p.ruleLoader.IDsForStage("analyst")
+	stageRules := p.ruleLoader.IDsForPrompt("analyst")
 	scoutJSON, _ := json.MarshalIndent(scout, "", "  ")
 
 	tmplCtx := map[string]any{
@@ -141,7 +141,7 @@ func (p *Pipeline) buildReviewerCtx(issue *models.Issue, analyst *AnalystResult,
 // --- Submitter ---
 
 func (p *Pipeline) runSubmitter(ctx context.Context, issue *models.Issue, workspace string, analyst *AnalystResult) (*SubmitResult, error) {
-	stageRules := p.ruleLoader.IDsForStage("submitter")
+	stageRules := p.ruleLoader.IDsForPrompt("submitter")
 	planJSON, _ := json.MarshalIndent(analyst.FixPlan, "", "  ")
 
 	tmplCtx := map[string]any{
@@ -377,8 +377,8 @@ func (p *Pipeline) engineerReviewLoopWithStats(ctx context.Context, issue *model
 	var lastReview *CodeReviewResult
 	lastSummary := ""
 
-	engineerRules := p.ruleLoader.IDsForStage("engineer")
-	reviewerRules := p.ruleLoader.IDsForStage("reviewer")
+	engineerRules := p.ruleLoader.IDsForPrompt("engineer")
+	reviewerRules := p.ruleLoader.IDsForPrompt("reviewer")
 
 	for round := 1; round <= p.maxReview; round++ {
 		// Engineer

--- a/internal/pipeline/agents.go
+++ b/internal/pipeline/agents.go
@@ -13,6 +13,7 @@ import (
 // --- Scout ---
 
 func (p *Pipeline) runScout(ctx context.Context, issue *models.Issue) (*ScoutResult, error) {
+	stageRules := p.ruleLoader.IDsForStage("scout")
 	tmplCtx := map[string]any{
 		"Repo":        issue.Repo,
 		"IssueNumber": issue.IssueNumber,
@@ -30,17 +31,18 @@ func (p *Pipeline) runScout(ctx context.Context, issue *models.Issue) (*ScoutRes
 	start := time.Now()
 	var result ScoutResult
 	if _, err := p.runner.RunJSON(ctx, "scout", p.cfg.WorkspaceDir, tmplCtx, &result); err != nil {
-		p.recordEvent(issue, nil, "scout", 1, start, "", false, "", err.Error())
+		p.recordEvent(issue, nil, "scout", 1, start, "", false, "", err.Error(), stageRules)
 		return nil, err
 	}
 	summary, _ := json.Marshal(map[string]any{"verdict": result.Verdict, "difficulty": result.Difficulty, "competing_pr": result.HasCompetingPR})
-	p.recordEvent(issue, nil, "scout", 1, start, result.Verdict, result.Verdict == "PROCEED", string(summary), "")
+	p.recordEvent(issue, nil, "scout", 1, start, result.Verdict, result.Verdict == "PROCEED", string(summary), "", stageRules)
 	return &result, nil
 }
 
 // --- Analyst ---
 
 func (p *Pipeline) runAnalyst(ctx context.Context, issue *models.Issue, workspace string, scout *ScoutResult) (*AnalystResult, error) {
+	stageRules := p.ruleLoader.IDsForStage("analyst")
 	scoutJSON, _ := json.MarshalIndent(scout, "", "  ")
 
 	tmplCtx := map[string]any{
@@ -55,7 +57,7 @@ func (p *Pipeline) runAnalyst(ctx context.Context, issue *models.Issue, workspac
 	start := time.Now()
 	var result AnalystResult
 	if _, err := p.runner.RunJSON(ctx, "analyst", workspace, tmplCtx, &result); err != nil {
-		p.recordEvent(issue, nil, "analyst", 1, start, "", false, "", err.Error())
+		p.recordEvent(issue, nil, "analyst", 1, start, "", false, "", err.Error(), stageRules)
 		return nil, err
 	}
 
@@ -67,7 +69,7 @@ func (p *Pipeline) runAnalyst(ctx context.Context, issue *models.Issue, workspac
 	if !result.CanFix {
 		verdict = "cannot_fix"
 	}
-	p.recordEvent(issue, nil, "analyst", 1, start, verdict, result.CanFix, fmt.Sprintf("base_branch=%s files=%d", result.BaseBranch, len(result.FixPlan.FilesToModify)), "")
+	p.recordEvent(issue, nil, "analyst", 1, start, verdict, result.CanFix, fmt.Sprintf("base_branch=%s files=%d", result.BaseBranch, len(result.FixPlan.FilesToModify)), "", stageRules)
 	return &result, nil
 }
 
@@ -139,6 +141,7 @@ func (p *Pipeline) buildReviewerCtx(issue *models.Issue, analyst *AnalystResult,
 // --- Submitter ---
 
 func (p *Pipeline) runSubmitter(ctx context.Context, issue *models.Issue, workspace string, analyst *AnalystResult) (*SubmitResult, error) {
+	stageRules := p.ruleLoader.IDsForStage("submitter")
 	planJSON, _ := json.MarshalIndent(analyst.FixPlan, "", "  ")
 
 	tmplCtx := map[string]any{
@@ -166,16 +169,17 @@ func (p *Pipeline) runSubmitter(ctx context.Context, issue *models.Issue, worksp
 			"output_len":  len(raw),
 			"output_tail": truncate(raw, 500),
 		}).Warn("submitter failed to produce valid JSON")
-		p.recordEvent(issue, nil, "submitter", 1, start, "", false, "", err.Error())
+		p.recordEvent(issue, nil, "submitter", 1, start, "", false, "", err.Error(), stageRules)
 		return nil, err
 	}
-	p.recordEvent(issue, nil, "submitter", 1, start, result.Status, result.Status == "submitted", fmt.Sprintf("pr=%s", result.PRURL), "")
+	p.recordEvent(issue, nil, "submitter", 1, start, result.Status, result.Status == "submitted", fmt.Sprintf("pr=%s", result.PRURL), "", stageRules)
 	return &result, nil
 }
 
 // --- Critic ---
 
 func (p *Pipeline) runCritic(ctx context.Context, issue *models.Issue, workspace string, analyst *AnalystResult, round int) (*CriticResult, error) {
+	criticRules := p.ruleLoader.IDsForStage("critic")
 	planJSON, _ := json.MarshalIndent(analyst.FixPlan, "", "  ")
 
 	tmplCtx := map[string]any{
@@ -194,7 +198,7 @@ func (p *Pipeline) runCritic(ctx context.Context, issue *models.Issue, workspace
 	start := time.Now()
 	var result CriticResult
 	if _, err := p.runner.RunJSON(ctx, "critic", workspace, tmplCtx, &result); err != nil {
-		p.recordEvent(issue, nil, "critic", round, start, "", false, "", err.Error())
+		p.recordEvent(issue, nil, "critic", round, start, "", false, "", err.Error(), criticRules)
 		return nil, err
 	}
 
@@ -207,7 +211,7 @@ func (p *Pipeline) runCritic(ctx context.Context, issue *models.Issue, workspace
 		"severity": result.Severity,
 		"findings": len(result.Findings),
 	})
-	p.recordEvent(issue, nil, "critic", round, start, result.Verdict, result.Verdict == "approve", string(summary), "")
+	p.recordEvent(issue, nil, "critic", round, start, result.Verdict, result.Verdict == "approve", string(summary), "", criticRules)
 	return &result, nil
 }
 
@@ -225,6 +229,8 @@ func (p *Pipeline) criticLoop(ctx context.Context, issue *models.Issue, workspac
 		return err
 	}
 	for round := 1; round <= p.maxCriticRounds; round++ {
+		engineerRules := p.ruleLoader.IDsForStage("engineer")
+		reviewerRules := p.ruleLoader.IDsForStage("reviewer")
 		if err := p.db.UpdateIssueStatus(issue.ID, models.IssueStatusReviewing, ""); err != nil {
 			log.WithError(err).Warn("update status to reviewing (critic)")
 		}
@@ -318,13 +324,13 @@ func (p *Pipeline) criticLoop(ctx context.Context, issue *models.Issue, workspac
 		engStart := time.Now()
 		raw, err := p.runner.Run(ctx, "engineer", workspace, engCtx)
 		if err != nil {
-			p.recordEvent(issue, nil, "engineer", round, engStart, "", false, "", err.Error())
+			p.recordEvent(issue, nil, "engineer", round, engStart, "", false, "", err.Error(), engineerRules)
 			p.markFailed(issue, "engineer_failed_critic_rework", err.Error())
 			return err
 		}
 
 		fixComplete := containsMarker(raw, "FIX_COMPLETE")
-		p.recordEvent(issue, nil, "engineer", round, engStart, fmt.Sprintf("fix_complete=%v critic_rework=true", fixComplete), fixComplete, "", "")
+		p.recordEvent(issue, nil, "engineer", round, engStart, fmt.Sprintf("fix_complete=%v critic_rework=true", fixComplete), fixComplete, "", "", engineerRules)
 		if !fixComplete {
 			log.WithFields(Fields{
 				"repo":  issue.Repo,
@@ -345,11 +351,11 @@ func (p *Pipeline) criticLoop(ctx context.Context, issue *models.Issue, workspac
 		revCtx := p.buildReviewerCtx(issue, analyst, round, nil)
 		revStart := time.Now()
 		if _, err := p.runner.RunJSON(ctx, "reviewer", workspace, revCtx, &postCriticReview); err != nil {
-			p.recordEvent(issue, nil, "reviewer", round, revStart, "", false, "", err.Error())
+			p.recordEvent(issue, nil, "reviewer", round, revStart, "", false, "", err.Error(), reviewerRules)
 			p.markFailed(issue, "reviewer_parse_error_after_critic_rework", err.Error())
 			return fmt.Errorf("reviewer parse error after critic rework at round %d for %s#%d: %w", round, issue.Repo, issue.IssueNumber, err)
 		}
-		p.recordEvent(issue, nil, "reviewer", round, revStart, postCriticReview.Verdict, postCriticReview.Verdict == "approve", "", "")
+		p.recordEvent(issue, nil, "reviewer", round, revStart, postCriticReview.Verdict, postCriticReview.Verdict == "approve", "", "", reviewerRules)
 		if postCriticReview.Verdict != "approve" {
 			p.markAbandoned(issue, fmt.Sprintf("reviewer rejected code after critic rework at round %d", round))
 			return fmt.Errorf("reviewer rejected critic-driven rework at round %d for %s#%d: %s",
@@ -371,6 +377,9 @@ func (p *Pipeline) engineerReviewLoopWithStats(ctx context.Context, issue *model
 	var lastReview *CodeReviewResult
 	lastSummary := ""
 
+	engineerRules := p.ruleLoader.IDsForStage("engineer")
+	reviewerRules := p.ruleLoader.IDsForStage("reviewer")
+
 	for round := 1; round <= p.maxReview; round++ {
 		// Engineer
 		if err := p.db.UpdateIssueStatus(issue.ID, models.IssueStatusEngineering, ""); err != nil {
@@ -381,7 +390,7 @@ func (p *Pipeline) engineerReviewLoopWithStats(ctx context.Context, issue *model
 		engStart := time.Now()
 		raw, err := p.runner.Run(ctx, "engineer", workspace, engCtx)
 		if err != nil {
-			p.recordEvent(issue, nil, "engineer", round, engStart, "", false, "", err.Error())
+			p.recordEvent(issue, nil, "engineer", round, engStart, "", false, "", err.Error(), engineerRules)
 			p.markFailed(issue, "engineer_failed", err.Error())
 			return round, lastSummary, err
 		}
@@ -394,7 +403,7 @@ func (p *Pipeline) engineerReviewLoopWithStats(ctx context.Context, issue *model
 				"round": round,
 			}).Warn("engineer did not produce FIX_COMPLETE marker, proceeding to review anyway")
 		}
-		p.recordEvent(issue, nil, "engineer", round, engStart, fmt.Sprintf("fix_complete=%v", fixComplete), fixComplete, "", "")
+		p.recordEvent(issue, nil, "engineer", round, engStart, fmt.Sprintf("fix_complete=%v", fixComplete), fixComplete, "", "", engineerRules)
 
 		// Reviewer
 		if err := p.db.UpdateIssueStatus(issue.ID, models.IssueStatusReviewing, ""); err != nil {
@@ -410,7 +419,7 @@ func (p *Pipeline) engineerReviewLoopWithStats(ctx context.Context, issue *model
 		}
 		reviewSummaryJSON, _ := json.Marshal(map[string]any{"verdict": review.Verdict, "confidence": review.Confidence, "issues": len(review.IssuesFound)})
 		lastSummary = review.Summary
-		p.recordEvent(issue, nil, "reviewer", round, revStart, review.Verdict, review.Verdict == "approve", string(reviewSummaryJSON), "")
+		p.recordEvent(issue, nil, "reviewer", round, revStart, review.Verdict, review.Verdict == "approve", string(reviewSummaryJSON), "", reviewerRules)
 
 		p.logReview(issue, &review, round)
 

--- a/internal/pipeline/agents.go
+++ b/internal/pipeline/agents.go
@@ -13,14 +13,14 @@ import (
 // --- Scout ---
 
 func (p *Pipeline) runScout(ctx context.Context, issue *models.Issue) (*ScoutResult, error) {
-	stageRules := p.ruleLoader.IDsForPrompt("scout")
+	stageRules, rulesFormatted := p.ruleLoader.PromptSnapshot("scout")
 	tmplCtx := map[string]any{
 		"Repo":        issue.Repo,
 		"IssueNumber": issue.IssueNumber,
 		"IssueTitle":  issue.Title,
 		"IssueBody":   issue.Body,
 		"IssueLabels": issue.Labels,
-		"Rules":       p.ruleLoader.FormatForPrompt("scout"),
+		"Rules":       rulesFormatted,
 	}
 
 	// Inject repo_structure lessons so scout can detect wrong-repo patterns
@@ -42,7 +42,7 @@ func (p *Pipeline) runScout(ctx context.Context, issue *models.Issue) (*ScoutRes
 // --- Analyst ---
 
 func (p *Pipeline) runAnalyst(ctx context.Context, issue *models.Issue, workspace string, scout *ScoutResult) (*AnalystResult, error) {
-	stageRules := p.ruleLoader.IDsForPrompt("analyst")
+	stageRules, rulesFormatted := p.ruleLoader.PromptSnapshot("analyst")
 	scoutJSON, _ := json.MarshalIndent(scout, "", "  ")
 
 	tmplCtx := map[string]any{
@@ -51,7 +51,7 @@ func (p *Pipeline) runAnalyst(ctx context.Context, issue *models.Issue, workspac
 		"IssueTitle":  issue.Title,
 		"IssueBody":   issue.Body,
 		"ScoutResult": string(scoutJSON),
-		"Rules":       p.ruleLoader.FormatForPrompt("analyst"),
+		"Rules":       rulesFormatted,
 	}
 
 	start := time.Now()
@@ -75,7 +75,7 @@ func (p *Pipeline) runAnalyst(ctx context.Context, issue *models.Issue, workspac
 
 // --- Engineer context ---
 
-func (p *Pipeline) buildEngineerCtx(issue *models.Issue, analyst *AnalystResult, lastReview *CodeReviewResult, round int) map[string]any {
+func (p *Pipeline) buildEngineerCtx(issue *models.Issue, analyst *AnalystResult, lastReview *CodeReviewResult, round int, rulesFormatted string) map[string]any {
 	planJSON, _ := json.MarshalIndent(analyst.FixPlan, "", "  ")
 
 	ctx := map[string]any{
@@ -108,13 +108,13 @@ func (p *Pipeline) buildEngineerCtx(issue *models.Issue, analyst *AnalystResult,
 		ctx["SimilarTrajectories"] = formatTrajectoriesForPrompt(trajs)
 	}
 
-	ctx["Rules"] = p.ruleLoader.FormatForPrompt("engineer")
+	ctx["Rules"] = rulesFormatted
 	return ctx
 }
 
 // --- Reviewer context ---
 
-func (p *Pipeline) buildReviewerCtx(issue *models.Issue, analyst *AnalystResult, round int, lastReview *CodeReviewResult) map[string]any {
+func (p *Pipeline) buildReviewerCtx(issue *models.Issue, analyst *AnalystResult, round int, lastReview *CodeReviewResult, rulesFormatted string) map[string]any {
 	planJSON, _ := json.MarshalIndent(analyst.FixPlan, "", "  ")
 
 	ctx := map[string]any{
@@ -134,14 +134,14 @@ func (p *Pipeline) buildReviewerCtx(issue *models.Issue, analyst *AnalystResult,
 		ctx["PreviousReview"] = string(prevJSON)
 	}
 
-	ctx["Rules"] = p.ruleLoader.FormatForPrompt("reviewer")
+	ctx["Rules"] = rulesFormatted
 	return ctx
 }
 
 // --- Submitter ---
 
 func (p *Pipeline) runSubmitter(ctx context.Context, issue *models.Issue, workspace string, analyst *AnalystResult) (*SubmitResult, error) {
-	stageRules := p.ruleLoader.IDsForPrompt("submitter")
+	stageRules, rulesFormatted := p.ruleLoader.PromptSnapshot("submitter")
 	planJSON, _ := json.MarshalIndent(analyst.FixPlan, "", "  ")
 
 	tmplCtx := map[string]any{
@@ -156,7 +156,7 @@ func (p *Pipeline) runSubmitter(ctx context.Context, issue *models.Issue, worksp
 		"PRTitle":        issue.Title,
 		"ChangesSummary": analyst.FixPlan.Description,
 		"TestPlan":       analyst.FixPlan.TestStrategy,
-		"Rules":          p.ruleLoader.FormatForPrompt("submitter"),
+		"Rules":          rulesFormatted,
 	}
 
 	start := time.Now()
@@ -179,7 +179,7 @@ func (p *Pipeline) runSubmitter(ctx context.Context, issue *models.Issue, worksp
 // --- Critic ---
 
 func (p *Pipeline) runCritic(ctx context.Context, issue *models.Issue, workspace string, analyst *AnalystResult, round int) (*CriticResult, error) {
-	criticRules := p.ruleLoader.IDsForPrompt("critic")
+	criticRules, rulesFormatted := p.ruleLoader.PromptSnapshot("critic")
 	planJSON, _ := json.MarshalIndent(analyst.FixPlan, "", "  ")
 
 	tmplCtx := map[string]any{
@@ -192,7 +192,7 @@ func (p *Pipeline) runCritic(ctx context.Context, issue *models.Issue, workspace
 		"CICommands":  analyst.CICommands,
 		"CriticRound": round,
 		"MaxRounds":   p.maxCriticRounds,
-		"Rules":       p.ruleLoader.FormatForPrompt("critic"),
+		"Rules":       rulesFormatted,
 	}
 
 	start := time.Now()
@@ -229,8 +229,8 @@ func (p *Pipeline) criticLoop(ctx context.Context, issue *models.Issue, workspac
 		return err
 	}
 	for round := 1; round <= p.maxCriticRounds; round++ {
-		engineerRules := p.ruleLoader.IDsForPrompt("engineer")
-		reviewerRules := p.ruleLoader.IDsForPrompt("reviewer")
+		engineerRules, engRulesFormatted := p.ruleLoader.PromptSnapshot("engineer")
+		reviewerRules, revRulesFormatted := p.ruleLoader.PromptSnapshot("reviewer")
 		if err := p.db.UpdateIssueStatus(issue.ID, models.IssueStatusReviewing, ""); err != nil {
 			log.WithError(err).Warn("update status to reviewing (critic)")
 		}
@@ -320,7 +320,7 @@ func (p *Pipeline) criticLoop(ctx context.Context, issue *models.Issue, workspac
 		criticRework := &CodeReviewResult{
 			ReworkInstructions: criticResult.ReworkInstructions,
 		}
-		engCtx := p.buildEngineerCtx(issue, analyst, criticRework, round)
+		engCtx := p.buildEngineerCtx(issue, analyst, criticRework, round, engRulesFormatted)
 		engStart := time.Now()
 		raw, err := p.runner.Run(ctx, "engineer", workspace, engCtx)
 		if err != nil {
@@ -348,7 +348,7 @@ func (p *Pipeline) criticLoop(ctx context.Context, issue *models.Issue, workspac
 			log.WithError(err).Warn("update status to reviewing (post-critic-rework)")
 		}
 		var postCriticReview CodeReviewResult
-		revCtx := p.buildReviewerCtx(issue, analyst, round, nil)
+		revCtx := p.buildReviewerCtx(issue, analyst, round, nil, revRulesFormatted)
 		revStart := time.Now()
 		if _, err := p.runner.RunJSON(ctx, "reviewer", workspace, revCtx, &postCriticReview); err != nil {
 			p.recordEvent(issue, nil, "reviewer", round, revStart, "", false, "", err.Error(), reviewerRules)
@@ -377,16 +377,16 @@ func (p *Pipeline) engineerReviewLoopWithStats(ctx context.Context, issue *model
 	var lastReview *CodeReviewResult
 	lastSummary := ""
 
-	engineerRules := p.ruleLoader.IDsForPrompt("engineer")
-	reviewerRules := p.ruleLoader.IDsForPrompt("reviewer")
-
 	for round := 1; round <= p.maxReview; round++ {
+		engineerRules, engRulesFormatted := p.ruleLoader.PromptSnapshot("engineer")
+		reviewerRules, revRulesFormatted := p.ruleLoader.PromptSnapshot("reviewer")
+
 		// Engineer
 		if err := p.db.UpdateIssueStatus(issue.ID, models.IssueStatusEngineering, ""); err != nil {
 			log.WithError(err).Warn("update status to engineering")
 		}
 
-		engCtx := p.buildEngineerCtx(issue, analyst, lastReview, round)
+		engCtx := p.buildEngineerCtx(issue, analyst, lastReview, round, engRulesFormatted)
 		engStart := time.Now()
 		raw, err := p.runner.Run(ctx, "engineer", workspace, engCtx)
 		if err != nil {
@@ -411,7 +411,7 @@ func (p *Pipeline) engineerReviewLoopWithStats(ctx context.Context, issue *model
 		}
 
 		var review CodeReviewResult
-		revCtx := p.buildReviewerCtx(issue, analyst, round, lastReview)
+		revCtx := p.buildReviewerCtx(issue, analyst, round, lastReview, revRulesFormatted)
 		revStart := time.Now()
 		if _, err := p.runner.RunJSON(ctx, "reviewer", workspace, revCtx, &review); err != nil {
 			log.WithError(err).Warn("reviewer parse error, treating as approve")

--- a/internal/pipeline/feedback.go
+++ b/internal/pipeline/feedback.go
@@ -82,6 +82,9 @@ func (p *Pipeline) ProcessPR(ctx context.Context, pr *models.PullRequest) error 
 			} else {
 				p.db.UpdatePRStatus(pr.ID, models.PRStatusClosed)
 			}
+			prInfo.State = "CLOSED"
+			p.extractAndStoreLessons(ctx, pr, prRepo, prInfo)
+			p.updateQValues(pr.IssueID)
 		}
 		return nil
 	}
@@ -149,6 +152,9 @@ func (p *Pipeline) handleDraft(ctx context.Context, pr *models.PullRequest, prRe
 				} else {
 					p.db.UpdatePRStatus(pr.ID, models.PRStatusClosed)
 				}
+				prInfo.State = "CLOSED"
+				p.extractAndStoreLessons(ctx, pr, prRepo, prInfo)
+				p.updateQValues(pr.IssueID)
 			}
 			return nil
 		}

--- a/internal/pipeline/feedback.go
+++ b/internal/pipeline/feedback.go
@@ -42,6 +42,7 @@ func (p *Pipeline) ProcessPR(ctx context.Context, pr *models.PullRequest) error 
 			return fmt.Errorf("update PR status to merged: %w", err)
 		}
 		p.extractAndStoreLessons(ctx, pr, prRepo, prInfo)
+		p.updateQValues(pr.IssueID)
 		p.cleanupWorkspace(pr)
 		log.WithField("pr", pr.PRURL).Info("PR merged")
 		return nil
@@ -54,6 +55,7 @@ func (p *Pipeline) ProcessPR(ctx context.Context, pr *models.PullRequest) error 
 			return fmt.Errorf("update PR status to closed: %w", err)
 		}
 		p.extractAndStoreLessons(ctx, pr, prRepo, prInfo)
+		p.updateQValues(pr.IssueID)
 		p.cleanupWorkspace(pr)
 		log.WithField("pr", pr.PRURL).Info("PR closed")
 		return nil

--- a/internal/pipeline/feedback.go
+++ b/internal/pipeline/feedback.go
@@ -79,12 +79,13 @@ func (p *Pipeline) ProcessPR(ctx context.Context, pr *models.PullRequest) error 
 			// terminalAt is empty: we just triggered the close so time.Now()≈close time.
 			if err := p.db.RecordPROutcome(pr.ID, prRepo, false, prResponseHours(prInfo.CreatedAt, "", pr.CreatedAt)); err != nil {
 				log.WithError(err).Warn("failed to record stale auto-close outcome")
+			} else if err := p.db.UpdatePRStatus(pr.ID, models.PRStatusClosed); err != nil {
+				log.WithError(err).Warn("failed to update PR status to closed after stale auto-close")
 			} else {
-				p.db.UpdatePRStatus(pr.ID, models.PRStatusClosed)
+				prInfo.State = "CLOSED"
+				p.extractAndStoreLessons(ctx, pr, prRepo, prInfo)
+				p.updateQValues(pr.IssueID)
 			}
-			prInfo.State = "CLOSED"
-			p.extractAndStoreLessons(ctx, pr, prRepo, prInfo)
-			p.updateQValues(pr.IssueID)
 		}
 		return nil
 	}
@@ -149,12 +150,13 @@ func (p *Pipeline) handleDraft(ctx context.Context, pr *models.PullRequest, prRe
 				// ordering as the stale auto-close path above).
 				if err := p.db.RecordPROutcome(pr.ID, prRepo, false, prResponseHours(prInfo.CreatedAt, "", pr.CreatedAt)); err != nil {
 					log.WithError(err).Warn("failed to record CI auto-close outcome")
+				} else if err := p.db.UpdatePRStatus(pr.ID, models.PRStatusClosed); err != nil {
+					log.WithError(err).Warn("failed to update PR status to closed after CI auto-close")
 				} else {
-					p.db.UpdatePRStatus(pr.ID, models.PRStatusClosed)
+					prInfo.State = "CLOSED"
+					p.extractAndStoreLessons(ctx, pr, prRepo, prInfo)
+					p.updateQValues(pr.IssueID)
 				}
-				prInfo.State = "CLOSED"
-				p.extractAndStoreLessons(ctx, pr, prRepo, prInfo)
-				p.updateQValues(pr.IssueID)
 			}
 			return nil
 		}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -2,6 +2,7 @@ package pipeline
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -96,8 +97,15 @@ func (p *Pipeline) saveTrajectory(issue *models.Issue, scout *ScoutResult, analy
 }
 
 // recordEvent records a pipeline event for learning. Non-fatal on error.
-func (p *Pipeline) recordEvent(issue *models.Issue, prID *int64, stage string, round int, startedAt time.Time, verdict string, success bool, outputSummary string, errMsg string) {
+// ruleIDs is the list of rule IDs that were injected into the agent prompt for this stage.
+func (p *Pipeline) recordEvent(issue *models.Issue, prID *int64, stage string, round int, startedAt time.Time, verdict string, success bool, outputSummary string, errMsg string, ruleIDs []string) {
 	now := time.Now()
+	var experiencesUsed string
+	if len(ruleIDs) > 0 {
+		if b, err := marshalRuleIDs(ruleIDs); err == nil {
+			experiencesUsed = b
+		}
+	}
 	event := &models.PipelineEvent{
 		IssueID:         issue.ID,
 		PRID:            prID,
@@ -112,10 +120,20 @@ func (p *Pipeline) recordEvent(issue *models.Issue, prID *int64, stage string, r
 		Verdict:         verdict,
 		Success:         success,
 		ErrorMessage:    truncate(errMsg, 500),
+		ExperiencesUsed: experiencesUsed,
 	}
 	if err := p.db.RecordEvent(event); err != nil {
 		log.WithFields(Fields{"error": err, "stage": stage}).Warn("failed to record pipeline event")
 	}
+}
+
+// marshalRuleIDs encodes a slice of rule IDs to a JSON string.
+func marshalRuleIDs(ids []string) (string, error) {
+	b, err := json.Marshal(ids)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
 }
 
 // ProcessIssue runs the full pipeline for a single issue.

--- a/internal/pipeline/qvalue.go
+++ b/internal/pipeline/qvalue.go
@@ -1,0 +1,119 @@
+package pipeline
+
+import (
+	"encoding/json"
+
+	"github.com/majiayu000/auto-contributor/internal/rules"
+)
+
+// qAlpha is the MemRL learning rate for Q-value updates.
+// Q_new = Q_old + alpha * (reward - Q_old)
+const qAlpha = 0.1
+
+// rewardForOutcome maps outcome labels to scalar rewards.
+//
+//	merged        → 1.0  (full positive signal)
+//	unknown_closed → 0.2  (closed without clear reason; may not be our fault)
+//	everything else → 0.0  (rejected for a specific reason)
+func rewardForOutcome(outcomeLabel string) float64 {
+	switch outcomeLabel {
+	case OutcomeMerged:
+		return 1.0
+	case OutcomeUnknownClosed:
+		return 0.2
+	default:
+		return 0.0
+	}
+}
+
+// updateQValues backward-updates Q-values for all rules that participated in the
+// pipeline for the given issue, once the PR has reached a terminal state.
+//
+// It reads experiences_used from each pipeline event (set at agent-run time),
+// collects unique rule IDs, then applies the MemRL update rule:
+//
+//	Q_new = Q_old + alpha * (reward - Q_old)
+//
+// Called after extractAndStoreLessons, which has already labelled all events
+// with the outcome via LabelEventsByIssue.
+func (p *Pipeline) updateQValues(issueID int64) {
+	events, err := p.db.GetEventsByIssue(issueID)
+	if err != nil || len(events) == 0 {
+		return
+	}
+
+	// Determine outcome from the first event that has a label set.
+	var outcomeLabel string
+	for _, e := range events {
+		if e.OutcomeLabel != "" {
+			outcomeLabel = e.OutcomeLabel
+			break
+		}
+	}
+	if outcomeLabel == "" {
+		return
+	}
+
+	reward := rewardForOutcome(outcomeLabel)
+	rulesDir := p.ruleLoader.RulesDir()
+
+	// Collect unique rule IDs across all events for this issue.
+	seen := make(map[string]bool)
+	var ruleIDs []string
+	for _, e := range events {
+		if e.ExperiencesUsed == "" {
+			continue
+		}
+		var ids []string
+		if err := json.Unmarshal([]byte(e.ExperiencesUsed), &ids); err != nil {
+			continue
+		}
+		for _, id := range ids {
+			if !seen[id] {
+				seen[id] = true
+				ruleIDs = append(ruleIDs, id)
+			}
+		}
+	}
+
+	if len(ruleIDs) == 0 {
+		return
+	}
+
+	// Apply Q-value update for each participating rule.
+	updated := 0
+	for _, ruleID := range ruleIDs {
+		r := p.ruleLoader.ByID(ruleID)
+		if r == nil {
+			continue
+		}
+
+		// Initialise QValue to 0.5 for rules that predate this feature.
+		qOld := r.QValue
+		if qOld == 0 {
+			qOld = 0.5
+		}
+
+		newQ := qOld + qAlpha*(reward-qOld)
+		newRetrievals := r.RetrievalCount + 1
+		newSuccess := r.SuccessCount
+		if reward >= 1.0 {
+			newSuccess++
+		}
+
+		if err := rules.UpdateRuleQValue(rulesDir, ruleID, r.Stage, newQ, newRetrievals, newSuccess); err != nil {
+			log.WithFields(Fields{"rule": ruleID, "error": err}).Warn("failed to update rule Q-value")
+			continue
+		}
+		updated++
+	}
+
+	if updated > 0 {
+		log.WithFields(Fields{
+			"issue":   issueID,
+			"outcome": outcomeLabel,
+			"rules":   updated,
+			"reward":  reward,
+		}).Info("updated rule Q-values (MemRL)")
+	}
+}

--- a/internal/pipeline/qvalue.go
+++ b/internal/pipeline/qvalue.go
@@ -2,6 +2,7 @@ package pipeline
 
 import (
 	"encoding/json"
+	"strings"
 
 	"github.com/majiayu000/auto-contributor/internal/rules"
 )
@@ -12,8 +13,10 @@ const qAlpha = 0.1
 
 // rewardForOutcome maps outcome labels to scalar rewards.
 //
-//	merged        → 1.0  (full positive signal)
+//	merged         → 1.0  (full positive signal)
 //	unknown_closed → 0.2  (closed without clear reason; may not be our fault)
+//	auto_closed    → 0.5  (closed for external reasons such as inactivity/CI timeout;
+//	                       not attributable to rule quality — neutral signal)
 //	everything else → 0.0  (rejected for a specific reason)
 func rewardForOutcome(outcomeLabel string) float64 {
 	switch outcomeLabel {
@@ -21,6 +24,8 @@ func rewardForOutcome(outcomeLabel string) float64 {
 		return 1.0
 	case OutcomeUnknownClosed:
 		return 0.2
+	case OutcomeAutoClosed:
+		return 0.5
 	default:
 		return 0.0
 	}
@@ -57,9 +62,10 @@ func (p *Pipeline) updateQValues(issueID int64) {
 	reward := rewardForOutcome(outcomeLabel)
 	rulesDir := p.ruleLoader.RulesDir()
 
-	// Collect unique rule IDs across all events for this issue.
+	// Collect unique participation keys across all events for this issue.
+	// Keys are stored as "stage/ruleID" (new format) or bare "ruleID" (legacy).
 	seen := make(map[string]bool)
-	var ruleIDs []string
+	var participantKeys []string
 	for _, e := range events {
 		if e.ExperiencesUsed == "" {
 			continue
@@ -71,38 +77,47 @@ func (p *Pipeline) updateQValues(issueID int64) {
 		for _, id := range ids {
 			if !seen[id] {
 				seen[id] = true
-				ruleIDs = append(ruleIDs, id)
+				participantKeys = append(participantKeys, id)
 			}
 		}
 	}
 
-	if len(ruleIDs) == 0 {
+	if len(participantKeys) == 0 {
 		return
 	}
 
 	// Apply Q-value update for each participating rule.
 	updated := 0
-	for _, ruleID := range ruleIDs {
-		r := p.ruleLoader.ByID(ruleID)
-		if r == nil {
+	for _, key := range participantKeys {
+		// Keys are stored as "stage/ruleID" (new format) or bare "ruleID" (legacy).
+		var rule *rules.Rule
+		var ruleID string
+		if idx := strings.Index(key, "/"); idx >= 0 {
+			rule = p.ruleLoader.ByStageAndID(key[:idx], key[idx+1:])
+			ruleID = key[idx+1:]
+		} else {
+			rule = p.ruleLoader.ByID(key)
+			ruleID = key
+		}
+		if rule == nil {
 			continue
 		}
 
 		// Initialise QValue to 0.5 for rules that predate this feature.
-		qOld := r.QValue
+		qOld := rule.QValue
 		if qOld == 0 {
 			qOld = 0.5
 		}
 
 		newQ := qOld + qAlpha*(reward-qOld)
-		newRetrievals := r.RetrievalCount + 1
-		newSuccess := r.SuccessCount
+		newRetrievals := rule.RetrievalCount + 1
+		newSuccess := rule.SuccessCount
 		if reward >= 1.0 {
 			newSuccess++
 		}
 
-		if err := rules.UpdateRuleQValue(rulesDir, ruleID, r.Stage, newQ, newRetrievals, newSuccess); err != nil {
-			log.WithFields(Fields{"rule": ruleID, "error": err}).Warn("failed to update rule Q-value")
+		if err := rules.UpdateRuleQValue(rulesDir, ruleID, rule.Stage, newQ, newRetrievals, newSuccess); err != nil {
+			log.WithFields(Fields{"rule": key, "error": err}).Warn("failed to update rule Q-value")
 			continue
 		}
 		updated++

--- a/internal/pipeline/qvalue.go
+++ b/internal/pipeline/qvalue.go
@@ -109,6 +109,11 @@ func (p *Pipeline) updateQValues(issueID int64) {
 	}
 
 	if updated > 0 {
+		// Reload in-memory cache so subsequent calls in this process use the
+		// freshly-written Q-values/counters rather than the stale baseline.
+		if err := p.ruleLoader.Reload(); err != nil {
+			log.WithError(err).Warn("failed to reload rules after Q-value update")
+		}
 		log.WithFields(Fields{
 			"issue":   issueID,
 			"outcome": outcomeLabel,

--- a/internal/rules/loader.go
+++ b/internal/rules/loader.go
@@ -171,11 +171,14 @@ func (rl *RuleLoader) FormatForPrompt(stage string) string {
 		return ""
 	}
 
+	const header = "## Self-Learning Rules\n\nFollow these rules based on past experience:\n\n"
 	var sb strings.Builder
-	sb.WriteString("## Self-Learning Rules\n\n")
-	sb.WriteString("Follow these rules based on past experience:\n\n")
+	sb.WriteString(header)
 
-	total := 0
+	// Start total at len(header) so the budget matches IDsForPrompt exactly;
+	// without this, FormatForPrompt could include more entries than IDsForPrompt
+	// reports, causing rules to be injected but not credited in experiences_used.
+	total := len(header)
 	for _, r := range matched {
 		entry := fmt.Sprintf("### %s (confidence: %.2f)\n\n%s\n\n---\n\n", r.ID, r.Confidence, r.Body)
 		if total+len(entry) > MaxPromptChars {

--- a/internal/rules/loader.go
+++ b/internal/rules/loader.go
@@ -196,7 +196,8 @@ func (rl *RuleLoader) FormatForPrompt(stage string) string {
 func (rl *RuleLoader) InjectedRuleIDsForStage(stage string) map[string]bool {
 	matched := rl.ForStage(stage)
 	injected := make(map[string]bool)
-	total := 0
+	const header = "## Self-Learning Rules\n\nFollow these rules based on past experience:\n\n"
+	total := len(header)
 	for _, r := range matched {
 		entry := fmt.Sprintf("### %s (confidence: %.2f)\n\n%s\n\n---\n\n", r.ID, r.Confidence, r.Body)
 		if total+len(entry) > MaxPromptChars {
@@ -206,6 +207,36 @@ func (rl *RuleLoader) InjectedRuleIDsForStage(stage string) map[string]bool {
 		total += len(entry)
 	}
 	return injected
+}
+
+// PromptSnapshot returns both the rule IDs and formatted text for stage from a
+// single ForStage call, so IDsForPrompt and FormatForPrompt cannot diverge due
+// to a concurrent Reload between two separate calls.
+func (rl *RuleLoader) PromptSnapshot(stage string) (ids []string, formatted string) {
+	matched := rl.ForStage(stage)
+	if len(matched) == 0 {
+		return nil, ""
+	}
+
+	const header = "## Self-Learning Rules\n\nFollow these rules based on past experience:\n\n"
+	var sb strings.Builder
+	sb.WriteString(header)
+	total := len(header)
+
+	for _, r := range matched {
+		entry := fmt.Sprintf("### %s (confidence: %.2f)\n\n%s\n\n---\n\n", r.ID, r.Confidence, r.Body)
+		if total+len(entry) > MaxPromptChars {
+			break
+		}
+		ids = append(ids, r.Stage+"/"+r.ID)
+		sb.WriteString(entry)
+		total += len(entry)
+	}
+
+	if len(ids) > 0 {
+		formatted = sb.String()
+	}
+	return ids, formatted
 }
 
 // ByID finds a rule by its ID. When multiple rules share an ID across stages,

--- a/internal/rules/loader.go
+++ b/internal/rules/loader.go
@@ -131,6 +131,17 @@ func (rl *RuleLoader) ForStage(stage string) []*Rule {
 	return matched
 }
 
+// IDsForStage returns the IDs of rules that would be injected for a given stage.
+// This is used to record which rules were active when an agent ran (for Q-value tracking).
+func (rl *RuleLoader) IDsForStage(stage string) []string {
+	matched := rl.ForStage(stage)
+	ids := make([]string, 0, len(matched))
+	for _, r := range matched {
+		ids = append(ids, r.ID)
+	}
+	return ids
+}
+
 // FormatForPrompt returns concatenated rule bodies as Markdown for prompt injection.
 func (rl *RuleLoader) FormatForPrompt(stage string) string {
 	matched := rl.ForStage(stage)

--- a/internal/rules/loader.go
+++ b/internal/rules/loader.go
@@ -44,12 +44,9 @@ func (rl *RuleLoader) Load() error {
 	return rl.readFromDisk()
 }
 
-// Reload re-reads rules from disk. It holds writeMu so it cannot read a file
-// that is currently being truncated or written by a concurrent WriteRule /
-// UpdateRuleQValue call.
+// Reload re-reads rules from disk. readFromDisk acquires writeMu internally
+// so it cannot read a file being written by a concurrent WriteRule/UpdateRuleQValue call.
 func (rl *RuleLoader) Reload() error {
-	writeMu.Lock()
-	defer writeMu.Unlock()
 	return rl.readFromDisk()
 }
 

--- a/internal/rules/loader.go
+++ b/internal/rules/loader.go
@@ -39,7 +39,23 @@ func (rl *RuleLoader) RulesDir() string {
 }
 
 // Load reads all YAML files from the rules directory.
+// Call this at startup before any write goroutines are running.
 func (rl *RuleLoader) Load() error {
+	return rl.readFromDisk()
+}
+
+// Reload re-reads rules from disk. It holds writeMu so it cannot read a file
+// that is currently being truncated or written by a concurrent WriteRule /
+// UpdateRuleQValue call.
+func (rl *RuleLoader) Reload() error {
+	writeMu.Lock()
+	defer writeMu.Unlock()
+	return rl.readFromDisk()
+}
+
+// readFromDisk walks the rules directory and reloads the in-memory cache.
+// Callers are responsible for holding writeMu when concurrent writes may occur.
+func (rl *RuleLoader) readFromDisk() error {
 	if rl.rulesDir == "" {
 		return nil
 	}
@@ -102,11 +118,6 @@ func (rl *RuleLoader) Load() error {
 	return nil
 }
 
-// Reload re-reads rules from disk.
-func (rl *RuleLoader) Reload() error {
-	return rl.Load()
-}
-
 // All returns all loaded rules.
 func (rl *RuleLoader) All() []*Rule {
 	rl.mu.RLock()
@@ -142,10 +153,10 @@ func (rl *RuleLoader) IDsForStage(stage string) []string {
 	return ids
 }
 
-// IDsForPrompt returns the IDs of rules that were actually included in the prompt
-// for a given stage, honouring the same MaxPromptChars budget as FormatForPrompt.
-// Use this instead of IDsForStage when recording Q-value participation, so that
-// rules truncated out of the prompt are not credited or penalised for outcomes.
+// IDsForPrompt returns the participation keys of rules actually included in the
+// prompt for a given stage, honouring the same MaxPromptChars budget as
+// FormatForPrompt. Keys are returned as "stage/ruleID" so that Q-value updates
+// can resolve rules unambiguously even when IDs are not unique across stages.
 func (rl *RuleLoader) IDsForPrompt(stage string) []string {
 	matched := rl.ForStage(stage)
 
@@ -158,7 +169,7 @@ func (rl *RuleLoader) IDsForPrompt(stage string) []string {
 		if total+len(entry) > MaxPromptChars {
 			break
 		}
-		ids = append(ids, r.ID)
+		ids = append(ids, r.Stage+"/"+r.ID)
 		total += len(entry)
 	}
 	return ids
@@ -208,7 +219,8 @@ func (rl *RuleLoader) InjectedRuleIDsForStage(stage string) map[string]bool {
 	return injected
 }
 
-// ByID finds a rule by its ID.
+// ByID finds a rule by its ID. When multiple rules share an ID across stages,
+// the first match is returned. Prefer ByStageAndID for unambiguous lookup.
 func (rl *RuleLoader) ByID(id string) *Rule {
 	rl.mu.RLock()
 	defer rl.mu.RUnlock()
@@ -261,6 +273,20 @@ func (rl *RuleLoader) HasSemanticMatch(id string, tags []string, stage string) (
 		}
 	}
 	return false, ""
+}
+
+// ByStageAndID finds a rule by its stage and ID, avoiding false matches when
+// IDs are not unique across stages.
+func (rl *RuleLoader) ByStageAndID(stage, id string) *Rule {
+	rl.mu.RLock()
+	defer rl.mu.RUnlock()
+
+	for _, r := range rl.rules {
+		if r.ID == id && r.Stage == stage {
+			return r
+		}
+	}
+	return nil
 }
 
 // HasSemanticMatchAmong checks whether any rule in the provided candidates slice is

--- a/internal/rules/loader.go
+++ b/internal/rules/loader.go
@@ -142,17 +142,6 @@ func (rl *RuleLoader) ForStage(stage string) []*Rule {
 	return matched
 }
 
-// IDsForStage returns the IDs of rules that pass the confidence filter for a given stage.
-// This is used to record which rules were active when an agent ran (for Q-value tracking).
-func (rl *RuleLoader) IDsForStage(stage string) []string {
-	matched := rl.ForStage(stage)
-	ids := make([]string, 0, len(matched))
-	for _, r := range matched {
-		ids = append(ids, r.ID)
-	}
-	return ids
-}
-
 // IDsForPrompt returns the participation keys of rules actually included in the
 // prompt for a given stage, honouring the same MaxPromptChars budget as
 // FormatForPrompt. Keys are returned as "stage/ruleID" so that Q-value updates

--- a/internal/rules/loader.go
+++ b/internal/rules/loader.go
@@ -50,12 +50,12 @@ func (rl *RuleLoader) Load() error {
 	}
 
 	var loaded []*Rule
-	// Hold fileMu for the entire walk so we cannot read a file that a concurrent
+	// Hold writeMu for the entire walk so we cannot read a file that a concurrent
 	// writer (UpdateRuleConfidence, UpdateRuleLastValidatedAt, WriteRule, DeleteRule)
 	// has only partially written.  Without this lock, os.ReadFile can observe a
 	// truncated or zero-byte file mid-os.WriteFile, producing a malformed YAML
 	// unmarshal that silently drops the rule from in-memory state.
-	fileMu.Lock()
+	writeMu.Lock()
 	err = filepath.Walk(rl.rulesDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return nil // skip unreadable files
@@ -82,7 +82,7 @@ func (rl *RuleLoader) Load() error {
 		loaded = append(loaded, &rule)
 		return nil
 	})
-	fileMu.Unlock()
+	writeMu.Unlock()
 	if err != nil {
 		return err
 	}
@@ -131,13 +131,35 @@ func (rl *RuleLoader) ForStage(stage string) []*Rule {
 	return matched
 }
 
-// IDsForStage returns the IDs of rules that would be injected for a given stage.
+// IDsForStage returns the IDs of rules that pass the confidence filter for a given stage.
 // This is used to record which rules were active when an agent ran (for Q-value tracking).
 func (rl *RuleLoader) IDsForStage(stage string) []string {
 	matched := rl.ForStage(stage)
 	ids := make([]string, 0, len(matched))
 	for _, r := range matched {
 		ids = append(ids, r.ID)
+	}
+	return ids
+}
+
+// IDsForPrompt returns the IDs of rules that were actually included in the prompt
+// for a given stage, honouring the same MaxPromptChars budget as FormatForPrompt.
+// Use this instead of IDsForStage when recording Q-value participation, so that
+// rules truncated out of the prompt are not credited or penalised for outcomes.
+func (rl *RuleLoader) IDsForPrompt(stage string) []string {
+	matched := rl.ForStage(stage)
+
+	const header = "## Self-Learning Rules\n\nFollow these rules based on past experience:\n\n"
+	total := len(header)
+
+	ids := make([]string, 0, len(matched))
+	for _, r := range matched {
+		entry := fmt.Sprintf("### %s (confidence: %.2f)\n\n%s\n\n---\n\n", r.ID, r.Confidence, r.Body)
+		if total+len(entry) > MaxPromptChars {
+			break
+		}
+		ids = append(ids, r.ID)
+		total += len(entry)
 	}
 	return ids
 }

--- a/internal/rules/types.go
+++ b/internal/rules/types.go
@@ -13,6 +13,10 @@ type Rule struct {
 	Tags            []string `yaml:"tags"`
 	Condition       string   `yaml:"condition"`
 	Body            string   `yaml:"body"`
+	// MemRL Q-value fields (see GitHub issue #15)
+	QValue         float64 `yaml:"q_value"`
+	RetrievalCount int     `yaml:"retrieval_count"`
+	SuccessCount   int     `yaml:"success_count"`
 }
 
 // SeverityRank returns a numeric rank for sorting (lower = more severe).

--- a/internal/rules/writer.go
+++ b/internal/rules/writer.go
@@ -11,12 +11,9 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// fileMu serializes all read-modify-write operations on rule YAML files.
-// Both the feedback goroutine (stampRuleValidation) and the synthesis goroutine
-// (applySynthesisResult / applyDecay) write rule files concurrently; without this
-// lock a read→modify→write in one goroutine can overwrite a concurrent write from
-// the other, silently dropping either the confidence or last_validated_at update.
-var fileMu sync.Mutex
+// writeMu serializes all rule YAML read-modify-write operations so that
+// concurrent goroutines (feedback scanner + synthesis) never race on the same file.
+var writeMu sync.Mutex
 
 // WriteRule writes a Rule to a YAML file in rules/{stage}/ directory.
 func WriteRule(rulesDir string, rule *Rule) error {
@@ -25,6 +22,8 @@ func WriteRule(rulesDir string, rule *Rule) error {
 	if rule.ID == "" || strings.ContainsAny(rule.ID, "/\\") || strings.Contains(rule.ID, "..") || filepath.Base(rule.ID) != rule.ID {
 		return fmt.Errorf("unsafe rule ID %q", rule.ID)
 	}
+	writeMu.Lock()
+	defer writeMu.Unlock()
 
 	dir := filepath.Join(rulesDir, rule.Stage)
 	if err := os.MkdirAll(dir, 0755); err != nil {
@@ -37,15 +36,13 @@ func WriteRule(rulesDir string, rule *Rule) error {
 	}
 
 	path := filepath.Join(dir, rule.ID+".yaml")
-	fileMu.Lock()
-	defer fileMu.Unlock()
 	return os.WriteFile(path, data, 0644)
 }
 
 // UpdateRuleConfidence updates only the confidence field of an existing rule file.
 func UpdateRuleConfidence(rulesDir string, ruleID string, stage string, newConfidence float64) error {
-	fileMu.Lock()
-	defer fileMu.Unlock()
+	writeMu.Lock()
+	defer writeMu.Unlock()
 
 	path := findRuleFile(rulesDir, ruleID, stage)
 	if path == "" {
@@ -73,8 +70,8 @@ func UpdateRuleConfidence(rulesDir string, ruleID string, stage string, newConfi
 
 // UpdateRuleLastValidatedAt updates the last_validated_at field of an existing rule file.
 func UpdateRuleLastValidatedAt(rulesDir string, ruleID string, stage string, validatedAt string) error {
-	fileMu.Lock()
-	defer fileMu.Unlock()
+	writeMu.Lock()
+	defer writeMu.Unlock()
 
 	path := findRuleFile(rulesDir, ruleID, stage)
 	if path == "" {
@@ -102,8 +99,8 @@ func UpdateRuleLastValidatedAt(rulesDir string, ruleID string, stage string, val
 
 // UpdateRuleQValue updates the q_value, retrieval_count, and success_count fields of an existing rule file.
 func UpdateRuleQValue(rulesDir string, ruleID string, stage string, qValue float64, retrievalCount int, successCount int) error {
-	fileMu.Lock()
-	defer fileMu.Unlock()
+	writeMu.Lock()
+	defer writeMu.Unlock()
 
 	path := findRuleFile(rulesDir, ruleID, stage)
 	if path == "" {
@@ -133,8 +130,8 @@ func UpdateRuleQValue(rulesDir string, ruleID string, stage string, qValue float
 
 // DeleteRule removes a rule file from disk.
 func DeleteRule(rulesDir string, ruleID string, stage string) error {
-	fileMu.Lock()
-	defer fileMu.Unlock()
+	writeMu.Lock()
+	defer writeMu.Unlock()
 
 	path := findRuleFile(rulesDir, ruleID, stage)
 	if path == "" {
@@ -145,11 +142,11 @@ func DeleteRule(rulesDir string, ruleID string, stage string) error {
 
 // DecayRuleIfStale atomically reads last_validated_at from disk and, only if the
 // rule has not been validated within staleDays, multiplies confidence by decayFactor
-// (floored at minConf). The entire read-check-write runs under fileMu, which prevents
+// (floored at minConf). The entire read-check-write runs under writeMu, which prevents
 // a concurrent stampRuleValidation write from racing with the applyDecay decision.
 func DecayRuleIfStale(rulesDir, ruleID, stage string, decayFactor, minConf float64, staleDays int) error {
-	fileMu.Lock()
-	defer fileMu.Unlock()
+	writeMu.Lock()
+	defer writeMu.Unlock()
 
 	path := findRuleFile(rulesDir, ruleID, stage)
 	if path == "" {
@@ -167,7 +164,7 @@ func DecayRuleIfStale(rulesDir, ruleID, stage string, decayFactor, minConf float
 	}
 
 	// Skip if validated within staleDays — reading from disk guarantees we see
-	// any last_validated_at that stampRuleValidation wrote before we acquired fileMu.
+	// any last_validated_at that stampRuleValidation wrote before we acquired writeMu.
 	if rule.LastValidatedAt != "" {
 		validated, err := time.Parse("2006-01-02", rule.LastValidatedAt)
 		if err == nil && time.Since(validated) < time.Duration(staleDays)*24*time.Hour {

--- a/internal/rules/writer.go
+++ b/internal/rules/writer.go
@@ -100,6 +100,37 @@ func UpdateRuleLastValidatedAt(rulesDir string, ruleID string, stage string, val
 	return os.WriteFile(path, updated, 0644)
 }
 
+// UpdateRuleQValue updates the q_value, retrieval_count, and success_count fields of an existing rule file.
+func UpdateRuleQValue(rulesDir string, ruleID string, stage string, qValue float64, retrievalCount int, successCount int) error {
+	fileMu.Lock()
+	defer fileMu.Unlock()
+
+	path := findRuleFile(rulesDir, ruleID, stage)
+	if path == "" {
+		return fmt.Errorf("rule file not found: %s", ruleID)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+
+	var rule Rule
+	if err := yaml.Unmarshal(data, &rule); err != nil {
+		return err
+	}
+
+	rule.QValue = qValue
+	rule.RetrievalCount = retrievalCount
+	rule.SuccessCount = successCount
+	updated, err := yaml.Marshal(&rule)
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(path, updated, 0644)
+}
+
 // DeleteRule removes a rule file from disk.
 func DeleteRule(rulesDir string, ruleID string, stage string) error {
 	fileMu.Lock()

--- a/internal/rules/writer.go
+++ b/internal/rules/writer.go
@@ -129,6 +129,7 @@ func UpdateRuleQValue(rulesDir string, ruleID string, stage string, qValue float
 }
 
 // DeleteRule removes a rule file from disk.
+// Holds writeMu to prevent races with UpdateRuleQValue and Reload.
 func DeleteRule(rulesDir string, ruleID string, stage string) error {
 	writeMu.Lock()
 	defer writeMu.Unlock()

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -339,5 +339,6 @@ type PipelineEvent struct {
 	Success         bool       `db:"success" json:"success"`
 	ErrorMessage    string     `db:"error_message" json:"error_message,omitempty"`
 	OutcomeLabel    string     `db:"outcome_label" json:"outcome_label,omitempty"`
+	ExperiencesUsed string     `db:"experiences_used" json:"experiences_used,omitempty"` // JSON array of rule IDs used in this stage
 	CreatedAt       time.Time  `db:"created_at" json:"created_at"`
 }


### PR DESCRIPTION
## Summary

Implements the MemRL pattern ([arxiv:2601.03192](https://arxiv.org/abs/2601.03192)) for adaptive rule evolution — replacing blind confidence decay with reward-signal-driven Q-value updates.

- **`Rule` struct** gains `q_value` (default 0.5), `retrieval_count`, and `success_count` fields, persisted in YAML rule files
- **`pipeline_events`** gains `experiences_used TEXT` column (JSON array of rule IDs injected at each stage)
- **`IDsForStage()`** added to `RuleLoader` to capture which rules were active per agent run
- **`updateQValues(issueID)`** called when PR reaches terminal state (`MERGED` or `CLOSED`); applies:
  ```
  Q_new = Q_old + α * (reward - Q_old)   α = 0.1
  merged → reward=1.0 | unknown_closed → 0.2 | rejected/* → 0.0
  ```
- **`UpdateRuleQValue()`** added to `internal/rules/writer.go` to persist updated fields

## Test plan

- [x] `gofmt -w .` — no diffs
- [x] `go vet ./...` — clean
- [x] `go build ./...` — clean
- [x] `go test ./...` — all pass (rules, pipeline, github, prompt, utils packages)

Closes #15