### PR TITLE
fix: check json.Unmarshal error in HasExistingPR to prevent duplicate PRs

### DIFF
--- a/cmd/auto-contributor/cmd_loop.go
+++ b/cmd/auto-contributor/cmd_loop.go
@@ -220,8 +220,17 @@ func runDiscovery(ctx context.Context, issueCh chan<- *models.Issue) {
 			continue
 		}
 
-		// Double-check for existing PR
-		hasPR, _ := ghClient.HasExistingPR(ctx, issue.Repo, issue.IssueNumber)
+		// Double-check for existing PR; skip on error to avoid duplicate PRs.
+		hasPR, prErr := ghClient.HasExistingPR(ctx, issue.Repo, issue.IssueNumber)
+		if prErr != nil {
+			log.Warn("failed to check existing PR, skipping issue to avoid duplicate",
+				"repo", issue.Repo,
+				"issue", issue.IssueNumber,
+				"error", prErr,
+			)
+			skipped++
+			continue
+		}
 		if hasPR {
 			skipped++
 			continue

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -9,7 +9,10 @@ import (
 	"strings"
 
 	"github.com/majiayu000/auto-contributor/internal/config"
+	"github.com/majiayu000/auto-contributor/pkg/logger"
 )
+
+var log = logger.NewComponent("github")
 
 // Client wraps the gh CLI for GitHub API calls
 type Client struct {

--- a/internal/github/repo.go
+++ b/internal/github/repo.go
@@ -127,7 +127,9 @@ func (c *Client) HasExistingPR(ctx context.Context, repoFullName string, issueNu
 	var prs []struct {
 		Number int `json:"number"`
 	}
-	json.Unmarshal(output, &prs)
+	if err := json.Unmarshal(output, &prs); err != nil {
+		return false, fmt.Errorf("failed to parse pr list output: %w", err)
+	}
 
 	return len(prs) > 0, nil
 }

--- a/internal/github/search.go
+++ b/internal/github/search.go
@@ -171,7 +171,15 @@ func (c *Client) GetUnassignedBugs(ctx context.Context, repoFullName string, lim
 
 		// Skip if already has a competing PR; also skip on error to avoid duplicates.
 		hasPR, prErr := c.HasExistingPR(ctx, repoFullName, r.Number)
-		if hasPR || prErr != nil {
+		if prErr != nil {
+			log.Warn("failed to check existing PR, skipping issue to avoid duplicate",
+				"repo", repoFullName,
+				"issue", r.Number,
+				"error", prErr,
+			)
+			continue
+		}
+		if hasPR {
 			continue
 		}
 

--- a/internal/github/search.go
+++ b/internal/github/search.go
@@ -169,9 +169,9 @@ func (c *Client) GetUnassignedBugs(ctx context.Context, repoFullName string, lim
 			continue
 		}
 
-		// Skip if already has a competing PR
-		hasPR, _ := c.HasExistingPR(ctx, repoFullName, r.Number)
-		if hasPR {
+		// Skip if already has a competing PR; also skip on error to avoid duplicates.
+		hasPR, prErr := c.HasExistingPR(ctx, repoFullName, r.Number)
+		if hasPR || prErr != nil {
 			continue
 		}
 

--- a/internal/rules/writer.go
+++ b/internal/rules/writer.go
@@ -191,7 +191,7 @@ func DecayRuleIfStale(rulesDir, ruleID, stage string, decayFactor, minConf float
 }
 
 // IncrementEvidenceCount increments the evidence_count field of an existing rule file
-// and stamps last_validated_at to today. Both fields are updated atomically under fileMu
+// and stamps last_validated_at to today. Both fields are updated atomically under writeMu
 // so that applyDecay cannot observe a stale last_validated_at between the two writes.
 // It is called when a candidate rule is merged into an existing rule during dedup.
 func IncrementEvidenceCount(rulesDir string, ruleID string, stage string) error {
@@ -202,8 +202,8 @@ func IncrementEvidenceCount(rulesDir string, ruleID string, stage string) error 
 		return fmt.Errorf("unsafe rule ID %q", ruleID)
 	}
 
-	fileMu.Lock()
-	defer fileMu.Unlock()
+	writeMu.Lock()
+	defer writeMu.Unlock()
 
 	path := findRuleFile(rulesDir, ruleID, stage)
 	if path == "" {


### PR DESCRIPTION
## Summary
- **Root cause (U-17)**: `json.Unmarshal` error was silently discarded in `HasExistingPR`. On malformed JSON (e.g., transient API / rate-limit errors), `prs` stayed nil, `len(prs)==0`, and the function returned `(false, nil)` — falsely claiming no PR exists, causing the pipeline to create duplicate PRs.
- **Fix**: propagate the unmarshal error via `fmt.Errorf("failed to parse pr list output: %w", err)`.
- **Build fix**: `IncrementEvidenceCount` in `internal/rules/writer.go` referenced undefined `fileMu`; corrected to the declared `writeMu`.

## Test plan
- [ ] `go build ./...` passes
- [ ] `go vet ./...` passes
- [ ] `go test ./...` passes (all existing tests green)
- [ ] Verify `HasExistingPR` now surfaces JSON parse errors instead of silently returning false