### PR TITLE
fix(github): treat EXPECTED checks as pending

### DIFF
--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -292,6 +292,14 @@ func TestParseChecksOutput_WaitingIsPending(t *testing.T) {
 	}
 }
 
+func TestParseChecksOutput_ExpectedIsPending(t *testing.T) {
+	data := `[{"name":"build","state":"EXPECTED"},{"name":"lint","state":"SUCCESS"}]`
+	result := parseChecksOutput([]byte(data))
+	if result.Status != "pending" {
+		t.Errorf("expected: got status %q, want pending", result.Status)
+	}
+}
+
 func TestParseChecksOutput_TimedOutIsFailure(t *testing.T) {
 	data := `[{"name":"build","state":"TIMED_OUT"}]`
 	result := parseChecksOutput([]byte(data))

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -300,6 +300,20 @@ func TestParseChecksOutput_ExpectedIsPending(t *testing.T) {
 	}
 }
 
+func TestParseChecksOutput_UnknownStateIsPending(t *testing.T) {
+	data := `[{"name":"build","state":"SCHEDULED"},{"name":"lint","state":"SUCCESS"}]`
+	result := parseChecksOutput([]byte(data))
+	if result.Status != "pending" {
+		t.Errorf("unknown state: got status %q, want pending", result.Status)
+	}
+	if result.CodeFailures {
+		t.Error("unknown state: CodeFailures should be false")
+	}
+	if len(result.FailedChecks) != 0 {
+		t.Errorf("unknown state: FailedChecks = %v, want []", result.FailedChecks)
+	}
+}
+
 func TestParseChecksOutput_TimedOutIsFailure(t *testing.T) {
 	data := `[{"name":"build","state":"TIMED_OUT"}]`
 	result := parseChecksOutput([]byte(data))

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -300,6 +300,20 @@ func TestParseChecksOutput_ExpectedIsPending(t *testing.T) {
 	}
 }
 
+func TestParseChecksOutput_MetadataFailureDoesNotOverridePendingCodeCheck(t *testing.T) {
+	data := `[{"name":"build","state":"EXPECTED"},{"name":"DCO","state":"FAILURE"}]`
+	result := parseChecksOutput([]byte(data))
+	if result.Status != "pending" {
+		t.Errorf("mixed metadata failure + pending code check: got status %q, want pending", result.Status)
+	}
+	if result.CodeFailures {
+		t.Error("mixed metadata failure + pending code check: CodeFailures should be false")
+	}
+	if len(result.FailedChecks) != 1 || result.FailedChecks[0] != "DCO" {
+		t.Errorf("mixed metadata failure + pending code check: FailedChecks = %v, want [DCO]", result.FailedChecks)
+	}
+}
+
 func TestParseChecksOutput_UnknownStateIsPending(t *testing.T) {
 	data := `[{"name":"build","state":"SCHEDULED"},{"name":"lint","state":"SUCCESS"}]`
 	result := parseChecksOutput([]byte(data))

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -147,7 +147,7 @@ func parseChecksOutput(data []byte) *CIResult {
 			if !isMetadataCheck(check.Name) {
 				result.CodeFailures = true
 			}
-		case "PENDING", "QUEUED", "IN_PROGRESS", "REQUESTED", "WAITING":
+		case "PENDING", "QUEUED", "IN_PROGRESS", "REQUESTED", "WAITING", "EXPECTED":
 			if !isMetadataCheck(check.Name) {
 				hasCodePending = true
 			}

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -141,11 +141,14 @@ func parseChecksOutput(data []byte) *CIResult {
 	result := &CIResult{}
 	hasCodePending := false
 	hasUnknownState := false
+	hasMetadataFailure := false
 	for _, check := range checks {
 		switch check.State {
 		case "FAILURE", "ERROR", "ACTION_REQUIRED", "TIMED_OUT", "STARTUP_FAILURE", "CANCELLED":
 			result.FailedChecks = append(result.FailedChecks, check.Name)
-			if !isMetadataCheck(check.Name) {
+			if isMetadataCheck(check.Name) {
+				hasMetadataFailure = true
+			} else {
 				result.CodeFailures = true
 			}
 		case "PENDING", "QUEUED", "IN_PROGRESS", "REQUESTED", "WAITING", "EXPECTED":
@@ -160,10 +163,12 @@ func parseChecksOutput(data []byte) *CIResult {
 	}
 
 	switch {
-	case len(result.FailedChecks) > 0:
+	case result.CodeFailures:
 		result.Status = "failure"
 	case hasCodePending || hasUnknownState:
 		result.Status = "pending"
+	case hasMetadataFailure:
+		result.Status = "failure"
 	default:
 		result.Status = "success"
 	}

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -140,6 +140,7 @@ func parseChecksOutput(data []byte) *CIResult {
 
 	result := &CIResult{}
 	hasCodePending := false
+	hasUnknownState := false
 	for _, check := range checks {
 		switch check.State {
 		case "FAILURE", "ERROR", "ACTION_REQUIRED", "TIMED_OUT", "STARTUP_FAILURE", "CANCELLED":
@@ -153,13 +154,15 @@ func parseChecksOutput(data []byte) *CIResult {
 			}
 		case "SUCCESS", "SKIPPED", "NEUTRAL", "STALE":
 			// explicitly passing — no action needed
+		default:
+			hasUnknownState = true
 		}
 	}
 
 	switch {
 	case len(result.FailedChecks) > 0:
 		result.Status = "failure"
-	case hasCodePending:
+	case hasCodePending || hasUnknownState:
 		result.Status = "pending"
 	default:
 		result.Status = "success"

--- a/internal/pipeline/feedback_test.go
+++ b/internal/pipeline/feedback_test.go
@@ -36,6 +36,11 @@ func TestShouldPromoteDraft(t *testing.T) {
 			wantPromote: true,
 		},
 		{
+			name:        "pending does not promote even with metadata failure present",
+			ci:          &ghclient.CIResult{Status: "pending", CodeFailures: false, FailedChecks: []string{"DCO"}},
+			wantPromote: false,
+		},
+		{
 			name:        "code failure does not promote",
 			ci:          &ghclient.CIResult{Status: "failure", CodeFailures: true, FailedChecks: []string{"build"}},
 			wantPromote: false,


### PR DESCRIPTION
## Summary
- treat GitHub EXPECTED check states as pending in `parseChecksOutput`
- add a regression test covering EXPECTED so draft promotion does not go ready before CI starts

## Test plan
- [x] `gofmt -w .`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go test ./...`