### PR TITLE
fix reviewer parse failures in pipeline

### DIFF
--- a/docs/pr-49-signal-report.md
+++ b/docs/pr-49-signal-report.md
@@ -1,0 +1,29 @@
+# Signal Report: PR 49 Reviewer Parse Failure Blocks
+
+Issue: https://github.com/majiayu000/auto-contributor/issues/45
+PR: https://github.com/majiayu000/auto-contributor/pull/49
+
+## Root Cause
+
+The original engineer-review loop treated reviewer `RunJSON` runtime or
+JSON parse failures as implicit approval, allowing the pipeline to continue
+toward submission without a valid reviewer result.
+
+## Current Branch Diagnosis
+
+- `internal/pipeline/agents.go` now records a failed reviewer event, marks the
+  issue failed with `reviewer_failed`, and returns the reviewer error.
+- Existing regression tests cover failed issue status for reviewer parse and
+  runtime failures.
+- The remaining enforcement gap is that tests do not assert the failure is
+  persisted to `pipeline_events`, even though issue #45 requires recording it.
+
+## Fix Direction
+
+Add deterministic regression assertions that reviewer parse and runtime
+failures create failed reviewer events containing the original error message.
+
+## Review Comments
+
+- PR review comments: none.
+- PR submitted reviews: none.

--- a/docs/pr-49-signal-report.md
+++ b/docs/pr-49-signal-report.md
@@ -9,21 +9,31 @@ The original engineer-review loop treated reviewer `RunJSON` runtime or
 JSON parse failures as implicit approval, allowing the pipeline to continue
 toward submission without a valid reviewer result.
 
-## Current Branch Diagnosis
+## Branch Diagnosis
 
 - `internal/pipeline/agents.go` now records a failed reviewer event, marks the
   issue failed with `reviewer_failed`, and returns the reviewer error.
-- Existing regression tests cover failed issue status for reviewer parse and
-  runtime failures.
-- The remaining enforcement gap is that tests do not assert the failure is
-  persisted to `pipeline_events`, even though issue #45 requires recording it.
+- Regression tests cover failed issue status for reviewer parse and runtime
+  failures.
+- Regression tests also assert that the failure is persisted to
+  `pipeline_events` with `stage=reviewer`, `success=false`, `verdict=error`,
+  and the original error message.
 
-## Fix Direction
+## Resolution
 
-Add deterministic regression assertions that reviewer parse and runtime
-failures create failed reviewer events containing the original error message.
+- Reviewer parse/runtime failures no longer become implicit approval.
+- The engineer-review loop stops immediately on reviewer failures.
+- The issue status and event log both preserve the reviewer failure signal.
 
 ## Review Comments
 
 - PR review comments: none.
 - PR submitted reviews: none.
+
+## Validation
+
+- `gofmt -w .`: passed
+- `go vet ./...`: passed
+- `go build ./...`: passed
+- `go test ./...`: passed
+- `cargo check && cargo test`: not applicable; repository has no `Cargo.toml`

--- a/internal/pipeline/agent_test.go
+++ b/internal/pipeline/agent_test.go
@@ -228,3 +228,55 @@ func TestEngineerReviewLoop_ReviewerParseFailureBlocksAndFailsIssue(t *testing.T
 		t.Fatalf("got error_message=%q, want reviewer_failed prefix", stored.ErrorMessage)
 	}
 }
+
+func TestEngineerReviewLoop_ReviewerRuntimeFailureBlocksAndFailsIssue(t *testing.T) {
+	rt := &stubRuntime{outputs: []stubOutput{
+		{output: "FIX_COMPLETE"},
+		{err: errors.New("reviewer runtime exploded")},
+	}}
+	p, database := newLoopTestPipeline(t, rt)
+
+	issue := &models.Issue{
+		Repo:            "owner/repo",
+		IssueNumber:     45,
+		Title:           "reviewer runtime failure should block",
+		Status:          models.IssueStatusDiscovered,
+		DifficultyScore: 0.1,
+	}
+	if err := database.CreateIssue(issue); err != nil {
+		t.Fatalf("create issue: %v", err)
+	}
+
+	analyst := &AnalystResult{
+		CanFix:       true,
+		BaseBranch:   "main",
+		CommitFormat: "test",
+		BranchName:   "feat/test-45",
+		FixPlan: FixPlan{
+			Description:  "minimal fix",
+			TestStrategy: "go test ./...",
+		},
+	}
+
+	rounds, _, err := p.engineerReviewLoopWithStats(context.Background(), issue, t.TempDir(), analyst)
+	if err == nil {
+		t.Fatal("expected reviewer runtime failure error, got nil")
+	}
+	if rounds != 1 {
+		t.Fatalf("got rounds=%d, want 1", rounds)
+	}
+	if !strings.Contains(err.Error(), "reviewer runtime exploded") {
+		t.Fatalf("got error %q, want reviewer runtime failure", err)
+	}
+
+	stored, err := database.GetIssueByID(issue.ID)
+	if err != nil {
+		t.Fatalf("get issue: %v", err)
+	}
+	if stored.Status != models.IssueStatusFailed {
+		t.Fatalf("got status=%q, want %q", stored.Status, models.IssueStatusFailed)
+	}
+	if !strings.Contains(stored.ErrorMessage, "reviewer_failed") {
+		t.Fatalf("got error_message=%q, want reviewer_failed prefix", stored.ErrorMessage)
+	}
+}

--- a/internal/pipeline/agent_test.go
+++ b/internal/pipeline/agent_test.go
@@ -1,8 +1,90 @@
 package pipeline
 
 import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/majiayu000/auto-contributor/internal/db"
+	"github.com/majiayu000/auto-contributor/internal/prompt"
+	"github.com/majiayu000/auto-contributor/internal/rules"
+	"github.com/majiayu000/auto-contributor/internal/runtime"
+	"github.com/majiayu000/auto-contributor/pkg/models"
 )
+
+var _ runtime.Runtime = (*stubRuntime)(nil)
+
+type stubRuntime struct {
+	outputs []stubOutput
+	index   int
+}
+
+type stubOutput struct {
+	output string
+	err    error
+}
+
+func (r *stubRuntime) Name() string {
+	return "stub"
+}
+
+func (r *stubRuntime) Execute(ctx context.Context, workDir string, prompt string) (string, error) {
+	if r.index >= len(r.outputs) {
+		return "", errors.New("unexpected runtime call")
+	}
+	result := r.outputs[r.index]
+	r.index++
+	return result.output, result.err
+}
+
+func (r *stubRuntime) ExecuteStdin(ctx context.Context, prompt string) (string, error) {
+	return "", errors.New("not implemented")
+}
+
+func writePromptTemplate(t *testing.T, dir, name, body string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name+".md"), []byte(body), 0644); err != nil {
+		t.Fatalf("write %s prompt: %v", name, err)
+	}
+}
+
+func newLoopTestPipeline(t *testing.T, rt runtime.Runtime) (*Pipeline, *db.DB) {
+	t.Helper()
+
+	database, err := db.New(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("create test db: %v", err)
+	}
+	deferCleanup := func() {
+		_ = database.Close()
+	}
+	t.Cleanup(deferCleanup)
+
+	promptsDir := t.TempDir()
+	writePromptTemplate(t, promptsDir, "engineer", `engineer {{.IssueTitle}}`)
+	writePromptTemplate(t, promptsDir, "reviewer", `reviewer {{.IssueTitle}}`)
+
+	ps := prompt.NewStore(promptsDir)
+	if err := ps.Load(); err != nil {
+		t.Fatalf("load prompts: %v", err)
+	}
+
+	rl := rules.NewRuleLoader(t.TempDir())
+	if err := rl.Load(); err != nil {
+		t.Fatalf("load rules: %v", err)
+	}
+
+	return &Pipeline{
+		db:         database,
+		prompts:    ps,
+		runner:     NewAgentRunner(ps, rt, 0),
+		ruleLoader: rl,
+		maxReview:  2,
+	}, database
+}
 
 func TestExtractJSON_PlainJSON(t *testing.T) {
 	var dest map[string]any
@@ -91,5 +173,58 @@ func TestExtractFromCodeFence_NoFence(t *testing.T) {
 	s := extractFromCodeFence("no fences here")
 	if s != "" {
 		t.Errorf("expected empty string, got %q", s)
+	}
+}
+
+func TestEngineerReviewLoop_ReviewerParseFailureBlocksAndFailsIssue(t *testing.T) {
+	rt := &stubRuntime{outputs: []stubOutput{
+		{output: "FIX_COMPLETE"},
+		{output: "not json at all"},
+		{output: "still not json"},
+	}}
+	p, database := newLoopTestPipeline(t, rt)
+
+	issue := &models.Issue{
+		Repo:            "owner/repo",
+		IssueNumber:     45,
+		Title:           "reviewer parse failure should block",
+		Status:          models.IssueStatusDiscovered,
+		DifficultyScore: 0.1,
+	}
+	if err := database.CreateIssue(issue); err != nil {
+		t.Fatalf("create issue: %v", err)
+	}
+
+	analyst := &AnalystResult{
+		CanFix:       true,
+		BaseBranch:   "main",
+		CommitFormat: "test",
+		BranchName:   "feat/test-45",
+		FixPlan: FixPlan{
+			Description:  "minimal fix",
+			TestStrategy: "go test ./...",
+		},
+	}
+
+	rounds, _, err := p.engineerReviewLoopWithStats(context.Background(), issue, t.TempDir(), analyst)
+	if err == nil {
+		t.Fatal("expected reviewer failure error, got nil")
+	}
+	if rounds != 1 {
+		t.Fatalf("got rounds=%d, want 1", rounds)
+	}
+	if !strings.Contains(err.Error(), "parse reviewer JSON output") {
+		t.Fatalf("got error %q, want reviewer parse failure", err)
+	}
+
+	stored, err := database.GetIssueByID(issue.ID)
+	if err != nil {
+		t.Fatalf("get issue: %v", err)
+	}
+	if stored.Status != models.IssueStatusFailed {
+		t.Fatalf("got status=%q, want %q", stored.Status, models.IssueStatusFailed)
+	}
+	if !strings.Contains(stored.ErrorMessage, "reviewer_failed") {
+		t.Fatalf("got error_message=%q, want reviewer_failed prefix", stored.ErrorMessage)
 	}
 }

--- a/internal/pipeline/agent_test.go
+++ b/internal/pipeline/agent_test.go
@@ -86,6 +86,34 @@ func newLoopTestPipeline(t *testing.T, rt runtime.Runtime) (*Pipeline, *db.DB) {
 	}, database
 }
 
+func assertReviewerFailureEvent(t *testing.T, database *db.DB, issueID int64, wantErr string) {
+	t.Helper()
+
+	events, err := database.GetEventsByIssue(issueID)
+	if err != nil {
+		t.Fatalf("get events: %v", err)
+	}
+	for _, event := range events {
+		if event.Stage != "reviewer" {
+			continue
+		}
+		if event.Round != 1 {
+			t.Fatalf("got reviewer round=%d, want 1", event.Round)
+		}
+		if event.Success {
+			t.Fatal("got reviewer success=true, want false")
+		}
+		if event.Verdict != "error" {
+			t.Fatalf("got reviewer verdict=%q, want error", event.Verdict)
+		}
+		if !strings.Contains(event.ErrorMessage, wantErr) {
+			t.Fatalf("got reviewer error_message=%q, want %q", event.ErrorMessage, wantErr)
+		}
+		return
+	}
+	t.Fatal("expected reviewer failure event, found none")
+}
+
 func TestExtractJSON_PlainJSON(t *testing.T) {
 	var dest map[string]any
 	err := extractJSON(`{"verdict":"PROCEED","score":0.9}`, &dest)
@@ -227,6 +255,8 @@ func TestEngineerReviewLoop_ReviewerParseFailureBlocksAndFailsIssue(t *testing.T
 	if !strings.Contains(stored.ErrorMessage, "reviewer_failed") {
 		t.Fatalf("got error_message=%q, want reviewer_failed prefix", stored.ErrorMessage)
 	}
+
+	assertReviewerFailureEvent(t, database, issue.ID, "parse reviewer JSON output")
 }
 
 func TestEngineerReviewLoop_ReviewerRuntimeFailureBlocksAndFailsIssue(t *testing.T) {
@@ -279,4 +309,6 @@ func TestEngineerReviewLoop_ReviewerRuntimeFailureBlocksAndFailsIssue(t *testing
 	if !strings.Contains(stored.ErrorMessage, "reviewer_failed") {
 		t.Fatalf("got error_message=%q, want reviewer_failed prefix", stored.ErrorMessage)
 	}
+
+	assertReviewerFailureEvent(t, database, issue.ID, "reviewer runtime exploded")
 }

--- a/internal/pipeline/agents.go
+++ b/internal/pipeline/agents.go
@@ -414,8 +414,9 @@ func (p *Pipeline) engineerReviewLoopWithStats(ctx context.Context, issue *model
 		revCtx := p.buildReviewerCtx(issue, analyst, round, lastReview, revRulesFormatted)
 		revStart := time.Now()
 		if _, err := p.runner.RunJSON(ctx, "reviewer", workspace, revCtx, &review); err != nil {
-			log.WithError(err).Warn("reviewer parse error, treating as approve")
-			review.Verdict = "approve"
+			p.recordEvent(issue, nil, "reviewer", round, revStart, "error", false, "", err.Error(), reviewerRules)
+			p.markFailed(issue, "reviewer_failed", err.Error())
+			return round, lastSummary, err
 		}
 		reviewSummaryJSON, _ := json.Marshal(map[string]any{"verdict": review.Verdict, "confidence": review.Confidence, "issues": len(review.IssuesFound)})
 		lastSummary = review.Summary


### PR DESCRIPTION
Closes #45

## Summary
- fail closed when the reviewer agent returns malformed or unparsable JSON in the engineer→reviewer loop
- record the reviewer failure and mark the issue failed instead of forcing an approval verdict
- add a regression test covering malformed reviewer output in the real loop

## Test plan
- [x] gofmt -w .
- [x] go vet ./...
- [x] go build ./...
- [x] go test ./...