### PR TITLE
ci: add Go build and test workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build and test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+          cache: true
+
+      - name: Resolve dependencies
+        run: go mod download
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Build
+        run: go build ./...
+
+      - name: Test
+        run: go test ./...


### PR DESCRIPTION
## Summary
- Adds a minimal GitHub Actions CI workflow (go vet / build / test) for every push to `main` and every pull request.
- Unblocks PR review convergence for pull requests that previously had no CI checks (e.g. #49).

## Test plan
- [ ] Workflow run succeeds on this PR
- [ ] After merge, existing open PRs (e.g. #49) start receiving CI status checks