### PR TITLE
fix(sec): validate Stage field in WriteRule to prevent path traversal (SEC-07)

### DIFF
--- a/internal/rules/writer.go
+++ b/internal/rules/writer.go
@@ -15,12 +15,30 @@ import (
 // concurrent goroutines (feedback scanner + synthesis) never race on the same file.
 var writeMu sync.Mutex
 
+// allowedStages is the set of valid stage directory names for rule files.
+// WriteRule rejects any Stage value not in this set to prevent path traversal
+// via LLM-generated Stage fields (SEC-07).
+var allowedStages = map[string]bool{
+	"scout":     true,
+	"analyst":   true,
+	"engineer":  true,
+	"reviewer":  true,
+	"submitter": true,
+	"responder": true,
+	"global":    true,
+}
+
 // WriteRule writes a Rule to a YAML file in rules/{stage}/ directory.
 func WriteRule(rulesDir string, rule *Rule) error {
 	// Defense-in-depth: reject IDs that could escape the rules/{stage} directory
 	// via path traversal (e.g. "../../../etc/passwd" or absolute paths).
 	if rule.ID == "" || strings.ContainsAny(rule.ID, "/\\") || strings.Contains(rule.ID, "..") || filepath.Base(rule.ID) != rule.ID {
 		return fmt.Errorf("unsafe rule ID %q", rule.ID)
+	}
+	// Validate Stage against the known-good allowlist to prevent LLM-generated
+	// values like "../../../etc/cron.d" from escaping the rules directory (SEC-07).
+	if !allowedStages[rule.Stage] {
+		return fmt.Errorf("unsafe rule stage %q", rule.Stage)
 	}
 	writeMu.Lock()
 	defer writeMu.Unlock()
@@ -202,8 +220,8 @@ func IncrementEvidenceCount(rulesDir string, ruleID string, stage string) error 
 		return fmt.Errorf("unsafe rule ID %q", ruleID)
 	}
 
-	fileMu.Lock()
-	defer fileMu.Unlock()
+	writeMu.Lock()
+	defer writeMu.Unlock()
 
 	path := findRuleFile(rulesDir, ruleID, stage)
 	if path == "" {

--- a/internal/rules/writer_test.go
+++ b/internal/rules/writer_test.go
@@ -208,6 +208,48 @@ func TestIncrementEvidenceCount_StampsLastValidatedAt(t *testing.T) {
 	}
 }
 
+// TestWriteRule_UnsafeStage verifies that WriteRule rejects Stage values that
+// could escape the rules directory via path traversal (SEC-07).
+func TestWriteRule_UnsafeStage(t *testing.T) {
+	dir := t.TempDir()
+	cases := []struct {
+		stage string
+	}{
+		{"../../../etc/cron.d"},
+		{".."},
+		{"scout/../../../etc"},
+		{""},
+		{"unknown-stage"},
+		{"/etc/passwd"},
+	}
+	for _, tc := range cases {
+		rule := &Rule{
+			ID:    "safe-id",
+			Stage: tc.stage,
+			Body:  "test",
+		}
+		if err := WriteRule(dir, rule); err == nil {
+			t.Errorf("WriteRule(%q) should have returned an error for unsafe stage", tc.stage)
+		}
+	}
+}
+
+// TestWriteRule_AllowedStages verifies that WriteRule accepts all valid stage names.
+func TestWriteRule_AllowedStages(t *testing.T) {
+	dir := t.TempDir()
+	stages := []string{"scout", "analyst", "engineer", "reviewer", "submitter", "responder", "global"}
+	for _, stage := range stages {
+		rule := &Rule{
+			ID:    "test-stage-rule",
+			Stage: stage,
+			Body:  "test body",
+		}
+		if err := WriteRule(dir, rule); err != nil {
+			t.Errorf("WriteRule with valid stage %q returned unexpected error: %v", stage, err)
+		}
+	}
+}
+
 func containsStr(s, substr string) bool {
 	for i := 0; i <= len(s)-len(substr); i++ {
 		if s[i:i+len(substr)] == substr {


### PR DESCRIPTION
## Summary

- `WriteRule` used `rule.Stage` directly in `filepath.Join` without validation, allowing an adversarially-crafted LLM output (e.g. `Stage="../../../etc/cron.d"`) to write arbitrary files outside the `rules/` directory.
- Add `allowedStages` allowlist; `WriteRule` now returns an error for any Stage not in `{scout, analyst, engineer, reviewer, submitter, responder, global}`.
- Fix pre-existing `fileMu` undefined reference in `IncrementEvidenceCount` (should have been `writeMu` after the mutex rename in 7f153fd).
- Add `TestWriteRule_UnsafeStage` and `TestWriteRule_AllowedStages` tests.

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./internal/rules/...` passes including new tests
- [ ] `go test ./...` full suite passes
- [ ] Traversal inputs like `../../../etc/cron.d`, `..`, `/etc/passwd`, empty string, and unknown stage names are all rejected
- [ ] All valid stages (`scout`, `analyst`, `engineer`, `reviewer`, `submitter`, `responder`, `global`) are accepted

Fixes #29