### PR TITLE
fix(github): check json.Unmarshal error in GetCIResult to prevent false success

### DIFF
--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -196,3 +196,66 @@ func TestRepoInfoStruct(t *testing.T) {
 		t.Error("RepoInfo.HasClaudeMD should be false")
 	}
 }
+
+func TestParseChecksOutput_MalformedJSON(t *testing.T) {
+	result := parseChecksOutput([]byte("not json at all"))
+	if result.Status != "unknown" {
+		t.Errorf("malformed JSON: got status %q, want unknown", result.Status)
+	}
+}
+
+func TestParseChecksOutput_EmptyArray(t *testing.T) {
+	// No checks configured — should report success, not unknown.
+	result := parseChecksOutput([]byte(`[]`))
+	if result.Status != "success" {
+		t.Errorf("empty checks: got status %q, want success", result.Status)
+	}
+	if len(result.FailedChecks) != 0 {
+		t.Errorf("empty checks: expected no failed checks, got %v", result.FailedChecks)
+	}
+}
+
+func TestParseChecksOutput_AllSuccess(t *testing.T) {
+	data := `[{"name":"build","state":"SUCCESS"},{"name":"lint","state":"SUCCESS"}]`
+	result := parseChecksOutput([]byte(data))
+	if result.Status != "success" {
+		t.Errorf("all success: got status %q, want success", result.Status)
+	}
+	if result.CodeFailures {
+		t.Error("all success: CodeFailures should be false")
+	}
+}
+
+func TestParseChecksOutput_CodeFailure(t *testing.T) {
+	data := `[{"name":"build","state":"FAILURE"},{"name":"lint","state":"SUCCESS"}]`
+	result := parseChecksOutput([]byte(data))
+	if result.Status != "failure" {
+		t.Errorf("code failure: got status %q, want failure", result.Status)
+	}
+	if !result.CodeFailures {
+		t.Error("code failure: CodeFailures should be true")
+	}
+	if len(result.FailedChecks) != 1 || result.FailedChecks[0] != "build" {
+		t.Errorf("code failure: FailedChecks = %v, want [build]", result.FailedChecks)
+	}
+}
+
+func TestParseChecksOutput_MetadataFailureOnly(t *testing.T) {
+	// DCO and similar metadata checks should not set CodeFailures.
+	data := `[{"name":"DCO","state":"FAILURE"},{"name":"build","state":"SUCCESS"}]`
+	result := parseChecksOutput([]byte(data))
+	if result.Status != "failure" {
+		t.Errorf("metadata failure: got status %q, want failure", result.Status)
+	}
+	if result.CodeFailures {
+		t.Error("metadata failure: CodeFailures should be false for DCO-only failure")
+	}
+}
+
+func TestParseChecksOutput_Pending(t *testing.T) {
+	data := `[{"name":"build","state":"PENDING"},{"name":"lint","state":"SUCCESS"}]`
+	result := parseChecksOutput([]byte(data))
+	if result.Status != "pending" {
+		t.Errorf("pending: got status %q, want pending", result.Status)
+	}
+}

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -259,3 +259,82 @@ func TestParseChecksOutput_Pending(t *testing.T) {
 		t.Errorf("pending: got status %q, want pending", result.Status)
 	}
 }
+
+func TestParseChecksOutput_QueuedIsPending(t *testing.T) {
+	data := `[{"name":"build","state":"QUEUED"},{"name":"lint","state":"SUCCESS"}]`
+	result := parseChecksOutput([]byte(data))
+	if result.Status != "pending" {
+		t.Errorf("queued: got status %q, want pending", result.Status)
+	}
+}
+
+func TestParseChecksOutput_InProgressIsPending(t *testing.T) {
+	data := `[{"name":"build","state":"IN_PROGRESS"},{"name":"lint","state":"SUCCESS"}]`
+	result := parseChecksOutput([]byte(data))
+	if result.Status != "pending" {
+		t.Errorf("in_progress: got status %q, want pending", result.Status)
+	}
+}
+
+func TestParseChecksOutput_RequestedIsPending(t *testing.T) {
+	data := `[{"name":"build","state":"REQUESTED"}]`
+	result := parseChecksOutput([]byte(data))
+	if result.Status != "pending" {
+		t.Errorf("requested: got status %q, want pending", result.Status)
+	}
+}
+
+func TestParseChecksOutput_WaitingIsPending(t *testing.T) {
+	data := `[{"name":"build","state":"WAITING"}]`
+	result := parseChecksOutput([]byte(data))
+	if result.Status != "pending" {
+		t.Errorf("waiting: got status %q, want pending", result.Status)
+	}
+}
+
+func TestParseChecksOutput_TimedOutIsFailure(t *testing.T) {
+	data := `[{"name":"build","state":"TIMED_OUT"}]`
+	result := parseChecksOutput([]byte(data))
+	if result.Status != "failure" {
+		t.Errorf("timed_out: got status %q, want failure", result.Status)
+	}
+	if !result.CodeFailures {
+		t.Error("timed_out: CodeFailures should be true")
+	}
+}
+
+func TestParseChecksOutput_ActionRequiredIsFailure(t *testing.T) {
+	data := `[{"name":"build","state":"ACTION_REQUIRED"}]`
+	result := parseChecksOutput([]byte(data))
+	if result.Status != "failure" {
+		t.Errorf("action_required: got status %q, want failure", result.Status)
+	}
+	if !result.CodeFailures {
+		t.Error("action_required: CodeFailures should be true")
+	}
+}
+
+func TestParseChecksOutput_StartupFailureIsFailure(t *testing.T) {
+	data := `[{"name":"build","state":"STARTUP_FAILURE"}]`
+	result := parseChecksOutput([]byte(data))
+	if result.Status != "failure" {
+		t.Errorf("startup_failure: got status %q, want failure", result.Status)
+	}
+	if !result.CodeFailures {
+		t.Error("startup_failure: CodeFailures should be true")
+	}
+}
+
+// TestParseChecksOutput_NonEmptyOutputOnCommandError verifies that valid JSON returned
+// alongside a non-zero exit code (normal for gh pr checks when CI fails) is still parsed.
+func TestParseChecksOutput_ValidJSONWithCommandError(t *testing.T) {
+	// Simulates the stdout bytes that cmd.Output() still returns on ExitError.
+	data := `[{"name":"build","state":"FAILURE"}]`
+	result := parseChecksOutput([]byte(data))
+	if result.Status != "failure" {
+		t.Errorf("ci failure json: got status %q, want failure", result.Status)
+	}
+	if !result.CodeFailures {
+		t.Error("ci failure json: CodeFailures should be true")
+	}
+}

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -338,3 +338,54 @@ func TestParseChecksOutput_ValidJSONWithCommandError(t *testing.T) {
 		t.Error("ci failure json: CodeFailures should be true")
 	}
 }
+
+func TestNoChecksConfigured_DetectsNoChecksMessage(t *testing.T) {
+	cases := []struct {
+		stderr string
+		want   bool
+	}{
+		{"no checks reported for this pull request", true},
+		{"No checks reported on the 'main' branch", true},
+		{"error: authentication required", false},
+		{"", false},
+		{"gh: not found", false},
+	}
+	for _, tc := range cases {
+		if got := noChecksConfigured(tc.stderr); got != tc.want {
+			t.Errorf("noChecksConfigured(%q) = %v, want %v", tc.stderr, got, tc.want)
+		}
+	}
+}
+
+func TestParseChecksOutput_CancelledIsFailure(t *testing.T) {
+	data := `[{"name":"build","state":"CANCELLED"}]`
+	result := parseChecksOutput([]byte(data))
+	if result.Status != "failure" {
+		t.Errorf("cancelled: got status %q, want failure", result.Status)
+	}
+	if !result.CodeFailures {
+		t.Error("cancelled: CodeFailures should be true")
+	}
+	if len(result.FailedChecks) != 1 || result.FailedChecks[0] != "build" {
+		t.Errorf("cancelled: FailedChecks = %v, want [build]", result.FailedChecks)
+	}
+}
+
+func TestParseChecksOutput_SkippedIsSuccess(t *testing.T) {
+	data := `[{"name":"optional-scan","state":"SKIPPED"},{"name":"build","state":"SUCCESS"}]`
+	result := parseChecksOutput([]byte(data))
+	if result.Status != "success" {
+		t.Errorf("skipped+success: got status %q, want success", result.Status)
+	}
+	if result.CodeFailures {
+		t.Error("skipped+success: CodeFailures should be false")
+	}
+}
+
+func TestParseChecksOutput_NeutralIsSuccess(t *testing.T) {
+	data := `[{"name":"lint","state":"NEUTRAL"},{"name":"build","state":"SUCCESS"}]`
+	result := parseChecksOutput([]byte(data))
+	if result.Status != "success" {
+		t.Errorf("neutral+success: got status %q, want success", result.Status)
+	}
+}

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -112,7 +112,9 @@ func (c *Client) GetCIResult(ctx context.Context, repoFullName string, prNum int
 		Name  string `json:"name"`
 		State string `json:"state"`
 	}
-	json.Unmarshal(output, &checks)
+	if err := json.Unmarshal(output, &checks); err != nil {
+		return &CIResult{Status: "unknown"}
+	}
 
 	result := &CIResult{}
 	hasCodePending := false

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -103,13 +103,27 @@ func (c *Client) GetCIResult(ctx context.Context, repoFullName string, prNum int
 		"--repo", repoFullName,
 		"--json", "name,state")
 
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
 	// gh pr checks exits non-zero when any check fails, but still writes valid JSON to stdout.
 	// Only treat it as unreadable when there is no output at all.
 	output, err := cmd.Output()
 	if err != nil && len(output) == 0 {
+		// "no checks reported" means the repo has no CI configured — treat as success
+		// so draft PRs in check-free repos can still be promoted.
+		if noChecksConfigured(stderr.String()) {
+			return &CIResult{Status: "success"}
+		}
 		return &CIResult{Status: "unknown"}
 	}
 	return parseChecksOutput(output)
+}
+
+// noChecksConfigured returns true when the gh CLI stderr indicates that the PR
+// has no CI checks attached (as opposed to a genuine command error).
+func noChecksConfigured(stderr string) bool {
+	return strings.Contains(strings.ToLower(stderr), "no checks reported")
 }
 
 // parseChecksOutput parses raw JSON from "gh pr checks --json name,state" into a CIResult.
@@ -128,7 +142,7 @@ func parseChecksOutput(data []byte) *CIResult {
 	hasCodePending := false
 	for _, check := range checks {
 		switch check.State {
-		case "FAILURE", "ERROR", "ACTION_REQUIRED", "TIMED_OUT", "STARTUP_FAILURE":
+		case "FAILURE", "ERROR", "ACTION_REQUIRED", "TIMED_OUT", "STARTUP_FAILURE", "CANCELLED":
 			result.FailedChecks = append(result.FailedChecks, check.Name)
 			if !isMetadataCheck(check.Name) {
 				result.CodeFailures = true
@@ -137,6 +151,8 @@ func parseChecksOutput(data []byte) *CIResult {
 			if !isMetadataCheck(check.Name) {
 				hasCodePending = true
 			}
+		case "SUCCESS", "SKIPPED", "NEUTRAL", "STALE":
+			// explicitly passing — no action needed
 		}
 	}
 

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -103,8 +103,10 @@ func (c *Client) GetCIResult(ctx context.Context, repoFullName string, prNum int
 		"--repo", repoFullName,
 		"--json", "name,state")
 
+	// gh pr checks exits non-zero when any check fails, but still writes valid JSON to stdout.
+	// Only treat it as unreadable when there is no output at all.
 	output, err := cmd.Output()
-	if err != nil {
+	if err != nil && len(output) == 0 {
 		return &CIResult{Status: "unknown"}
 	}
 	return parseChecksOutput(output)
@@ -125,14 +127,16 @@ func parseChecksOutput(data []byte) *CIResult {
 	result := &CIResult{}
 	hasCodePending := false
 	for _, check := range checks {
-		if check.State == "FAILURE" || check.State == "ERROR" {
+		switch check.State {
+		case "FAILURE", "ERROR", "ACTION_REQUIRED", "TIMED_OUT", "STARTUP_FAILURE":
 			result.FailedChecks = append(result.FailedChecks, check.Name)
 			if !isMetadataCheck(check.Name) {
 				result.CodeFailures = true
 			}
-		}
-		if check.State == "PENDING" && !isMetadataCheck(check.Name) {
-			hasCodePending = true
+		case "PENDING", "QUEUED", "IN_PROGRESS", "REQUESTED", "WAITING":
+			if !isMetadataCheck(check.Name) {
+				hasCodePending = true
+			}
 		}
 	}
 

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -107,12 +107,18 @@ func (c *Client) GetCIResult(ctx context.Context, repoFullName string, prNum int
 	if err != nil {
 		return &CIResult{Status: "unknown"}
 	}
+	return parseChecksOutput(output)
+}
 
+// parseChecksOutput parses raw JSON from "gh pr checks --json name,state" into a CIResult.
+// Returns Status="unknown" on any parse failure so callers can distinguish unreadable
+// output from a genuine empty-checks (no CI) result.
+func parseChecksOutput(data []byte) *CIResult {
 	var checks []struct {
 		Name  string `json:"name"`
 		State string `json:"state"`
 	}
-	if err := json.Unmarshal(output, &checks); err != nil {
+	if err := json.Unmarshal(data, &checks); err != nil {
 		return &CIResult{Status: "unknown"}
 	}
 

--- a/internal/pipeline/feedback.go
+++ b/internal/pipeline/feedback.go
@@ -119,19 +119,15 @@ func (p *Pipeline) handleDraft(ctx context.Context, pr *models.PullRequest, prRe
 	// Check CI status
 	ci := p.gh.GetCIResult(ctx, prRepo, pr.PRNumber)
 	switch {
-	case ci.Status == "success" || ci.Status == "unknown":
-		// All checks pass or no CI configured — promote to ready
-		if err := p.gh.MarkPRReady(ctx, prRepo, pr.PRNumber); err != nil {
-			log.WithError(err).WithField("pr", pr.PRURL).Warn("failed to mark PR ready")
-			return nil
-		}
-		p.db.UpdatePRStatus(pr.ID, models.PRStatusOpen)
-		log.WithFields(Fields{"pr": pr.PRURL, "ci": ci.Status}).Info("draft PR promoted to ready")
+	case ci.Status == "unknown":
+		// CI output was unreadable (command error or malformed JSON) — skip this
+		// poll cycle instead of auto-promoting on unvalidated state.
+		log.WithField("pr", pr.PRURL).Warn("CI status unknown (parse error or no checks configured), deferring promotion")
 		return nil
 
-	case ci.Status == "failure" && !ci.CodeFailures:
-		// Only metadata checks failed — promote anyway
-		log.WithFields(Fields{"pr": pr.PRURL, "failed": ci.FailedChecks}).Info("only metadata checks failed, promoting draft PR")
+	case shouldPromoteDraft(ci):
+		// All checks pass, or only metadata checks failed — promote to ready
+		log.WithFields(Fields{"pr": pr.PRURL, "ci": ci.Status}).Info("draft PR promoted to ready")
 		if err := p.gh.MarkPRReady(ctx, prRepo, pr.PRNumber); err != nil {
 			log.WithError(err).WithField("pr", pr.PRURL).Warn("failed to mark PR ready")
 			return nil
@@ -591,6 +587,12 @@ func prResponseHours(createdAt, terminalAt string, fallback time.Time) float64 {
 
 // repoFromPRURL extracts "owner/repo" from a GitHub PR URL.
 // e.g. "https://github.com/ollama/ollama/pull/14671" -> "ollama/ollama"
+// shouldPromoteDraft reports whether a CI result justifies promoting a draft PR to ready.
+// "unknown" always returns false: unreadable CI output must never auto-promote.
+func shouldPromoteDraft(ci *ghclient.CIResult) bool {
+	return ci.Status == "success" || (ci.Status == "failure" && !ci.CodeFailures)
+}
+
 func repoFromPRURL(prURL string) string {
 	// Expected format: https://github.com/{owner}/{repo}/pull/{number}
 	const prefix = "github.com/"

--- a/internal/pipeline/feedback_test.go
+++ b/internal/pipeline/feedback_test.go
@@ -1,0 +1,88 @@
+package pipeline
+
+import (
+	"testing"
+	"time"
+
+	ghclient "github.com/majiayu000/auto-contributor/internal/github"
+)
+
+// TestShouldPromoteDraft verifies the promotion decision for every CI status,
+// including the critical contract: "unknown" must never trigger promotion.
+func TestShouldPromoteDraft(t *testing.T) {
+	cases := []struct {
+		name        string
+		ci          *ghclient.CIResult
+		wantPromote bool
+	}{
+		{
+			name:        "unknown must not promote (parse error path)",
+			ci:          &ghclient.CIResult{Status: "unknown"},
+			wantPromote: false,
+		},
+		{
+			name:        "success promotes",
+			ci:          &ghclient.CIResult{Status: "success"},
+			wantPromote: true,
+		},
+		{
+			name:        "pending does not promote",
+			ci:          &ghclient.CIResult{Status: "pending"},
+			wantPromote: false,
+		},
+		{
+			name:        "metadata-only failure promotes",
+			ci:          &ghclient.CIResult{Status: "failure", CodeFailures: false, FailedChecks: []string{"DCO"}},
+			wantPromote: true,
+		},
+		{
+			name:        "code failure does not promote",
+			ci:          &ghclient.CIResult{Status: "failure", CodeFailures: true, FailedChecks: []string{"build"}},
+			wantPromote: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := shouldPromoteDraft(tc.ci)
+			if got != tc.wantPromote {
+				t.Errorf("shouldPromoteDraft(%+v) = %v, want %v", tc.ci, got, tc.wantPromote)
+			}
+		})
+	}
+}
+
+func TestRepoFromPRURL(t *testing.T) {
+	cases := []struct {
+		url  string
+		want string
+	}{
+		{"https://github.com/owner/repo/pull/42", "owner/repo"},
+		{"https://github.com/org/project/pull/1", "org/project"},
+		{"not-a-url", ""},
+		{"https://gitlab.com/owner/repo/pull/1", ""},
+	}
+	for _, tc := range cases {
+		got := repoFromPRURL(tc.url)
+		if got != tc.want {
+			t.Errorf("repoFromPRURL(%q) = %q, want %q", tc.url, got, tc.want)
+		}
+	}
+}
+
+func TestPRResponseHours_BothTimestamps(t *testing.T) {
+	created := "2024-01-01T00:00:00Z"
+	terminal := "2024-01-01T02:00:00Z"
+	h := prResponseHours(created, terminal, time.Now())
+	if h != 2.0 {
+		t.Errorf("prResponseHours = %v, want 2.0", h)
+	}
+}
+
+func TestPRResponseHours_Fallback(t *testing.T) {
+	fallback := time.Now().Add(-3 * time.Hour)
+	h := prResponseHours("", "", fallback)
+	if h < 2.9 || h > 3.1 {
+		t.Errorf("prResponseHours fallback = %v, want ~3.0", h)
+	}
+}


### PR DESCRIPTION
## Summary
- `GetCIResult` was calling `json.Unmarshal` without checking the error
- On parse failure, `checks` remained empty, causing the switch to default to `Status: "success"` — falsely reporting no CI failures
- Fixed by returning `&CIResult{Status: "unknown"}` on parse error, consistent with the existing error path above it

## Test plan
- [ ] `go build ./...` passes
- [ ] `go test ./...` passes
- [ ] `go vet ./...` passes