### PR TITLE
fix: harden hostile PR lock classification

### DIFF
--- a/docs/lockreason-signal-report.md
+++ b/docs/lockreason-signal-report.md
@@ -1,0 +1,35 @@
+# Signal Report: Lock Reason Classification Path
+
+Issue source: harness finding `LOGIC-03`
+
+## Root Cause
+
+The finding is stale against `origin/main`: the current code already requests
+`lockReason` from `gh pr view`, stores it on `github.PRInfo`, and classifies
+`CLOSED` PRs with hostile lock reasons as `hostile_spam`.
+
+The remaining risk is regression at two boundaries:
+
+- `GetPRInfo` has no unit test proving `lockReason` survives JSON parsing.
+- Hostile lock classification is case-sensitive, so any lowercase
+  `"spam"`/`"off_topic"` value from a future caller would fall through to
+  generic closure buckets.
+
+## Resolution
+
+- Add a focused parser helper test that proves `lockReason` is decoded into
+  `PRInfo`.
+- Normalize lock reasons during classification so casing differences do not
+  suppress `hostile_spam`.
+
+## Review Notes
+
+- No GitHub issue was created because the defect report is already covered by
+  the current codebase and the remaining work is a regression hardening change.
+
+## Validation
+
+- `gofmt -w .`: passed
+- `go vet ./...`: passed
+- `go build ./...`: passed
+- `go test ./...`: passed

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -59,6 +59,14 @@ func (c *Client) GetPRInfo(ctx context.Context, repo string, prNum int) (*PRInfo
 		return nil, fmt.Errorf("gh pr view %s#%d: %s", repo, prNum, stderr.String())
 	}
 
+	info, err := parsePRInfoOutput(output)
+	if err != nil {
+		return nil, err
+	}
+	return info, nil
+}
+
+func parsePRInfoOutput(output []byte) (*PRInfo, error) {
 	// Parse with nested author object
 	var raw struct {
 		State      string `json:"state"`

--- a/internal/github/pr_test.go
+++ b/internal/github/pr_test.go
@@ -1,0 +1,36 @@
+package github
+
+import "testing"
+
+func TestParsePRInfoOutput_PopulatesLockReason(t *testing.T) {
+	data := []byte(`{
+		"state":"CLOSED",
+		"isDraft":false,
+		"lockReason":"SPAM",
+		"createdAt":"2026-04-01T00:00:00Z",
+		"mergedAt":"",
+		"closedAt":"2026-04-02T00:00:00Z",
+		"reviews":[
+			{
+				"author":{"login":"reviewer1"},
+				"state":"COMMENTED",
+				"body":"needs work",
+				"submittedAt":"2026-04-01T01:00:00Z"
+			}
+		]
+	}`)
+
+	info, err := parsePRInfoOutput(data)
+	if err != nil {
+		t.Fatalf("parsePRInfoOutput() error = %v", err)
+	}
+	if info.LockReason != "SPAM" {
+		t.Fatalf("LockReason = %q, want %q", info.LockReason, "SPAM")
+	}
+	if len(info.Reviews) != 1 {
+		t.Fatalf("len(Reviews) = %d, want 1", len(info.Reviews))
+	}
+	if info.Reviews[0].Author != "reviewer1" {
+		t.Fatalf("Reviews[0].Author = %q, want %q", info.Reviews[0].Author, "reviewer1")
+	}
+}

--- a/internal/pipeline/outcome.go
+++ b/internal/pipeline/outcome.go
@@ -77,7 +77,7 @@ func ClassifyOutcome(prInfo *ghclient.PRInfo, issueComments []ghclient.IssueComm
 }
 
 func isHostileLockReason(lockReason string) bool {
-	switch lockReason {
+	switch strings.ToUpper(lockReason) {
 	case "SPAM", "OFF_TOPIC":
 		return true
 	default:

--- a/internal/pipeline/outcome_test.go
+++ b/internal/pipeline/outcome_test.go
@@ -18,3 +18,15 @@ func TestClassifyOutcome_HostileSpamLockReason(t *testing.T) {
 		t.Fatalf("ClassifyOutcome() = %q, want %q", got, OutcomeHostileSpam)
 	}
 }
+
+func TestClassifyOutcome_HostileSpamLockReasonLowercase(t *testing.T) {
+	prInfo := &ghclient.PRInfo{
+		State:      "CLOSED",
+		LockReason: "spam",
+	}
+
+	got := ClassifyOutcome(prInfo, nil, &models.PullRequest{})
+	if got != OutcomeHostileSpam {
+		t.Fatalf("ClassifyOutcome() = %q, want %q", got, OutcomeHostileSpam)
+	}
+}


### PR DESCRIPTION
## Summary
- add a durable signal report documenting that the original finding was stale on `origin/main`
- extract and test PR info parsing so `lockReason` propagation is covered explicitly
- normalize hostile lock reason classification so lowercase values still map to `hostile_spam`

## Validation
- `gofmt -w .`
- `go vet ./...`
- `go build ./...`
- `go test ./...`