### PR TITLE
Preserve hostile moderation signals in PR outcome classification

### DIFF
--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -36,12 +36,13 @@ type PRReviewComment struct {
 
 // PRInfo bundles state + reviews from a single gh call.
 type PRInfo struct {
-	State     string     `json:"state"`
-	IsDraft   bool       `json:"isDraft"`
-	Reviews   []PRReview `json:"reviews"`
-	CreatedAt string     `json:"createdAt"` // RFC3339, authoritative GitHub PR open time
-	MergedAt  string     `json:"mergedAt"`  // RFC3339, set when state=MERGED
-	ClosedAt  string     `json:"closedAt"`  // RFC3339, set when state=CLOSED or MERGED
+	State      string     `json:"state"`
+	IsDraft    bool       `json:"isDraft"`
+	LockReason string     `json:"lockReason"`
+	Reviews    []PRReview `json:"reviews"`
+	CreatedAt  string     `json:"createdAt"` // RFC3339, authoritative GitHub PR open time
+	MergedAt   string     `json:"mergedAt"`  // RFC3339, set when state=MERGED
+	ClosedAt   string     `json:"closedAt"`  // RFC3339, set when state=CLOSED or MERGED
 }
 
 // GetPRInfo fetches state and reviews in one gh call to avoid rate limiting.
@@ -49,7 +50,7 @@ func (c *Client) GetPRInfo(ctx context.Context, repo string, prNum int) (*PRInfo
 	cmd := exec.CommandContext(ctx, "gh", "pr", "view",
 		fmt.Sprintf("%d", prNum),
 		"-R", repo,
-		"--json", "state,isDraft,reviews,createdAt,mergedAt,closedAt")
+		"--json", "state,isDraft,lockReason,reviews,createdAt,mergedAt,closedAt")
 
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
@@ -60,12 +61,13 @@ func (c *Client) GetPRInfo(ctx context.Context, repo string, prNum int) (*PRInfo
 
 	// Parse with nested author object
 	var raw struct {
-		State     string `json:"state"`
-		IsDraft   bool   `json:"isDraft"`
-		CreatedAt string `json:"createdAt"`
-		MergedAt  string `json:"mergedAt"`
-		ClosedAt  string `json:"closedAt"`
-		Reviews   []struct {
+		State      string `json:"state"`
+		IsDraft    bool   `json:"isDraft"`
+		LockReason string `json:"lockReason"`
+		CreatedAt  string `json:"createdAt"`
+		MergedAt   string `json:"mergedAt"`
+		ClosedAt   string `json:"closedAt"`
+		Reviews    []struct {
 			Author struct {
 				Login string `json:"login"`
 			} `json:"author"`
@@ -78,7 +80,14 @@ func (c *Client) GetPRInfo(ctx context.Context, repo string, prNum int) (*PRInfo
 		return nil, fmt.Errorf("parse PR info: %w", err)
 	}
 
-	info := &PRInfo{State: raw.State, IsDraft: raw.IsDraft, CreatedAt: raw.CreatedAt, MergedAt: raw.MergedAt, ClosedAt: raw.ClosedAt}
+	info := &PRInfo{
+		State:      raw.State,
+		IsDraft:    raw.IsDraft,
+		LockReason: raw.LockReason,
+		CreatedAt:  raw.CreatedAt,
+		MergedAt:   raw.MergedAt,
+		ClosedAt:   raw.ClosedAt,
+	}
 	for _, r := range raw.Reviews {
 		info.Reviews = append(info.Reviews, PRReview{
 			Author:      r.Author.Login,

--- a/internal/pipeline/outcome.go
+++ b/internal/pipeline/outcome.go
@@ -10,6 +10,7 @@ import (
 // Outcome labels for pipeline events.
 const (
 	OutcomeMerged          = "merged"
+	OutcomeHostileSpam     = "hostile_spam"
 	OutcomeRejectedScope   = "rejected_scope"
 	OutcomeRejectedQuality = "rejected_quality"
 	OutcomeRejectedStyle   = "rejected_style"
@@ -31,6 +32,9 @@ var outcomeKeywords = map[string][]string{
 func ClassifyOutcome(prInfo *ghclient.PRInfo, issueComments []ghclient.IssueComment, pr *models.PullRequest) string {
 	if prInfo.State == "MERGED" {
 		return OutcomeMerged
+	}
+	if prInfo.State == "CLOSED" && isHostileLockReason(prInfo.LockReason) {
+		return OutcomeHostileSpam
 	}
 
 	// Check if we auto-closed it
@@ -70,4 +74,13 @@ func ClassifyOutcome(prInfo *ghclient.PRInfo, issueComments []ghclient.IssueComm
 	}
 
 	return OutcomeUnknownClosed
+}
+
+func isHostileLockReason(lockReason string) bool {
+	switch lockReason {
+	case "SPAM", "OFF_TOPIC":
+		return true
+	default:
+		return false
+	}
 }

--- a/internal/pipeline/outcome_test.go
+++ b/internal/pipeline/outcome_test.go
@@ -1,0 +1,20 @@
+package pipeline
+
+import (
+	"testing"
+
+	ghclient "github.com/majiayu000/auto-contributor/internal/github"
+	"github.com/majiayu000/auto-contributor/pkg/models"
+)
+
+func TestClassifyOutcome_HostileSpamLockReason(t *testing.T) {
+	prInfo := &ghclient.PRInfo{
+		State:      "CLOSED",
+		LockReason: "SPAM",
+	}
+
+	got := ClassifyOutcome(prInfo, nil, &models.PullRequest{})
+	if got != OutcomeHostileSpam {
+		t.Fatalf("ClassifyOutcome() = %q, want %q", got, OutcomeHostileSpam)
+	}
+}

--- a/internal/pipeline/qvalue.go
+++ b/internal/pipeline/qvalue.go
@@ -17,6 +17,7 @@ const qAlpha = 0.1
 //	unknown_closed → 0.2  (closed without clear reason; may not be our fault)
 //	auto_closed    → 0.5  (closed for external reasons such as inactivity/CI timeout;
 //	                       not attributable to rule quality — neutral signal)
+//	hostile_spam   → 0.5  (closed for hostile/spam moderation; neutral signal)
 //	everything else → 0.0  (rejected for a specific reason)
 func rewardForOutcome(outcomeLabel string) float64 {
 	switch outcomeLabel {
@@ -24,7 +25,7 @@ func rewardForOutcome(outcomeLabel string) float64 {
 		return 1.0
 	case OutcomeUnknownClosed:
 		return 0.2
-	case OutcomeAutoClosed:
+	case OutcomeAutoClosed, OutcomeHostileSpam:
 		return 0.5
 	default:
 		return 0.0

--- a/internal/pipeline/qvalue_test.go
+++ b/internal/pipeline/qvalue_test.go
@@ -1,0 +1,9 @@
+package pipeline
+
+import "testing"
+
+func TestRewardForOutcome_HostileSpamIsNeutral(t *testing.T) {
+	if got := rewardForOutcome(OutcomeHostileSpam); got != 0.5 {
+		t.Fatalf("rewardForOutcome(%q) = %v, want 0.5", OutcomeHostileSpam, got)
+	}
+}


### PR DESCRIPTION
Closes #47\n\n## Summary\n- request and store PR lock reasons from gh CLI metadata\n- classify spam/off-topic moderation closures as hostile instead of generic closed\n- add a regression test covering spam-locked closures\n\n## Verification\n- gofmt -w .\n- go vet ./...\n- go build ./...\n- go test ./...\n\n## Notes\n- cargo check/test are not applicable in this repository because there is no Cargo.toml