### PR TITLE
fix(sec): validate stage in findRuleFile to prevent path traversal (SEC-07)

### DIFF
--- a/internal/rules/loader.go
+++ b/internal/rules/loader.go
@@ -88,7 +88,20 @@ func (rl *RuleLoader) readFromDisk() error {
 			return nil
 		}
 
-		if rule.ID == "" || rule.Body == "" {
+		if rule.Body == "" {
+			return nil
+		}
+		// Rules with an invalid Stage or ID can never be managed via the normal
+		// write paths (WriteRule, DeleteRule, etc. all reject them). Delete them
+		// now so they are not re-injected into prompts on every Reload (self-healing).
+		if !allowedStages[rule.Stage] {
+			fmt.Fprintf(os.Stderr, "warn: quarantining rule with invalid stage %q: %s\n", rule.Stage, path)
+			os.Remove(path) //nolint:errcheck
+			return nil
+		}
+		if rule.ID == "" || strings.ContainsAny(rule.ID, "/\\") || strings.Contains(rule.ID, "..") || filepath.Base(rule.ID) != rule.ID {
+			fmt.Fprintf(os.Stderr, "warn: quarantining rule with unsafe ID %q: %s\n", rule.ID, path)
+			os.Remove(path) //nolint:errcheck
 			return nil
 		}
 

--- a/internal/rules/loader.go
+++ b/internal/rules/loader.go
@@ -73,6 +73,11 @@ func (rl *RuleLoader) readFromDisk() error {
 		if err != nil {
 			return nil // skip unreadable files
 		}
+		// Skip symlinks — following them could escape the rules directory (SEC-07).
+		// filepath.Walk uses os.Lstat, so ModeSymlink is set for symlink entries.
+		if info.Mode()&os.ModeSymlink != 0 {
+			return nil
+		}
 		if info.IsDir() || !strings.HasSuffix(path, ".yaml") {
 			return nil
 		}

--- a/internal/rules/loader_test.go
+++ b/internal/rules/loader_test.go
@@ -6,6 +6,20 @@ import (
 	"testing"
 )
 
+// writeRuleYAML writes a minimal rule YAML file to dir/subdir/name.yaml.
+func writeRuleYAML(t *testing.T, dir, subdir, name, content string) string {
+	t.Helper()
+	d := filepath.Join(dir, subdir)
+	if err := os.MkdirAll(d, 0755); err != nil {
+		t.Fatal(err)
+	}
+	p := filepath.Join(d, name)
+	if err := os.WriteFile(p, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
 func TestLoadRules(t *testing.T) {
 	// Use the actual rules directory
 	rulesDir := filepath.Join("..", "..", "rules")
@@ -113,5 +127,67 @@ func TestConfidenceFilter(t *testing.T) {
 		if r.Confidence < MinConfidenceForInjection {
 			t.Errorf("rule %s has confidence %.2f below threshold %.2f", r.ID, r.Confidence, MinConfidenceForInjection)
 		}
+	}
+}
+
+// TestQuarantineInvalidStage verifies that readFromDisk deletes rule files whose
+// Stage field is not in allowedStages and does not load them into memory.
+// This prevents legacy or manually-placed files with bad stages from being
+// re-injected into prompts on every Reload and from blocking the retirement path.
+func TestQuarantineInvalidStage(t *testing.T) {
+	dir := t.TempDir()
+
+	good := writeRuleYAML(t, dir, "engineer", "valid-rule.yaml",
+		"id: valid-rule\nstage: engineer\nbody: keep this\nconfidence: 0.8\n")
+	bad := writeRuleYAML(t, dir, "badstage", "poisoned.yaml",
+		"id: poisoned\nstage: badstage\nbody: should be deleted\nconfidence: 0.9\n")
+
+	rl := NewRuleLoader(dir)
+	if err := rl.Load(); err != nil {
+		t.Fatalf("Load() failed: %v", err)
+	}
+
+	all := rl.All()
+	for _, r := range all {
+		if r.Stage == "badstage" {
+			t.Errorf("rule with invalid stage %q should not be loaded", r.Stage)
+		}
+	}
+	if _, err := os.Stat(bad); !os.IsNotExist(err) {
+		t.Error("bad-stage rule file should have been quarantined (deleted) from disk")
+	}
+	if _, err := os.Stat(good); err != nil {
+		t.Errorf("valid rule file should remain on disk: %v", err)
+	}
+}
+
+// TestQuarantineUnsafeID verifies that readFromDisk deletes rule files whose
+// ID field contains path traversal characters and does not load them into memory.
+// A rule with stage: engineer but id: ../../../etc/cron.d/pwn would otherwise
+// be injected into prompts but can never be decayed, updated, or retired.
+func TestQuarantineUnsafeID(t *testing.T) {
+	dir := t.TempDir()
+
+	good := writeRuleYAML(t, dir, "engineer", "safe-rule.yaml",
+		"id: safe-rule\nstage: engineer\nbody: keep this\nconfidence: 0.8\n")
+	bad := writeRuleYAML(t, dir, "engineer", "traversal.yaml",
+		"id: \"../../../etc/cron.d/pwn\"\nstage: engineer\nbody: injected\nconfidence: 0.9\n")
+
+	rl := NewRuleLoader(dir)
+	if err := rl.Load(); err != nil {
+		t.Fatalf("Load() failed: %v", err)
+	}
+
+	all := rl.All()
+	for _, r := range all {
+		if r.ID == "../../../etc/cron.d/pwn" {
+			t.Error("rule with traversal ID should not be loaded")
+		}
+	}
+	if _, err := os.Stat(bad); !os.IsNotExist(err) {
+		t.Error("traversal-ID rule file should have been quarantined (deleted) from disk")
+	}
+	if _, err := os.Stat(good); err != nil {
+		t.Errorf("valid rule file should remain on disk: %v", err)
 	}
 }

--- a/internal/rules/writer.go
+++ b/internal/rules/writer.go
@@ -250,6 +250,12 @@ func IncrementEvidenceCount(rulesDir string, ruleID string, stage string) error 
 
 // findRuleFile locates a rule file by ID, checking stage dir first then walking all dirs.
 func findRuleFile(rulesDir, ruleID, stage string) string {
+	// Validate stage against the allowlist to prevent path traversal (SEC-07).
+	// All callers pass stage values that originate from rule YAML (r.Stage), which
+	// may be attacker-controlled; reject any value not in the known-good set.
+	if stage != "" && !allowedStages[stage] {
+		return ""
+	}
 	// Check stage-specific dir first
 	if stage != "" {
 		path := filepath.Join(rulesDir, stage, ruleID+".yaml")

--- a/internal/rules/writer.go
+++ b/internal/rules/writer.go
@@ -149,6 +149,14 @@ func UpdateRuleQValue(rulesDir string, ruleID string, stage string, qValue float
 // DeleteRule removes a rule file from disk.
 // Holds writeMu to prevent races with UpdateRuleQValue and Reload.
 func DeleteRule(rulesDir string, ruleID string, stage string) error {
+	// Validate stage against the allowlist to prevent path traversal (SEC-07).
+	// Without this guard, an invalid stage causes findRuleFile to return ""
+	// which this function would treat as "already gone", silently leaving
+	// attacker-controlled rule files on disk and active in later runs.
+	if stage != "" && !allowedStages[stage] {
+		return fmt.Errorf("unsafe rule stage %q", stage)
+	}
+
 	writeMu.Lock()
 	defer writeMu.Unlock()
 

--- a/internal/rules/writer.go
+++ b/internal/rules/writer.go
@@ -278,6 +278,8 @@ func IncrementEvidenceCount(rulesDir string, ruleID string, stage string) error 
 }
 
 // findRuleFile locates a rule file by ID, checking stage dir first then walking all dirs.
+// Symlinks are rejected: a poisoned symlink (e.g. rules/engineer/id.yaml -> /etc/cron.d/pwn)
+// would otherwise become an out-of-tree write primitive via the Update*/Decay helpers (SEC-07).
 func findRuleFile(rulesDir, ruleID, stage string) string {
 	// Validate stage against the allowlist to prevent path traversal (SEC-07).
 	// All callers pass stage values that originate from rule YAML (r.Stage), which
@@ -291,18 +293,23 @@ func findRuleFile(rulesDir, ruleID, stage string) string {
 	if ruleID == "" || strings.ContainsAny(ruleID, "/\\") || strings.Contains(ruleID, "..") || filepath.Base(ruleID) != ruleID {
 		return ""
 	}
-	// Check stage-specific dir first
+
+	// Check stage-specific dir first; use Lstat so we never follow a symlink (SEC-07).
 	if stage != "" {
 		path := filepath.Join(rulesDir, stage, ruleID+".yaml")
-		if _, err := os.Stat(path); err == nil {
+		if fi, err := os.Lstat(path); err == nil && fi.Mode()&os.ModeSymlink == 0 {
 			return path
 		}
 	}
 
-	// Walk all dirs
+	// Walk all dirs; filepath.Walk uses os.Lstat internally so info reflects the
+	// symlink itself, not its target — skip any entry with ModeSymlink set.
 	var found string
 	filepath.Walk(rulesDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil || info.IsDir() {
+			return nil
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
 			return nil
 		}
 		if strings.TrimSuffix(info.Name(), ".yaml") == ruleID {

--- a/internal/rules/writer.go
+++ b/internal/rules/writer.go
@@ -59,6 +59,9 @@ func WriteRule(rulesDir string, rule *Rule) error {
 
 // UpdateRuleConfidence updates only the confidence field of an existing rule file.
 func UpdateRuleConfidence(rulesDir string, ruleID string, stage string, newConfidence float64) error {
+	if stage != "" && !allowedStages[stage] {
+		return fmt.Errorf("unsafe rule stage %q", stage)
+	}
 	writeMu.Lock()
 	defer writeMu.Unlock()
 
@@ -88,6 +91,9 @@ func UpdateRuleConfidence(rulesDir string, ruleID string, stage string, newConfi
 
 // UpdateRuleLastValidatedAt updates the last_validated_at field of an existing rule file.
 func UpdateRuleLastValidatedAt(rulesDir string, ruleID string, stage string, validatedAt string) error {
+	if stage != "" && !allowedStages[stage] {
+		return fmt.Errorf("unsafe rule stage %q", stage)
+	}
 	writeMu.Lock()
 	defer writeMu.Unlock()
 
@@ -117,6 +123,9 @@ func UpdateRuleLastValidatedAt(rulesDir string, ruleID string, stage string, val
 
 // UpdateRuleQValue updates the q_value, retrieval_count, and success_count fields of an existing rule file.
 func UpdateRuleQValue(rulesDir string, ruleID string, stage string, qValue float64, retrievalCount int, successCount int) error {
+	if stage != "" && !allowedStages[stage] {
+		return fmt.Errorf("unsafe rule stage %q", stage)
+	}
 	writeMu.Lock()
 	defer writeMu.Unlock()
 
@@ -178,6 +187,9 @@ func DeleteRule(rulesDir string, ruleID string, stage string) error {
 // (floored at minConf). The entire read-check-write runs under writeMu, which prevents
 // a concurrent stampRuleValidation write from racing with the applyDecay decision.
 func DecayRuleIfStale(rulesDir, ruleID, stage string, decayFactor, minConf float64, staleDays int) error {
+	if stage != "" && !allowedStages[stage] {
+		return fmt.Errorf("unsafe rule stage %q", stage)
+	}
 	writeMu.Lock()
 	defer writeMu.Unlock()
 
@@ -227,6 +239,9 @@ func DecayRuleIfStale(rulesDir, ruleID, stage string, decayFactor, minConf float
 // so that applyDecay cannot observe a stale last_validated_at between the two writes.
 // It is called when a candidate rule is merged into an existing rule during dedup.
 func IncrementEvidenceCount(rulesDir string, ruleID string, stage string) error {
+	if stage != "" && !allowedStages[stage] {
+		return fmt.Errorf("unsafe rule stage %q", stage)
+	}
 	// Reject IDs that could escape the rules directory via path traversal.
 	// ruleID originates from dedup.MatchedRuleID which is loaded from rule YAML
 	// and may be attacker-controlled; apply the same guard used in WriteRule.

--- a/internal/rules/writer.go
+++ b/internal/rules/writer.go
@@ -156,6 +156,12 @@ func DeleteRule(rulesDir string, ruleID string, stage string) error {
 	if stage != "" && !allowedStages[stage] {
 		return fmt.Errorf("unsafe rule stage %q", stage)
 	}
+	// Validate ruleID to prevent path traversal (SEC-07).
+	// A poisoned rule with id: ../../../etc/cron.d/pwn and a valid stage would
+	// otherwise reach filepath.Join in findRuleFile and delete an external file.
+	if ruleID == "" || strings.ContainsAny(ruleID, "/\\") || strings.Contains(ruleID, "..") || filepath.Base(ruleID) != ruleID {
+		return fmt.Errorf("unsafe rule ID %q", ruleID)
+	}
 
 	writeMu.Lock()
 	defer writeMu.Unlock()
@@ -262,6 +268,12 @@ func findRuleFile(rulesDir, ruleID, stage string) string {
 	// All callers pass stage values that originate from rule YAML (r.Stage), which
 	// may be attacker-controlled; reject any value not in the known-good set.
 	if stage != "" && !allowedStages[stage] {
+		return ""
+	}
+	// Validate ruleID to prevent path traversal via attacker-controlled rule IDs (SEC-07).
+	// RuleLoader.Load reads id: fields verbatim from disk; a poisoned rule with
+	// id: ../../../etc/cron.d/pwn would otherwise escape rulesDir via filepath.Join.
+	if ruleID == "" || strings.ContainsAny(ruleID, "/\\") || strings.Contains(ruleID, "..") || filepath.Base(ruleID) != ruleID {
 		return ""
 	}
 	// Check stage-specific dir first

--- a/internal/rules/writer_test.go
+++ b/internal/rules/writer_test.go
@@ -250,6 +250,48 @@ func TestWriteRule_AllowedStages(t *testing.T) {
 	}
 }
 
+// TestFindRuleFile_UnsafeStage verifies that findRuleFile returns "" for stage values
+// outside the allowlist, preventing path traversal via LLM-controlled Stage fields (SEC-07).
+func TestFindRuleFile_UnsafeStage(t *testing.T) {
+	dir := t.TempDir()
+	cases := []string{
+		"../../../etc/cron.d",
+		"..",
+		"scout/../../../etc",
+		"/etc/passwd",
+		"unknown-stage",
+	}
+	for _, stage := range cases {
+		if got := findRuleFile(dir, "any-id", stage); got != "" {
+			t.Errorf("findRuleFile(stage=%q) = %q, want empty string", stage, got)
+		}
+	}
+}
+
+// TestUpdateFunctions_UnsafeStageReturnsError verifies that every update function
+// that delegates to findRuleFile returns an error when the stage is invalid (SEC-07).
+func TestUpdateFunctions_UnsafeStageReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	badStage := "../../../etc/cron.d"
+	id := "any-id"
+
+	if err := UpdateRuleConfidence(dir, id, badStage, 0.5); err == nil {
+		t.Error("UpdateRuleConfidence: expected error for unsafe stage, got nil")
+	}
+	if err := UpdateRuleLastValidatedAt(dir, id, badStage, "2025-01-01"); err == nil {
+		t.Error("UpdateRuleLastValidatedAt: expected error for unsafe stage, got nil")
+	}
+	if err := UpdateRuleQValue(dir, id, badStage, 0.5, 1, 1); err == nil {
+		t.Error("UpdateRuleQValue: expected error for unsafe stage, got nil")
+	}
+	if err := DecayRuleIfStale(dir, id, badStage, 0.9, 0.1, 30); err == nil {
+		t.Error("DecayRuleIfStale: expected error for unsafe stage, got nil")
+	}
+	if err := IncrementEvidenceCount(dir, id, badStage); err == nil {
+		t.Error("IncrementEvidenceCount: expected error for unsafe stage, got nil")
+	}
+}
+
 func containsStr(s, substr string) bool {
 	for i := 0; i <= len(s)-len(substr); i++ {
 		if s[i:i+len(substr)] == substr {

--- a/internal/rules/writer_test.go
+++ b/internal/rules/writer_test.go
@@ -295,6 +295,48 @@ func TestUpdateFunctions_UnsafeStageReturnsError(t *testing.T) {
 	}
 }
 
+// TestFindRuleFile_UnsafeRuleID verifies that findRuleFile returns "" for ruleID values
+// that could escape the rules directory via path traversal (SEC-07).
+func TestFindRuleFile_UnsafeRuleID(t *testing.T) {
+	dir := t.TempDir()
+	cases := []string{
+		"../../../etc/cron.d/pwn",
+		"..",
+		"/etc/passwd",
+		"",
+		"safe/../../../etc",
+	}
+	for _, id := range cases {
+		if got := findRuleFile(dir, id, "engineer"); got != "" {
+			t.Errorf("findRuleFile(ruleID=%q) = %q, want empty string", id, got)
+		}
+	}
+}
+
+// TestUpdateFunctions_UnsafeRuleIDReturnsError verifies that every update function
+// that delegates to findRuleFile returns an error when the ruleID could traverse paths (SEC-07).
+func TestUpdateFunctions_UnsafeRuleIDReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	badID := "../../../etc/cron.d/pwn"
+	stage := "engineer"
+
+	if err := UpdateRuleConfidence(dir, badID, stage, 0.5); err == nil {
+		t.Error("UpdateRuleConfidence: expected error for unsafe ruleID, got nil")
+	}
+	if err := UpdateRuleLastValidatedAt(dir, badID, stage, "2025-01-01"); err == nil {
+		t.Error("UpdateRuleLastValidatedAt: expected error for unsafe ruleID, got nil")
+	}
+	if err := UpdateRuleQValue(dir, badID, stage, 0.5, 1, 1); err == nil {
+		t.Error("UpdateRuleQValue: expected error for unsafe ruleID, got nil")
+	}
+	if err := DecayRuleIfStale(dir, badID, stage, 0.9, 0.1, 30); err == nil {
+		t.Error("DecayRuleIfStale: expected error for unsafe ruleID, got nil")
+	}
+	if err := DeleteRule(dir, badID, stage); err == nil {
+		t.Error("DeleteRule: expected error for unsafe ruleID, got nil")
+	}
+}
+
 func containsStr(s, substr string) bool {
 	for i := 0; i <= len(s)-len(substr); i++ {
 		if s[i:i+len(substr)] == substr {

--- a/internal/rules/writer_test.go
+++ b/internal/rules/writer_test.go
@@ -280,6 +280,91 @@ func TestFindRuleFile_UnsafeStage(t *testing.T) {
 	}
 }
 
+// TestSymlinkRejectedByFindRuleFile verifies that a poisoned symlink inside the rules
+// directory (e.g. rules/engineer/id.yaml -> /external/file) is not returned by
+// findRuleFile, preventing it from being used as a write target by the Update* helpers.
+func TestSymlinkRejectedByFindRuleFile(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create a victim file outside the rules directory.
+	victimDir := t.TempDir()
+	victimFile := filepath.Join(victimDir, "victim.yaml")
+	victimContent := "stage: engineer\nid: poisoned-rule\nbody: original\nconfidence: 0.9\n"
+	if err := os.WriteFile(victimFile, []byte(victimContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create the stage directory and plant a symlink pointing at the victim.
+	stageDir := filepath.Join(dir, "engineer")
+	if err := os.MkdirAll(stageDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	symlinkPath := filepath.Join(stageDir, "poisoned-rule.yaml")
+	if err := os.Symlink(victimFile, symlinkPath); err != nil {
+		t.Skipf("symlink creation not supported: %v", err)
+	}
+
+	// findRuleFile must not surface the symlink path (SEC-07).
+	got := findRuleFile(dir, "poisoned-rule", "engineer")
+	if got != "" {
+		t.Errorf("findRuleFile returned %q for a symlink; want empty string", got)
+	}
+
+	// Update helpers must return an error rather than writing through the symlink.
+	if err := UpdateRuleConfidence(dir, "poisoned-rule", "engineer", 0.1); err == nil {
+		t.Error("UpdateRuleConfidence should fail for a symlink target")
+	}
+	if err := UpdateRuleLastValidatedAt(dir, "poisoned-rule", "engineer", "2024-01-01"); err == nil {
+		t.Error("UpdateRuleLastValidatedAt should fail for a symlink target")
+	}
+	if err := IncrementEvidenceCount(dir, "poisoned-rule", "engineer"); err == nil {
+		t.Error("IncrementEvidenceCount should fail for a symlink target")
+	}
+
+	// Victim file must be unmodified.
+	after, err := os.ReadFile(victimFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != victimContent {
+		t.Errorf("victim file was modified via symlink: got %q", after)
+	}
+}
+
+// TestSymlinkSkippedByLoader verifies that a symlink inside the rules directory
+// is not loaded into the in-memory rule cache.
+func TestSymlinkSkippedByLoader(t *testing.T) {
+	dir := t.TempDir()
+
+	// Write a legitimate rule so the stage dir exists.
+	writeTestRule(t, dir, &Rule{
+		ID:    "legitimate-rule",
+		Stage: "engineer",
+		Body:  "real body",
+	})
+
+	// Plant a symlink next to the real rule.
+	victimDir := t.TempDir()
+	victimFile := filepath.Join(victimDir, "victim.yaml")
+	if err := os.WriteFile(victimFile, []byte("stage: engineer\nid: symlinked\nbody: via link\nconfidence: 0.9\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	symlinkPath := filepath.Join(dir, "engineer", "symlinked.yaml")
+	if err := os.Symlink(victimFile, symlinkPath); err != nil {
+		t.Skipf("symlink creation not supported: %v", err)
+	}
+
+	rl := NewRuleLoader(dir)
+	if err := rl.Load(); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	for _, r := range rl.All() {
+		if r.ID == "symlinked" {
+			t.Error("loader must not load a rule from a symlink (SEC-07)")
+		}
+	}
+}
+
 // TestUpdateFunctions_UnsafeStageReturnsError verifies that every update function
 // that delegates to findRuleFile returns an error when the stage is invalid (SEC-07).
 // A fixture file is placed one level above rulesDir so that stage=".." traversal

--- a/internal/rules/writer_test.go
+++ b/internal/rules/writer_test.go
@@ -282,10 +282,23 @@ func TestFindRuleFile_UnsafeStage(t *testing.T) {
 
 // TestUpdateFunctions_UnsafeStageReturnsError verifies that every update function
 // that delegates to findRuleFile returns an error when the stage is invalid (SEC-07).
+// A fixture file is placed one level above rulesDir so that stage=".." traversal
+// would reach it if the guard were absent; this ensures the test fails on a
+// regression rather than vacuously passing because no file exists.
 func TestUpdateFunctions_UnsafeStageReturnsError(t *testing.T) {
-	dir := t.TempDir()
-	badStage := "../../../etc/cron.d"
-	id := "any-id"
+	parent := t.TempDir()
+	dir := filepath.Join(parent, "rules")
+	if err := os.Mkdir(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	// Fixture reachable via stage=".." without the guard: rules/../target.yaml = parent/target.yaml
+	fixture := filepath.Join(parent, "target.yaml")
+	fixtureYAML := "id: target\nstage: engineer\nbody: test\nconfidence: 0.5\nlast_validated_at: \"\"\n"
+	if err := os.WriteFile(fixture, []byte(fixtureYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+	badStage := ".."
+	id := "target"
 
 	if err := UpdateRuleConfidence(dir, id, badStage, 0.5); err == nil {
 		t.Error("UpdateRuleConfidence: expected error for unsafe stage, got nil")

--- a/internal/rules/writer_test.go
+++ b/internal/rules/writer_test.go
@@ -290,6 +290,9 @@ func TestUpdateFunctions_UnsafeStageReturnsError(t *testing.T) {
 	if err := IncrementEvidenceCount(dir, id, badStage); err == nil {
 		t.Error("IncrementEvidenceCount: expected error for unsafe stage, got nil")
 	}
+	if err := DeleteRule(dir, id, badStage); err == nil {
+		t.Error("DeleteRule: expected error for unsafe stage, got nil")
+	}
 }
 
 func containsStr(s, substr string) bool {

--- a/internal/rules/writer_test.go
+++ b/internal/rules/writer_test.go
@@ -2,6 +2,7 @@ package rules
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -252,8 +253,19 @@ func TestWriteRule_AllowedStages(t *testing.T) {
 
 // TestFindRuleFile_UnsafeStage verifies that findRuleFile returns "" for stage values
 // outside the allowlist, preventing path traversal via LLM-controlled Stage fields (SEC-07).
+// A fixture file is placed outside the rules dir so the test catches regressions:
+// without the stage allowlist guard, stage=".." would resolve to the fixture and return it.
 func TestFindRuleFile_UnsafeStage(t *testing.T) {
-	dir := t.TempDir()
+	parent := t.TempDir()
+	rulesDir := filepath.Join(parent, "rules")
+	if err := os.Mkdir(rulesDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	// File reachable via stage=".." if the guard is absent: rules/../evil.yaml = parent/evil.yaml
+	outside := filepath.Join(parent, "evil.yaml")
+	if err := os.WriteFile(outside, []byte("id: evil\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
 	cases := []string{
 		"../../../etc/cron.d",
 		"..",
@@ -262,7 +274,7 @@ func TestFindRuleFile_UnsafeStage(t *testing.T) {
 		"unknown-stage",
 	}
 	for _, stage := range cases {
-		if got := findRuleFile(dir, "any-id", stage); got != "" {
+		if got := findRuleFile(rulesDir, "evil", stage); got != "" {
 			t.Errorf("findRuleFile(stage=%q) = %q, want empty string", stage, got)
 		}
 	}


### PR DESCRIPTION
## Summary

- `findRuleFile` was using the `stage` parameter directly in `filepath.Join` without validating it against the `allowedStages` allowlist introduced in PR #32.
- This left `UpdateRuleConfidence`, `UpdateRuleQValue`, `UpdateRuleLastValidatedAt`, `DeleteRule`, `DecayRuleIfStale`, and `IncrementEvidenceCount` open to path traversal when given a rule with a crafted `stage` field.
- Added the same `allowedStages` check at the top of `findRuleFile`, returning `""` immediately for any stage outside the known-good set.

## Test plan

- [ ] `TestFindRuleFile_UnsafeStage` — verifies `findRuleFile` returns `""` for traversal strings and unknown stages
- [ ] `TestUpdateFunctions_UnsafeStageReturnsError` — verifies all six update functions return an error for an unsafe stage
- [ ] Existing `TestWriteRule_UnsafeStage` and full suite still pass (`go test ./...`)

Closes #34