### PR TITLE
fix: scrub leaked personal email

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Binaries
 /auto-contributor
+/auto-contributor-v10
 /bin/
 *.exe
 *.exe~

--- a/README.md
+++ b/README.md
@@ -262,4 +262,4 @@ MIT
 
 ## Author
 
-majiayu000 <1835304752@qq.com>
+majiayu000 <user@example.com>

--- a/docs/redesign-proposal.md
+++ b/docs/redesign-proposal.md
@@ -393,7 +393,7 @@ func (o *Orchestrator) runAgent(name string, ctx map[string]any) AgentResult {
 # 全局配置
 github:
   username: majiayu000
-  email: 1835304752@qq.com
+  email: user@example.com
 
 # Agent 配置
 agents:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -66,7 +66,7 @@ func Default() *Config {
 	dataDir := filepath.Join(homeDir, ".auto-contributor")
 
 	return &Config{
-		GitHubEmail:            "1835304752@qq.com",
+		GitHubEmail:            "",
 		ClaudeTimeout:          24 * time.Hour,
 		ClaudeMaxRetries:       3,
 		WorkspaceDir:           filepath.Join(homeDir, "Desktop", "code", "opensourece", "auto-workspace"),

--- a/prompts/engineer.md
+++ b/prompts/engineer.md
@@ -72,7 +72,7 @@ Run ALL of these before marking complete:
 
 ```bash
 git config user.name "majiayu000"
-git config user.email "1835304752@qq.com"
+git config user.email "user@example.com"
 ```
 
 ## Commit Rules

--- a/prompts/responder.md
+++ b/prompts/responder.md
@@ -54,7 +54,7 @@ the PR was first created.
 
 ```bash
 git config user.name "majiayu000"
-git config user.email "1835304752@qq.com"
+git config user.email "user@example.com"
 ```
 
 ## Commit Rules


### PR DESCRIPTION
## Summary
- replace leaked personal email values in defaults and docs with safe placeholders
- remove the tracked binary artifact that still contained the email
- ignore the deleted binary path so it does not get reintroduced

## Test plan
- [x] `git grep -nEI '(AKIA[0-9A-Z]{16}|AIza[0-9A-Za-z_-]{35}|ghp_[A-Za-z0-9]{36}|github_pat_[A-Za-z0-9_]+|sk-[A-Za-z0-9_-]{20,}|-----BEGIN (RSA |EC |OPENSSH |DSA |PGP |PRIVATE )?PRIVATE KEY-----|authorization:[[:space:]]*(bearer|token)[[:space:]]+[A-Za-z0-9._-]+|password[[:space:]]*[:=][[:space:]]*[^[:space:]]+|secret[[:space:]]*[:=][[:space:]]*[^[:space:]]+|token[[:space:]]*[:=][[:space:]]*[^[:space:]]+)' -- . || true`
- [x] `git grep -n '1835304752@qq.com' -- . ':(exclude).git' || true`