### PR TITLE
feat: semantic retrieval for self-learning rules

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,13 +4,21 @@ GITHUB_USERNAME=your_github_username
 GITHUB_EMAIL=your_email@example.com
 
 # Database Configuration (optional - defaults to local SQLite)
-# For PostgreSQL (Supabase/Neon/etc), set this:
+# Semantic retrieval requires PostgreSQL with pgvector (Supabase works out of the box).
 # Get from: Supabase Dashboard > Project Settings > Database > Connection string > URI
 # DATABASE_URL=postgres://postgres:[YOUR-PASSWORD]@db.[PROJECT].supabase.co:5432/postgres
 
 # Claude Configuration (optional)
 CLAUDE_TIMEOUT=600
 CLAUDE_MAX_RETRIES=3
+
+# Semantic rule retrieval (optional; requires PostgreSQL/pgvector)
+SEMANTIC_RETRIEVAL_ENABLED=false
+SEMANTIC_RETRIEVAL_PHASE_A_CANDIDATES=20
+SEMANTIC_RETRIEVAL_TOP_K=5
+SEMANTIC_RETRIEVAL_LAMBDA=0.2
+SEMANTIC_RETRIEVAL_PROVIDER=local
+SEMANTIC_RETRIEVAL_MODEL=hash-v1
 
 # Scheduler Configuration (optional)
 SCHEDULER_TIMEZONE=UTC

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -52,8 +52,14 @@ type Config struct {
 	RuntimePath string `mapstructure:"runtime_path"` // override CLI binary path
 
 	// Self-learning
-	RulesDir          string `mapstructure:"rules_dir"`
-	SynthesisInterval int    `mapstructure:"synthesis_interval"` // hours between synthesis cycles
+	RulesDir                  string  `mapstructure:"rules_dir"`
+	SynthesisInterval         int     `mapstructure:"synthesis_interval"` // hours between synthesis cycles
+	SemanticRetrievalEnabled  bool    `mapstructure:"semantic_retrieval_enabled"`
+	SemanticRetrievalPhaseA   int     `mapstructure:"semantic_retrieval_phase_a_candidates"`
+	SemanticRetrievalTopK     int     `mapstructure:"semantic_retrieval_top_k"`
+	SemanticRetrievalLambda   float64 `mapstructure:"semantic_retrieval_lambda"`
+	SemanticRetrievalProvider string  `mapstructure:"semantic_retrieval_provider"`
+	SemanticRetrievalModel    string  `mapstructure:"semantic_retrieval_model"`
 
 	// Logging
 	LogLevel string `mapstructure:"log_level"`
@@ -66,32 +72,38 @@ func Default() *Config {
 	dataDir := filepath.Join(homeDir, ".auto-contributor")
 
 	return &Config{
-		GitHubEmail:            "",
-		ClaudeTimeout:          24 * time.Hour,
-		ClaudeMaxRetries:       3,
-		WorkspaceDir:           filepath.Join(homeDir, "Desktop", "code", "opensourece", "auto-workspace"),
-		DatabasePath:           filepath.Join(dataDir, "data.db"),
-		Languages:              []string{"go", "python", "typescript", "javascript", "rust"},
-		IncludeLabels:          []string{"good first issue", "help wanted", "bug"},
-		ExcludeLabels:          []string{"wontfix", "duplicate", "invalid"},
-		ExcludeRepos:           []string{},
-		PriorityRepos:          []string{},
-		MinRepoStars:           1000,
-		MaxIssueAgeDays:        30,
-		MaxReviewRounds:        3,
-		MaxCriticRounds:        2,
-		MaxPRsPerRepo:          1,
-		MaxConcurrentPipelines: 5,
-		PromptsDir:             filepath.Join(dataDir, "prompts"),
-		Mode:                   "full",
-		DiscoveryInterval:      30,
-		FeedbackInterval:       30,
-		Topic:                  "ai",
-		AnalysisDepth:          "deep",
-		RulesDir:               "",
-		SynthesisInterval:      24,
-		LogLevel:               "info",
-		LogFile:                filepath.Join(dataDir, "auto-contributor.log"),
+		GitHubEmail:               "",
+		ClaudeTimeout:             24 * time.Hour,
+		ClaudeMaxRetries:          3,
+		WorkspaceDir:              filepath.Join(homeDir, "Desktop", "code", "opensourece", "auto-workspace"),
+		DatabasePath:              filepath.Join(dataDir, "data.db"),
+		Languages:                 []string{"go", "python", "typescript", "javascript", "rust"},
+		IncludeLabels:             []string{"good first issue", "help wanted", "bug"},
+		ExcludeLabels:             []string{"wontfix", "duplicate", "invalid"},
+		ExcludeRepos:              []string{},
+		PriorityRepos:             []string{},
+		MinRepoStars:              1000,
+		MaxIssueAgeDays:           30,
+		MaxReviewRounds:           3,
+		MaxCriticRounds:           2,
+		MaxPRsPerRepo:             1,
+		MaxConcurrentPipelines:    5,
+		PromptsDir:                filepath.Join(dataDir, "prompts"),
+		Mode:                      "full",
+		DiscoveryInterval:         30,
+		FeedbackInterval:          30,
+		Topic:                     "ai",
+		AnalysisDepth:             "deep",
+		RulesDir:                  "",
+		SynthesisInterval:         24,
+		SemanticRetrievalEnabled:  false,
+		SemanticRetrievalPhaseA:   20,
+		SemanticRetrievalTopK:     5,
+		SemanticRetrievalLambda:   0.2,
+		SemanticRetrievalProvider: "local",
+		SemanticRetrievalModel:    "hash-v1",
+		LogLevel:                  "info",
+		LogFile:                   filepath.Join(dataDir, "auto-contributor.log"),
 	}
 }
 
@@ -113,6 +125,12 @@ func Load() (*Config, error) {
 	viper.BindEnv("github_token", "GITHUB_TOKEN")
 	viper.BindEnv("github_username", "GITHUB_USERNAME")
 	viper.BindEnv("database_url", "DATABASE_URL")
+	viper.BindEnv("semantic_retrieval_enabled", "SEMANTIC_RETRIEVAL_ENABLED")
+	viper.BindEnv("semantic_retrieval_phase_a_candidates", "SEMANTIC_RETRIEVAL_PHASE_A_CANDIDATES")
+	viper.BindEnv("semantic_retrieval_top_k", "SEMANTIC_RETRIEVAL_TOP_K")
+	viper.BindEnv("semantic_retrieval_lambda", "SEMANTIC_RETRIEVAL_LAMBDA")
+	viper.BindEnv("semantic_retrieval_provider", "SEMANTIC_RETRIEVAL_PROVIDER")
+	viper.BindEnv("semantic_retrieval_model", "SEMANTIC_RETRIEVAL_MODEL")
 
 	// Read config file (optional)
 	if err := viper.ReadInConfig(); err != nil {

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -126,6 +126,9 @@ func (db *DB) Migrate() error {
 	if err := db.MigrateTrajectories(); err != nil {
 		return err
 	}
+	if err := db.MigrateRuleEmbeddings(); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -101,6 +101,65 @@ func TestCreatePullRequestPopulatesIDAndSupportsUpdatePostgres(t *testing.T) {
 	testCreatePullRequestPopulatesIDAndSupportsUpdate(t, db)
 }
 
+func TestRuleEmbeddingsSQLiteNoop(t *testing.T) {
+	db := newSQLiteTestDB(t)
+
+	if err := db.MigrateRuleEmbeddings(); err != nil {
+		t.Fatalf("MigrateRuleEmbeddings() failed: %v", err)
+	}
+	hashes, err := db.GetRuleEmbeddingHashes()
+	if err != nil {
+		t.Fatalf("GetRuleEmbeddingHashes() failed: %v", err)
+	}
+	if len(hashes) != 0 {
+		t.Fatalf("hash count = %d, want 0", len(hashes))
+	}
+	if err := db.UpsertRuleEmbedding("engineer/rule", "engineer", "hash", []float64{0.1, 0.2}, "hash-v1"); err != nil {
+		t.Fatalf("UpsertRuleEmbedding() failed: %v", err)
+	}
+	if err := db.DeleteRuleEmbeddingsExcept([]string{"engineer/rule"}); err != nil {
+		t.Fatalf("DeleteRuleEmbeddingsExcept() failed: %v", err)
+	}
+	candidates, err := db.FindRuleEmbeddingCandidates([]string{"engineer"}, []float64{0.1, 0.2}, 5)
+	if err != nil {
+		t.Fatalf("FindRuleEmbeddingCandidates() failed: %v", err)
+	}
+	if len(candidates) != 0 {
+		t.Fatalf("candidate count = %d, want 0", len(candidates))
+	}
+}
+
+func TestMigrateRuleEmbeddingsPostgresCreatesVectorSchema(t *testing.T) {
+	stub := &ruleEmbeddingsPostgresStub{}
+	registerRuleEmbeddingsPostgresStub(t, stub)
+
+	sqlDB, err := sql.Open(ruleEmbeddingsPostgresStubDriverName, "")
+	if err != nil {
+		t.Fatalf("open stub postgres db: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = sqlDB.Close()
+	})
+
+	db := &DB{DB: sqlDB, dbType: DBTypePostgres}
+	if err := db.MigrateRuleEmbeddings(); err != nil {
+		t.Fatalf("MigrateRuleEmbeddings() failed: %v", err)
+	}
+
+	if len(stub.execQueries) != 3 {
+		t.Fatalf("exec count = %d, want 3", len(stub.execQueries))
+	}
+	if stub.execQueries[0] != "CREATE EXTENSION IF NOT EXISTS vector" {
+		t.Fatalf("first query = %q", stub.execQueries[0])
+	}
+	if !strings.Contains(stub.execQueries[1], "CREATE TABLE IF NOT EXISTS rule_embeddings") || !strings.Contains(stub.execQueries[1], "embedding vector(64) NOT NULL") {
+		t.Fatalf("table query = %q", stub.execQueries[1])
+	}
+	if stub.execQueries[2] != "CREATE INDEX IF NOT EXISTS idx_rule_embeddings_stage ON rule_embeddings(stage)" {
+		t.Fatalf("index query = %q", stub.execQueries[2])
+	}
+}
+
 func testCreatePullRequestPopulatesIDAndSupportsUpdate(t *testing.T, db *DB) {
 
 	uniqueSuffix := time.Now().UnixNano()
@@ -191,11 +250,14 @@ func newSQLiteTestDB(t *testing.T) *DB {
 }
 
 const createPullRequestPostgresStubDriverName = "create_pull_request_postgres_stub"
+const ruleEmbeddingsPostgresStubDriverName = "rule_embeddings_postgres_stub"
 
 var createPullRequestPostgresStubValue atomic.Pointer[createPullRequestPostgresStub]
+var ruleEmbeddingsPostgresStubValue atomic.Pointer[ruleEmbeddingsPostgresStub]
 
 func init() {
 	sql.Register(createPullRequestPostgresStubDriverName, createPullRequestPostgresStubDriver{})
+	sql.Register(ruleEmbeddingsPostgresStubDriverName, ruleEmbeddingsPostgresStubDriver{})
 }
 
 func registerCreatePullRequestPostgresStub(t *testing.T, stub *createPullRequestPostgresStub) {
@@ -203,6 +265,14 @@ func registerCreatePullRequestPostgresStub(t *testing.T, stub *createPullRequest
 	createPullRequestPostgresStubValue.Store(stub)
 	t.Cleanup(func() {
 		createPullRequestPostgresStubValue.Store(nil)
+	})
+}
+
+func registerRuleEmbeddingsPostgresStub(t *testing.T, stub *ruleEmbeddingsPostgresStub) {
+	t.Helper()
+	ruleEmbeddingsPostgresStubValue.Store(stub)
+	t.Cleanup(func() {
+		ruleEmbeddingsPostgresStubValue.Store(nil)
 	})
 }
 
@@ -215,6 +285,7 @@ type createPullRequestPostgresStub struct {
 }
 
 type createPullRequestPostgresStubDriver struct{}
+type ruleEmbeddingsPostgresStubDriver struct{}
 
 func (createPullRequestPostgresStubDriver) Open(string) (driver.Conn, error) {
 	stub := createPullRequestPostgresStubValue.Load()
@@ -224,8 +295,24 @@ func (createPullRequestPostgresStubDriver) Open(string) (driver.Conn, error) {
 	return &createPullRequestPostgresStubConn{stub: stub}, nil
 }
 
+func (ruleEmbeddingsPostgresStubDriver) Open(string) (driver.Conn, error) {
+	stub := ruleEmbeddingsPostgresStubValue.Load()
+	if stub == nil {
+		return nil, fmt.Errorf("rule embeddings postgres stub not registered")
+	}
+	return &ruleEmbeddingsPostgresStubConn{stub: stub}, nil
+}
+
 type createPullRequestPostgresStubConn struct {
 	stub *createPullRequestPostgresStub
+}
+
+type ruleEmbeddingsPostgresStub struct {
+	execQueries []string
+}
+
+type ruleEmbeddingsPostgresStubConn struct {
+	stub *ruleEmbeddingsPostgresStub
 }
 
 func (c *createPullRequestPostgresStubConn) Prepare(string) (driver.Stmt, error) {
@@ -248,6 +335,27 @@ func (c *createPullRequestPostgresStubConn) QueryContext(_ context.Context, quer
 		columns: []string{"id"},
 		rows:    [][]driver.Value{{c.stub.nextID}},
 	}, nil
+}
+
+func (c *ruleEmbeddingsPostgresStubConn) Prepare(string) (driver.Stmt, error) {
+	return nil, fmt.Errorf("prepare not implemented")
+}
+
+func (c *ruleEmbeddingsPostgresStubConn) Close() error {
+	return nil
+}
+
+func (c *ruleEmbeddingsPostgresStubConn) Begin() (driver.Tx, error) {
+	return nil, fmt.Errorf("transactions not implemented")
+}
+
+func (c *ruleEmbeddingsPostgresStubConn) QueryContext(_ context.Context, _ string, _ []driver.NamedValue) (driver.Rows, error) {
+	return nil, fmt.Errorf("unexpected QueryContext call")
+}
+
+func (c *ruleEmbeddingsPostgresStubConn) ExecContext(_ context.Context, query string, _ []driver.NamedValue) (driver.Result, error) {
+	c.stub.execQueries = append(c.stub.execQueries, normalizeWhitespace(query))
+	return driver.RowsAffected(0), nil
 }
 
 func (c *createPullRequestPostgresStubConn) ExecContext(context.Context, string, []driver.NamedValue) (driver.Result, error) {
@@ -523,3 +631,6 @@ func (c *filterQueryPostgresStubConn) ExecContext(context.Context, string, []dri
 var _ driver.Conn = (*filterQueryPostgresStubConn)(nil)
 var _ driver.QueryerContext = (*filterQueryPostgresStubConn)(nil)
 var _ driver.ExecerContext = (*filterQueryPostgresStubConn)(nil)
+var _ driver.Conn = (*ruleEmbeddingsPostgresStubConn)(nil)
+var _ driver.QueryerContext = (*ruleEmbeddingsPostgresStubConn)(nil)
+var _ driver.ExecerContext = (*ruleEmbeddingsPostgresStubConn)(nil)

--- a/internal/db/rule_embeddings.go
+++ b/internal/db/rule_embeddings.go
@@ -1,0 +1,170 @@
+package db
+
+import (
+	"database/sql"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/lib/pq"
+)
+
+const RuleEmbeddingDimensions = 64
+
+// RuleEmbeddingCandidate is a Phase A retrieval hit scored by cosine similarity.
+type RuleEmbeddingCandidate struct {
+	RuleKey    string
+	Stage      string
+	Similarity float64
+}
+
+// MigrateRuleEmbeddings creates the derived rule embedding index on PostgreSQL.
+// SQLite remains a no-op so the existing YAML full-load path keeps working.
+func (db *DB) MigrateRuleEmbeddings() error {
+	if !db.IsPostgres() {
+		return nil
+	}
+
+	statements := []string{
+		`CREATE EXTENSION IF NOT EXISTS vector`,
+		fmt.Sprintf(`
+			CREATE TABLE IF NOT EXISTS rule_embeddings (
+				rule_key TEXT PRIMARY KEY,
+				stage TEXT NOT NULL,
+				content_hash TEXT NOT NULL,
+				embedding vector(%d) NOT NULL,
+				model_name TEXT NOT NULL,
+				created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+				updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+			)
+		`, RuleEmbeddingDimensions),
+		`CREATE INDEX IF NOT EXISTS idx_rule_embeddings_stage ON rule_embeddings(stage)`,
+	}
+
+	for _, stmt := range statements {
+		if _, err := db.Exec(stmt); err != nil {
+			return fmt.Errorf("migrate rule embeddings: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// GetRuleEmbeddingHashes returns the current content hashes keyed by stage/ruleID.
+func (db *DB) GetRuleEmbeddingHashes() (map[string]string, error) {
+	if !db.IsPostgres() {
+		return map[string]string{}, nil
+	}
+
+	rows, err := db.Query(`SELECT rule_key, content_hash FROM rule_embeddings`)
+	if err != nil {
+		return nil, fmt.Errorf("query rule embedding hashes: %w", err)
+	}
+	defer rows.Close()
+
+	hashes := make(map[string]string)
+	for rows.Next() {
+		var ruleKey, contentHash string
+		if err := rows.Scan(&ruleKey, &contentHash); err != nil {
+			return nil, fmt.Errorf("scan rule embedding hash: %w", err)
+		}
+		hashes[ruleKey] = contentHash
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate rule embedding hashes: %w", err)
+	}
+
+	return hashes, nil
+}
+
+// UpsertRuleEmbedding inserts or updates a rule's derived embedding row.
+func (db *DB) UpsertRuleEmbedding(ruleKey, stage, contentHash string, embedding []float64, modelName string) error {
+	if !db.IsPostgres() {
+		return nil
+	}
+
+	const stmt = `
+		INSERT INTO rule_embeddings (rule_key, stage, content_hash, embedding, model_name)
+		VALUES ($1, $2, $3, $4::vector, $5)
+		ON CONFLICT (rule_key) DO UPDATE
+		SET stage = EXCLUDED.stage,
+			content_hash = EXCLUDED.content_hash,
+			embedding = EXCLUDED.embedding,
+			model_name = EXCLUDED.model_name,
+			updated_at = CURRENT_TIMESTAMP
+	`
+
+	if _, err := db.Exec(stmt, ruleKey, stage, contentHash, vectorLiteral(embedding), modelName); err != nil {
+		return fmt.Errorf("upsert rule embedding %s: %w", ruleKey, err)
+	}
+	return nil
+}
+
+// DeleteRuleEmbeddingsExcept removes derived rows for rules no longer present in YAML.
+func (db *DB) DeleteRuleEmbeddingsExcept(ruleKeys []string) error {
+	if !db.IsPostgres() {
+		return nil
+	}
+
+	if len(ruleKeys) == 0 {
+		if _, err := db.Exec(`DELETE FROM rule_embeddings`); err != nil {
+			return fmt.Errorf("delete rule embeddings: %w", err)
+		}
+		return nil
+	}
+
+	if _, err := db.Exec(`DELETE FROM rule_embeddings WHERE NOT (rule_key = ANY($1))`, pq.Array(ruleKeys)); err != nil {
+		return fmt.Errorf("delete stale rule embeddings: %w", err)
+	}
+	return nil
+}
+
+// FindRuleEmbeddingCandidates runs the Phase A cosine-similarity lookup.
+func (db *DB) FindRuleEmbeddingCandidates(stages []string, embedding []float64, limit int) ([]RuleEmbeddingCandidate, error) {
+	if !db.IsPostgres() || len(stages) == 0 || limit <= 0 {
+		return nil, nil
+	}
+
+	const stmt = `
+		SELECT
+			rule_key,
+			stage,
+			1 - (embedding <=> $2::vector) AS similarity
+		FROM rule_embeddings
+		WHERE stage = ANY($1)
+		ORDER BY embedding <=> $2::vector
+		LIMIT $3
+	`
+
+	rows, err := db.Query(stmt, pq.Array(stages), vectorLiteral(embedding), limit)
+	if err != nil {
+		return nil, fmt.Errorf("query rule embedding candidates: %w", err)
+	}
+	defer rows.Close()
+
+	var candidates []RuleEmbeddingCandidate
+	for rows.Next() {
+		var candidate RuleEmbeddingCandidate
+		var similarity sql.NullFloat64
+		if err := rows.Scan(&candidate.RuleKey, &candidate.Stage, &similarity); err != nil {
+			return nil, fmt.Errorf("scan rule embedding candidate: %w", err)
+		}
+		if similarity.Valid {
+			candidate.Similarity = similarity.Float64
+		}
+		candidates = append(candidates, candidate)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate rule embedding candidates: %w", err)
+	}
+
+	return candidates, nil
+}
+
+func vectorLiteral(values []float64) string {
+	parts := make([]string, 0, len(values))
+	for _, value := range values {
+		parts = append(parts, strconv.FormatFloat(value, 'f', -1, 64))
+	}
+	return "[" + strings.Join(parts, ",") + "]"
+}

--- a/internal/db/rule_embeddings.go
+++ b/internal/db/rule_embeddings.go
@@ -7,7 +7,10 @@ import (
 	"strings"
 
 	"github.com/lib/pq"
+	"github.com/majiayu000/auto-contributor/pkg/logger"
 )
+
+var log = logger.GetLogger()
 
 const RuleEmbeddingDimensions = 64
 
@@ -20,13 +23,24 @@ type RuleEmbeddingCandidate struct {
 
 // MigrateRuleEmbeddings creates the derived rule embedding index on PostgreSQL.
 // SQLite remains a no-op so the existing YAML full-load path keeps working.
+//
+// pgvector is treated as optional: if the `vector` extension cannot be created
+// (extension not installed, or the connecting role lacks privileges), the
+// migration logs a warning and returns nil so deployments that do not opt into
+// semantic retrieval are not forced to install pgvector. The retriever path
+// detects the missing index at sync time and falls back to full prompt
+// snapshots; see pipeline.New.
 func (db *DB) MigrateRuleEmbeddings() error {
 	if !db.IsPostgres() {
 		return nil
 	}
 
+	if _, err := db.Exec(`CREATE EXTENSION IF NOT EXISTS vector`); err != nil {
+		log.WithField("error", err).Warn("pgvector extension unavailable, skipping rule embeddings migration")
+		return nil
+	}
+
 	statements := []string{
-		`CREATE EXTENSION IF NOT EXISTS vector`,
 		fmt.Sprintf(`
 			CREATE TABLE IF NOT EXISTS rule_embeddings (
 				rule_key TEXT PRIMARY KEY,

--- a/internal/pipeline/agent_test.go
+++ b/internal/pipeline/agent_test.go
@@ -2,12 +2,14 @@ package pipeline
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/majiayu000/auto-contributor/internal/config"
 	"github.com/majiayu000/auto-contributor/internal/db"
 	"github.com/majiayu000/auto-contributor/internal/prompt"
 	"github.com/majiayu000/auto-contributor/internal/rules"
@@ -21,6 +23,7 @@ type stubRuntime struct {
 	outputs  []stubOutput
 	index    int
 	policies []runtime.ExecutionPolicy
+	prompts  []string
 }
 
 type stubOutput struct {
@@ -37,6 +40,7 @@ func (r *stubRuntime) Execute(ctx context.Context, workDir string, prompt string
 		return "", errors.New("unexpected runtime call")
 	}
 	r.policies = append(r.policies, policy)
+	r.prompts = append(r.prompts, prompt)
 	result := r.outputs[r.index]
 	r.index++
 	return result.output, result.err
@@ -260,6 +264,107 @@ func TestEngineerReviewLoop_ReviewerParseFailureBlocksAndFailsIssue(t *testing.T
 	}
 
 	assertReviewerFailureEvent(t, database, issue.ID, "parse reviewer JSON output")
+}
+
+func TestRunScoutUsesSemanticRetrieverRuleSelection(t *testing.T) {
+	rt := &stubRuntime{outputs: []stubOutput{
+		{output: `{"verdict":"PROCEED","reason":"","difficulty":1,"has_competing_pr":false,"suggested_approach":"minimal fix"}`},
+	}}
+	database, err := db.New(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("create test db: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = database.Close()
+	})
+
+	promptsDir := t.TempDir()
+	writePromptTemplate(t, promptsDir, "scout", `rules={{.Rules}}`)
+
+	ps := prompt.NewStore(promptsDir)
+	if err := ps.Load(); err != nil {
+		t.Fatalf("load prompts: %v", err)
+	}
+
+	rulesDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(rulesDir, "scout"), 0755); err != nil {
+		t.Fatalf("mkdir rules dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(rulesDir, "scout", "full-load.yaml"), []byte(
+		"id: full-load\nstage: scout\nconfidence: 0.9\nbody: full load fallback text\n",
+	), 0644); err != nil {
+		t.Fatalf("write rule: %v", err)
+	}
+
+	rl := rules.NewRuleLoader(rulesDir)
+	if err := rl.Load(); err != nil {
+		t.Fatalf("load rules: %v", err)
+	}
+
+	p := &Pipeline{
+		cfg:           &config.Config{WorkspaceDir: t.TempDir()},
+		db:            database,
+		prompts:       ps,
+		runner:        NewAgentRunner(ps, rt, 0),
+		ruleLoader:    rl,
+		ruleRetriever: stubStageRuleRetriever{ids: []string{"scout/semantic-one", "global/semantic-two"}, prompt: "semantic retrieval text"},
+	}
+
+	issue := &models.Issue{
+		Repo:        "owner/repo",
+		IssueNumber: 7,
+		Title:       "panic in parser",
+		Body:        "repro details",
+		Labels:      "[\"bug\"]",
+	}
+	if err := database.CreateIssue(issue); err != nil {
+		t.Fatalf("create issue: %v", err)
+	}
+
+	if _, err := p.runScout(context.Background(), issue); err != nil {
+		t.Fatalf("runScout() failed: %v", err)
+	}
+
+	if len(rt.prompts) != 1 {
+		t.Fatalf("runtime prompt count = %d, want 1", len(rt.prompts))
+	}
+	if !strings.Contains(rt.prompts[0], "semantic retrieval text") {
+		t.Fatalf("runtime prompt did not include semantic retrieval text:\n%s", rt.prompts[0])
+	}
+	if strings.Contains(rt.prompts[0], "full load fallback text") {
+		t.Fatalf("runtime prompt used full-load rules instead of semantic selection:\n%s", rt.prompts[0])
+	}
+
+	events, err := database.GetEventsByIssue(issue.ID)
+	if err != nil {
+		t.Fatalf("get events: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("event count = %d, want 1", len(events))
+	}
+
+	var recorded []string
+	if err := json.Unmarshal([]byte(events[0].ExperiencesUsed), &recorded); err != nil {
+		t.Fatalf("unmarshal experiences_used: %v", err)
+	}
+	want := []string{"scout/semantic-one", "global/semantic-two"}
+	if strings.Join(recorded, ",") != strings.Join(want, ",") {
+		t.Fatalf("recorded rule IDs = %v, want %v", recorded, want)
+	}
+}
+
+type stubStageRuleRetriever struct {
+	ids    []string
+	prompt string
+	err    error
+}
+
+func (s stubStageRuleRetriever) Retrieve(stage string, issue *models.Issue) ([]string, string, error) {
+	return s.ids, s.prompt, s.err
+}
+
+func (s stubStageRuleRetriever) Sync() error {
+	return nil
 }
 
 func TestEngineerReviewLoop_ReviewerRuntimeFailureBlocksAndFailsIssue(t *testing.T) {

--- a/internal/pipeline/agents.go
+++ b/internal/pipeline/agents.go
@@ -14,7 +14,7 @@ import (
 // --- Scout ---
 
 func (p *Pipeline) runScout(ctx context.Context, issue *models.Issue) (*ScoutResult, error) {
-	stageRules, rulesFormatted := p.ruleLoader.PromptSnapshot("scout")
+	stageRules, rulesFormatted := p.getRulesForStageIssue("scout", issue)
 	tmplCtx := map[string]any{
 		"Repo":        issue.Repo,
 		"IssueNumber": issue.IssueNumber,
@@ -42,7 +42,7 @@ func (p *Pipeline) runScout(ctx context.Context, issue *models.Issue) (*ScoutRes
 // --- Analyst ---
 
 func (p *Pipeline) runAnalyst(ctx context.Context, issue *models.Issue, workspace string, scout *ScoutResult) (*AnalystResult, error) {
-	stageRules, rulesFormatted := p.ruleLoader.PromptSnapshot("analyst")
+	stageRules, rulesFormatted := p.getRulesForStageIssue("analyst", issue)
 	scoutJSON, _ := json.MarshalIndent(scout, "", "  ")
 
 	tmplCtx := map[string]any{
@@ -140,7 +140,7 @@ func (p *Pipeline) buildReviewerCtx(issue *models.Issue, analyst *AnalystResult,
 // --- Submitter ---
 
 func (p *Pipeline) runSubmitter(ctx context.Context, issue *models.Issue, workspace string, analyst *AnalystResult) (*SubmitResult, error) {
-	stageRules, rulesFormatted := p.ruleLoader.PromptSnapshot("submitter")
+	stageRules, rulesFormatted := p.getRulesForStageIssue("submitter", issue)
 	planJSON, _ := json.MarshalIndent(analyst.FixPlan, "", "  ")
 
 	tmplCtx := map[string]any{
@@ -177,7 +177,7 @@ func (p *Pipeline) runSubmitter(ctx context.Context, issue *models.Issue, worksp
 // --- Critic ---
 
 func (p *Pipeline) runCritic(ctx context.Context, issue *models.Issue, workspace string, analyst *AnalystResult, round int) (*CriticResult, error) {
-	criticRules, rulesFormatted := p.ruleLoader.PromptSnapshot("critic")
+	criticRules, rulesFormatted := p.getRulesForStageIssue("critic", issue)
 	planJSON, _ := json.MarshalIndent(analyst.FixPlan, "", "  ")
 
 	tmplCtx := map[string]any{
@@ -226,8 +226,8 @@ func (p *Pipeline) criticLoop(ctx context.Context, issue *models.Issue, workspac
 		return err
 	}
 	for round := 1; round <= p.maxCriticRounds; round++ {
-		engineerRules, engRulesFormatted := p.ruleLoader.PromptSnapshot("engineer")
-		reviewerRules, revRulesFormatted := p.ruleLoader.PromptSnapshot("reviewer")
+		engineerRules, engRulesFormatted := p.getRulesForStageIssue("engineer", issue)
+		reviewerRules, revRulesFormatted := p.getRulesForStageIssue("reviewer", issue)
 		if err := p.db.UpdateIssueStatus(issue.ID, models.IssueStatusReviewing, ""); err != nil {
 			log.WithError(err).Warn("update status to reviewing (critic)")
 		}
@@ -375,8 +375,8 @@ func (p *Pipeline) engineerReviewLoopWithStats(ctx context.Context, issue *model
 	lastSummary := ""
 
 	for round := 1; round <= p.maxReview; round++ {
-		engineerRules, engRulesFormatted := p.ruleLoader.PromptSnapshot("engineer")
-		reviewerRules, revRulesFormatted := p.ruleLoader.PromptSnapshot("reviewer")
+		engineerRules, engRulesFormatted := p.getRulesForStageIssue("engineer", issue)
+		reviewerRules, revRulesFormatted := p.getRulesForStageIssue("reviewer", issue)
 
 		// Engineer
 		if err := p.db.UpdateIssueStatus(issue.ID, models.IssueStatusEngineering, ""); err != nil {

--- a/internal/pipeline/feedback.go
+++ b/internal/pipeline/feedback.go
@@ -361,7 +361,7 @@ func (p *Pipeline) handleOpen(ctx context.Context, pr *models.PullRequest, prRep
 	}
 
 	// Build context for responder agent (human feedback only)
-	responderRules, rulesFormatted := p.ruleLoader.PromptSnapshot("responder")
+	responderRules, rulesFormatted := p.getRulesForStageIssue("responder", issue)
 	tmplCtx := p.buildResponderCtx(issue, pr, humanReviews, humanComments, humanIssueComments, rulesFormatted)
 
 	log.WithFields(Fields{

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -30,8 +30,14 @@ type Pipeline struct {
 	prompts         *prompt.Store
 	runner          *AgentRunner
 	ruleLoader      *rules.RuleLoader
+	ruleRetriever   stageRuleRetriever
 	maxReview       int
 	maxCriticRounds int
+}
+
+type stageRuleRetriever interface {
+	Retrieve(stage string, issue *models.Issue) ([]string, string, error)
+	Sync() error
 }
 
 // New creates a Pipeline. promptsDir is the path to the prompts/ directory.
@@ -75,6 +81,16 @@ func New(cfg *config.Config, database *db.DB, gh *ghclient.Client, promptsDir st
 		log.WithFields(Fields{"count": len(rl.All())}).Info("loaded self-learning rules")
 	}
 
+	retriever, err := rules.NewRuleRetriever(cfg, database, rl)
+	if err != nil {
+		log.WithFields(Fields{"error": err}).Warn("failed to initialize semantic rule retrieval, falling back to full prompt snapshots")
+		retriever = nil
+	} else if retriever != nil {
+		if err := retriever.Sync(); err != nil {
+			log.WithFields(Fields{"error": err}).Warn("failed to sync semantic rule index, falling back to full prompt snapshots")
+		}
+	}
+
 	return &Pipeline{
 		cfg:             cfg,
 		db:              database,
@@ -82,9 +98,39 @@ func New(cfg *config.Config, database *db.DB, gh *ghclient.Client, promptsDir st
 		prompts:         ps,
 		runner:          NewAgentRunner(ps, rt, timeout),
 		ruleLoader:      rl,
+		ruleRetriever:   retriever,
 		maxReview:       maxReview,
 		maxCriticRounds: maxCriticRounds,
 	}, nil
+}
+
+func (p *Pipeline) getRulesForStageIssue(stage string, issue *models.Issue) ([]string, string) {
+	fallbackIDs, fallbackPrompt := p.ruleLoader.PromptSnapshot(stage)
+	if p.ruleRetriever == nil {
+		return fallbackIDs, fallbackPrompt
+	}
+
+	ids, promptText, err := p.ruleRetriever.Retrieve(stage, issue)
+	if err != nil {
+		fields := Fields{"stage": stage, "error": err}
+		if issue != nil {
+			fields["repo"] = issue.Repo
+			fields["issue"] = issue.IssueNumber
+		}
+		log.WithFields(fields).Warn("semantic rule retrieval failed, falling back to full prompt snapshot")
+		return fallbackIDs, fallbackPrompt
+	}
+
+	return ids, promptText
+}
+
+func (p *Pipeline) syncRuleRetriever(reason string) {
+	if p.ruleRetriever == nil {
+		return
+	}
+	if err := p.ruleRetriever.Sync(); err != nil {
+		log.WithFields(Fields{"reason": reason, "error": err}).Warn("failed to sync semantic rule index")
+	}
 }
 
 // saveTrajectory persists an experience-replay trajectory. Non-fatal on error.

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -81,13 +81,14 @@ func New(cfg *config.Config, database *db.DB, gh *ghclient.Client, promptsDir st
 		log.WithFields(Fields{"count": len(rl.All())}).Info("loaded self-learning rules")
 	}
 
-	retriever, err := rules.NewRuleRetriever(cfg, database, rl)
-	if err != nil {
+	var retriever stageRuleRetriever
+	if r, err := rules.NewRuleRetriever(cfg, database, rl); err != nil {
 		log.WithFields(Fields{"error": err}).Warn("failed to initialize semantic rule retrieval, falling back to full prompt snapshots")
-		retriever = nil
-	} else if retriever != nil {
-		if err := retriever.Sync(); err != nil {
-			log.WithFields(Fields{"error": err}).Warn("failed to sync semantic rule index, falling back to full prompt snapshots")
+	} else if r != nil {
+		if syncErr := r.Sync(); syncErr != nil {
+			log.WithFields(Fields{"error": syncErr}).Warn("failed to sync semantic rule index, falling back to full prompt snapshots")
+		} else {
+			retriever = r
 		}
 	}
 

--- a/internal/pipeline/synthesizer.go
+++ b/internal/pipeline/synthesizer.go
@@ -44,6 +44,7 @@ func (p *Pipeline) RunSynthesis(ctx context.Context) error {
 		if err := p.ruleLoader.Reload(); err != nil {
 			log.WithFields(Fields{"stage": stage, "error": err}).Warn("failed to reload rules after stage synthesis")
 		}
+		p.syncRuleRetriever("stage_synthesis_" + stage)
 
 		totalNew += applied.newCount
 		totalUpdated += applied.updatedCount
@@ -64,6 +65,7 @@ func (p *Pipeline) RunSynthesis(ctx context.Context) error {
 	if err := p.ruleLoader.Reload(); err != nil {
 		log.WithFields(Fields{"error": err}).Warn("failed to reload rules after synthesis")
 	}
+	p.syncRuleRetriever("post_synthesis_reload")
 
 	// Decay confidence on rules without recent evidence (runs on fresh in-memory state)
 	p.applyDecay()
@@ -72,6 +74,7 @@ func (p *Pipeline) RunSynthesis(ctx context.Context) error {
 	if err := p.ruleLoader.Reload(); err != nil {
 		log.WithFields(Fields{"error": err}).Warn("failed to reload rules after decay")
 	}
+	p.syncRuleRetriever("post_decay_reload")
 
 	log.WithFields(Fields{
 		"new":     totalNew,

--- a/internal/rules/loader.go
+++ b/internal/rules/loader.go
@@ -157,53 +157,49 @@ func (rl *RuleLoader) ForStage(stage string) []*Rule {
 	return matched
 }
 
-// IDsForPrompt returns the participation keys of rules actually included in the
-// prompt for a given stage, honouring the same MaxPromptChars budget as
-// FormatForPrompt. Keys are returned as "stage/ruleID" so that Q-value updates
-// can resolve rules unambiguously even when IDs are not unique across stages.
-func (rl *RuleLoader) IDsForPrompt(stage string) []string {
-	matched := rl.ForStage(stage)
-
-	const header = "## Self-Learning Rules\n\nFollow these rules based on past experience:\n\n"
-	total := len(header)
-
-	ids := make([]string, 0, len(matched))
-	for _, r := range matched {
-		entry := fmt.Sprintf("### %s (confidence: %.2f)\n\n%s\n\n---\n\n", r.ID, r.Confidence, r.Body)
-		if total+len(entry) > MaxPromptChars {
-			break
-		}
-		ids = append(ids, r.Stage+"/"+r.ID)
-		total += len(entry)
-	}
-	return ids
-}
-
-// FormatForPrompt returns concatenated rule bodies as Markdown for prompt injection.
-func (rl *RuleLoader) FormatForPrompt(stage string) string {
-	matched := rl.ForStage(stage)
+func promptSnapshotForRules(matched []*Rule) (ids []string, formatted string) {
 	if len(matched) == 0 {
-		return ""
+		return nil, ""
 	}
 
 	const header = "## Self-Learning Rules\n\nFollow these rules based on past experience:\n\n"
 	var sb strings.Builder
 	sb.WriteString(header)
-
-	// Start total at len(header) so the budget matches IDsForPrompt exactly;
-	// without this, FormatForPrompt could include more entries than IDsForPrompt
-	// reports, causing rules to be injected but not credited in experiences_used.
 	total := len(header)
+
 	for _, r := range matched {
 		entry := fmt.Sprintf("### %s (confidence: %.2f)\n\n%s\n\n---\n\n", r.ID, r.Confidence, r.Body)
 		if total+len(entry) > MaxPromptChars {
 			break
 		}
+		ids = append(ids, ruleParticipationKey(r.Stage, r.ID))
 		sb.WriteString(entry)
 		total += len(entry)
 	}
 
-	return sb.String()
+	if len(ids) > 0 {
+		formatted = sb.String()
+	}
+	return ids, formatted
+}
+
+func ruleParticipationKey(stage, id string) string {
+	return stage + "/" + id
+}
+
+// IDsForPrompt returns the participation keys of rules actually included in the
+// prompt for a given stage, honouring the same MaxPromptChars budget as
+// FormatForPrompt. Keys are returned as "stage/ruleID" so that Q-value updates
+// can resolve rules unambiguously even when IDs are not unique across stages.
+func (rl *RuleLoader) IDsForPrompt(stage string) []string {
+	ids, _ := promptSnapshotForRules(rl.ForStage(stage))
+	return ids
+}
+
+// FormatForPrompt returns concatenated rule bodies as Markdown for prompt injection.
+func (rl *RuleLoader) FormatForPrompt(stage string) string {
+	_, formatted := promptSnapshotForRules(rl.ForStage(stage))
+	return formatted
 }
 
 // InjectedRuleIDsForStage returns the set of rule IDs that would actually be
@@ -231,30 +227,7 @@ func (rl *RuleLoader) InjectedRuleIDsForStage(stage string) map[string]bool {
 // single ForStage call, so IDsForPrompt and FormatForPrompt cannot diverge due
 // to a concurrent Reload between two separate calls.
 func (rl *RuleLoader) PromptSnapshot(stage string) (ids []string, formatted string) {
-	matched := rl.ForStage(stage)
-	if len(matched) == 0 {
-		return nil, ""
-	}
-
-	const header = "## Self-Learning Rules\n\nFollow these rules based on past experience:\n\n"
-	var sb strings.Builder
-	sb.WriteString(header)
-	total := len(header)
-
-	for _, r := range matched {
-		entry := fmt.Sprintf("### %s (confidence: %.2f)\n\n%s\n\n---\n\n", r.ID, r.Confidence, r.Body)
-		if total+len(entry) > MaxPromptChars {
-			break
-		}
-		ids = append(ids, r.Stage+"/"+r.ID)
-		sb.WriteString(entry)
-		total += len(entry)
-	}
-
-	if len(ids) > 0 {
-		formatted = sb.String()
-	}
-	return ids, formatted
+	return promptSnapshotForRules(rl.ForStage(stage))
 }
 
 // ByID finds a rule by its ID. When multiple rules share an ID across stages,

--- a/internal/rules/loader_test.go
+++ b/internal/rules/loader_test.go
@@ -3,7 +3,13 @@ package rules
 import (
 	"os"
 	"path/filepath"
+	"reflect"
+	"strings"
 	"testing"
+
+	"github.com/majiayu000/auto-contributor/internal/config"
+	"github.com/majiayu000/auto-contributor/internal/db"
+	"github.com/majiayu000/auto-contributor/pkg/models"
 )
 
 // writeRuleYAML writes a minimal rule YAML file to dir/subdir/name.yaml.
@@ -190,4 +196,190 @@ func TestQuarantineUnsafeID(t *testing.T) {
 	if _, err := os.Stat(good); err != nil {
 		t.Errorf("valid rule file should remain on disk: %v", err)
 	}
+}
+
+func TestPromptSnapshotForRulesUsesSelectedRules(t *testing.T) {
+	selected := []*Rule{
+		{ID: "second", Stage: "engineer", Confidence: 0.7, Body: "apply the targeted fix"},
+		{ID: "first", Stage: "global", Confidence: 0.9, Body: "always explain the root cause"},
+	}
+
+	ids, promptText := promptSnapshotForRules(selected)
+	wantIDs := []string{"engineer/second", "global/first"}
+	if !reflect.DeepEqual(ids, wantIDs) {
+		t.Fatalf("ids = %v, want %v", ids, wantIDs)
+	}
+	if strings.Index(promptText, "### second") > strings.Index(promptText, "### first") {
+		t.Fatalf("prompt order did not preserve selection order:\n%s", promptText)
+	}
+	if !strings.Contains(promptText, "apply the targeted fix") || !strings.Contains(promptText, "always explain the root cause") {
+		t.Fatalf("prompt missing selected rule bodies:\n%s", promptText)
+	}
+}
+
+func TestRuleRetrieverRetrieveFiltersStagesAndReranks(t *testing.T) {
+	dir := t.TempDir()
+	writeRuleYAML(t, dir, "engineer", "high-q.yaml",
+		"id: high-q\nstage: engineer\nconfidence: 0.9\nq_value: 0.9\nbody: prefer the proven root-cause fix\n")
+	writeRuleYAML(t, dir, "engineer", "high-sim.yaml",
+		"id: high-sim\nstage: engineer\nconfidence: 0.9\nq_value: 0.51\nbody: match the exact failing parser path\n")
+	writeRuleYAML(t, dir, "global", "legacy-zero.yaml",
+		"id: legacy-zero\nstage: global\nconfidence: 0.9\nq_value: 0\nbody: keep changes minimal and well scoped\n")
+	writeRuleYAML(t, dir, "reviewer", "offstage.yaml",
+		"id: offstage\nstage: reviewer\nconfidence: 0.9\nq_value: 1.0\nbody: reviewer-only guidance should not leak\n")
+
+	rl := NewRuleLoader(dir)
+	if err := rl.Load(); err != nil {
+		t.Fatalf("Load() failed: %v", err)
+	}
+
+	store := &fakeRuleEmbeddingStore{
+		isPostgres: true,
+		candidates: []db.RuleEmbeddingCandidate{
+			{RuleKey: "engineer/high-sim", Stage: "engineer", Similarity: 0.82},
+			{RuleKey: "engineer/high-q", Stage: "engineer", Similarity: 0.80},
+			{RuleKey: "global/legacy-zero", Stage: "global", Similarity: 0.81},
+			{RuleKey: "reviewer/offstage", Stage: "reviewer", Similarity: 0.99},
+		},
+	}
+
+	cfg := config.Default()
+	cfg.SemanticRetrievalEnabled = true
+	cfg.SemanticRetrievalLambda = 0.5
+	cfg.SemanticRetrievalTopK = 5
+	cfg.SemanticRetrievalPhaseA = 20
+	cfg.SemanticRetrievalProvider = "local"
+	cfg.SemanticRetrievalModel = "hash-v1"
+
+	retriever, err := NewRuleRetriever(cfg, store, rl)
+	if err != nil {
+		t.Fatalf("NewRuleRetriever() failed: %v", err)
+	}
+
+	ids, promptText, err := retriever.Retrieve("engineer", &models.Issue{
+		Repo:        "owner/repo",
+		Language:    "go",
+		Labels:      "[\"bug\"]",
+		Title:       "panic in parser",
+		Body:        "nil pointer when parsing malformed input",
+		IssueNumber: 12,
+	})
+	if err != nil {
+		t.Fatalf("Retrieve() failed: %v", err)
+	}
+
+	if !reflect.DeepEqual(store.lastStages, []string{"engineer", "global"}) {
+		t.Fatalf("stages = %v, want [engineer global]", store.lastStages)
+	}
+	wantIDs := []string{"engineer/high-q", "engineer/high-sim", "global/legacy-zero"}
+	if !reflect.DeepEqual(ids, wantIDs) {
+		t.Fatalf("ids = %v, want %v", ids, wantIDs)
+	}
+	if strings.Contains(promptText, "reviewer-only guidance should not leak") {
+		t.Fatalf("off-stage rule leaked into prompt:\n%s", promptText)
+	}
+	if strings.Index(promptText, "### high-q") > strings.Index(promptText, "### high-sim") {
+		t.Fatalf("rerank did not prioritize higher-Q near-tie:\n%s", promptText)
+	}
+}
+
+func TestRuleRetrieverSyncUpsertsChangedAndDeletesMissing(t *testing.T) {
+	dir := t.TempDir()
+	writeRuleYAML(t, dir, "global", "keep.yaml",
+		"id: keep\nstage: global\nconfidence: 0.9\nbody: stable rule text\n")
+	writeRuleYAML(t, dir, "engineer", "update.yaml",
+		"id: update\nstage: engineer\nconfidence: 0.9\nbody: changed body text\n")
+	writeRuleYAML(t, dir, "engineer", "new.yaml",
+		"id: new\nstage: engineer\nconfidence: 0.9\nbody: newly added rule\n")
+
+	rl := NewRuleLoader(dir)
+	if err := rl.Load(); err != nil {
+		t.Fatalf("Load() failed: %v", err)
+	}
+
+	keepRule := rl.ByStageAndID("global", "keep")
+	store := &fakeRuleEmbeddingStore{
+		isPostgres: true,
+		hashes: map[string]string{
+			"global/keep":      contentHashForModel("hash-v1", buildRuleEmbeddingText(keepRule)),
+			"engineer/update":  "outdated-hash",
+			"engineer/deleted": "stale",
+		},
+	}
+
+	cfg := config.Default()
+	cfg.SemanticRetrievalEnabled = true
+	cfg.SemanticRetrievalProvider = "local"
+	cfg.SemanticRetrievalModel = "hash-v1"
+
+	retriever, err := NewRuleRetriever(cfg, store, rl)
+	if err != nil {
+		t.Fatalf("NewRuleRetriever() failed: %v", err)
+	}
+
+	if err := retriever.Sync(); err != nil {
+		t.Fatalf("Sync() failed: %v", err)
+	}
+
+	if len(store.upserts) != 2 {
+		t.Fatalf("upserts = %d, want 2", len(store.upserts))
+	}
+	if store.upserts[0].ruleKey != "engineer/new" && store.upserts[1].ruleKey != "engineer/new" {
+		t.Fatalf("new rule was not upserted: %+v", store.upserts)
+	}
+	if store.upserts[0].ruleKey != "engineer/update" && store.upserts[1].ruleKey != "engineer/update" {
+		t.Fatalf("changed rule was not upserted: %+v", store.upserts)
+	}
+	wantDeleted := []string{"engineer/new", "engineer/update", "global/keep"}
+	if !reflect.DeepEqual(store.deletedKeys, wantDeleted) {
+		t.Fatalf("deletedKeys = %v, want %v", store.deletedKeys, wantDeleted)
+	}
+}
+
+type fakeRuleEmbeddingStore struct {
+	isPostgres  bool
+	hashes      map[string]string
+	candidates  []db.RuleEmbeddingCandidate
+	upserts     []fakeRuleEmbeddingUpsert
+	deletedKeys []string
+	lastStages  []string
+}
+
+type fakeRuleEmbeddingUpsert struct {
+	ruleKey     string
+	stage       string
+	contentHash string
+	modelName   string
+}
+
+func (s *fakeRuleEmbeddingStore) IsPostgres() bool {
+	return s.isPostgres
+}
+
+func (s *fakeRuleEmbeddingStore) GetRuleEmbeddingHashes() (map[string]string, error) {
+	out := make(map[string]string, len(s.hashes))
+	for key, value := range s.hashes {
+		out[key] = value
+	}
+	return out, nil
+}
+
+func (s *fakeRuleEmbeddingStore) UpsertRuleEmbedding(ruleKey, stage, contentHash string, _ []float64, modelName string) error {
+	s.upserts = append(s.upserts, fakeRuleEmbeddingUpsert{
+		ruleKey:     ruleKey,
+		stage:       stage,
+		contentHash: contentHash,
+		modelName:   modelName,
+	})
+	return nil
+}
+
+func (s *fakeRuleEmbeddingStore) DeleteRuleEmbeddingsExcept(ruleKeys []string) error {
+	s.deletedKeys = append([]string(nil), ruleKeys...)
+	return nil
+}
+
+func (s *fakeRuleEmbeddingStore) FindRuleEmbeddingCandidates(stages []string, _ []float64, _ int) ([]db.RuleEmbeddingCandidate, error) {
+	s.lastStages = append([]string(nil), stages...)
+	return append([]db.RuleEmbeddingCandidate(nil), s.candidates...), nil
 }

--- a/internal/rules/retriever.go
+++ b/internal/rules/retriever.go
@@ -1,0 +1,351 @@
+package rules
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"hash/fnv"
+	"math"
+	"sort"
+	"strings"
+
+	"github.com/majiayu000/auto-contributor/internal/config"
+	"github.com/majiayu000/auto-contributor/internal/db"
+	"github.com/majiayu000/auto-contributor/pkg/models"
+)
+
+type ruleEmbeddingStore interface {
+	IsPostgres() bool
+	GetRuleEmbeddingHashes() (map[string]string, error)
+	UpsertRuleEmbedding(ruleKey, stage, contentHash string, embedding []float64, modelName string) error
+	DeleteRuleEmbeddingsExcept(ruleKeys []string) error
+	FindRuleEmbeddingCandidates(stages []string, embedding []float64, limit int) ([]db.RuleEmbeddingCandidate, error)
+}
+
+type textEmbedder interface {
+	Embed(text string) ([]float64, error)
+	ModelName() string
+}
+
+// RuleRetriever provides issue-aware rule selection backed by a derived vector index.
+type RuleRetriever struct {
+	store       ruleEmbeddingStore
+	loader      *RuleLoader
+	enabled     bool
+	phaseALimit int
+	topK        int
+	lambda      float64
+	embedder    textEmbedder
+}
+
+// NewRuleRetriever creates the semantic rule retriever. Unsupported providers fail
+// at construction so callers can degrade to the full-load prompt path explicitly.
+func NewRuleRetriever(cfg *config.Config, store ruleEmbeddingStore, loader *RuleLoader) (*RuleRetriever, error) {
+	if loader == nil {
+		return &RuleRetriever{}, nil
+	}
+
+	if cfg == nil || !cfg.SemanticRetrievalEnabled || store == nil || !store.IsPostgres() {
+		return &RuleRetriever{store: store, loader: loader}, nil
+	}
+
+	embedder, err := newTextEmbedder(cfg.SemanticRetrievalProvider, cfg.SemanticRetrievalModel)
+	if err != nil {
+		return nil, err
+	}
+
+	phaseALimit := cfg.SemanticRetrievalPhaseA
+	if phaseALimit <= 0 {
+		phaseALimit = 20
+	}
+	topK := cfg.SemanticRetrievalTopK
+	if topK <= 0 {
+		topK = 5
+	}
+	if topK > phaseALimit {
+		topK = phaseALimit
+	}
+	lambda := cfg.SemanticRetrievalLambda
+	if lambda < 0 {
+		lambda = 0
+	}
+	if lambda > 1 {
+		lambda = 1
+	}
+
+	return &RuleRetriever{
+		store:       store,
+		loader:      loader,
+		enabled:     true,
+		phaseALimit: phaseALimit,
+		topK:        topK,
+		lambda:      lambda,
+		embedder:    embedder,
+	}, nil
+}
+
+// Sync upserts changed/new YAML rules into the derived index and removes deleted rules.
+func (rr *RuleRetriever) Sync() error {
+	if rr == nil || !rr.enabled || rr.loader == nil {
+		return nil
+	}
+
+	existingHashes, err := rr.store.GetRuleEmbeddingHashes()
+	if err != nil {
+		return err
+	}
+
+	rules := rr.loader.All()
+	ruleKeys := make([]string, 0, len(rules))
+	for _, rule := range rules {
+		if rule == nil || rule.Body == "" {
+			continue
+		}
+
+		ruleKey := ruleParticipationKey(rule.Stage, rule.ID)
+		ruleKeys = append(ruleKeys, ruleKey)
+
+		ruleText := buildRuleEmbeddingText(rule)
+		contentHash := contentHashForModel(rr.embedder.ModelName(), ruleText)
+		if existingHashes[ruleKey] == contentHash {
+			continue
+		}
+
+		embedding, err := rr.embedder.Embed(ruleText)
+		if err != nil {
+			return fmt.Errorf("embed rule %s: %w", ruleKey, err)
+		}
+		if err := rr.store.UpsertRuleEmbedding(ruleKey, rule.Stage, contentHash, embedding, rr.embedder.ModelName()); err != nil {
+			return err
+		}
+	}
+
+	sort.Strings(ruleKeys)
+	return rr.store.DeleteRuleEmbeddingsExcept(ruleKeys)
+}
+
+// Retrieve returns the selected rule IDs and formatted prompt text for one stage+issue pair.
+func (rr *RuleRetriever) Retrieve(stage string, issue *models.Issue) ([]string, string, error) {
+	if rr == nil || rr.loader == nil {
+		return nil, "", nil
+	}
+	if issue == nil || !rr.enabled {
+		ids, promptText := rr.loader.PromptSnapshot(stage)
+		return ids, promptText, nil
+	}
+
+	queryEmbedding, err := rr.embedder.Embed(buildIssueQueryText(issue))
+	if err != nil {
+		return nil, "", fmt.Errorf("embed issue query: %w", err)
+	}
+
+	candidates, err := rr.store.FindRuleEmbeddingCandidates([]string{stage, "global"}, queryEmbedding, rr.phaseALimit)
+	if err != nil {
+		return nil, "", err
+	}
+	if len(candidates) == 0 {
+		return nil, "", nil
+	}
+
+	type rankedRule struct {
+		rule       *Rule
+		similarity float64
+		score      float64
+	}
+
+	ranked := make([]rankedRule, 0, len(candidates))
+	seen := make(map[string]bool)
+	for _, candidate := range candidates {
+		if seen[candidate.RuleKey] {
+			continue
+		}
+		seen[candidate.RuleKey] = true
+
+		ruleStage, ruleID, ok := splitRuleParticipationKey(candidate.RuleKey)
+		if !ok {
+			continue
+		}
+		if ruleStage != stage && ruleStage != "global" {
+			continue
+		}
+		rule := rr.loader.ByStageAndID(ruleStage, ruleID)
+		if rule == nil || rule.Confidence < MinConfidenceForInjection {
+			continue
+		}
+
+		similarity := clamp01(candidate.Similarity)
+		qValue := normalizedQValue(rule.QValue)
+		ranked = append(ranked, rankedRule{
+			rule:       rule,
+			similarity: similarity,
+			score:      (1-rr.lambda)*similarity + rr.lambda*qValue,
+		})
+	}
+
+	sort.SliceStable(ranked, func(i, j int) bool {
+		if ranked[i].score != ranked[j].score {
+			return ranked[i].score > ranked[j].score
+		}
+		if ranked[i].similarity != ranked[j].similarity {
+			return ranked[i].similarity > ranked[j].similarity
+		}
+		left := ruleParticipationKey(ranked[i].rule.Stage, ranked[i].rule.ID)
+		right := ruleParticipationKey(ranked[j].rule.Stage, ranked[j].rule.ID)
+		return left < right
+	})
+
+	selected := make([]*Rule, 0, rr.topK)
+	for _, item := range ranked {
+		selected = append(selected, item.rule)
+		if len(selected) == rr.topK {
+			break
+		}
+	}
+
+	ids, promptText := promptSnapshotForRules(selected)
+	return ids, promptText, nil
+}
+
+func buildRuleEmbeddingText(rule *Rule) string {
+	var parts []string
+	if rule.Condition != "" {
+		parts = append(parts, "condition: "+rule.Condition)
+	}
+	if rule.Body != "" {
+		parts = append(parts, "body: "+rule.Body)
+	}
+	if len(rule.Tags) > 0 {
+		parts = append(parts, "tags: "+strings.Join(rule.Tags, ", "))
+	}
+	if rule.Severity != "" {
+		parts = append(parts, "severity: "+rule.Severity)
+	}
+	return strings.Join(parts, "\n")
+}
+
+func buildIssueQueryText(issue *models.Issue) string {
+	parts := []string{
+		"repo: " + issue.Repo,
+		"language: " + issue.Language,
+		"labels: " + issue.Labels,
+		"title: " + issue.Title,
+		"body: " + issue.Body,
+	}
+	return strings.Join(parts, "\n")
+}
+
+func contentHashForModel(modelName, text string) string {
+	sum := sha256.Sum256([]byte(modelName + "\n" + text))
+	return hex.EncodeToString(sum[:])
+}
+
+func normalizedQValue(q float64) float64 {
+	if q == 0 {
+		return 0.5
+	}
+	return clamp01(q)
+}
+
+func clamp01(value float64) float64 {
+	switch {
+	case value < 0:
+		return 0
+	case value > 1:
+		return 1
+	default:
+		return value
+	}
+}
+
+func splitRuleParticipationKey(key string) (stage string, id string, ok bool) {
+	stage, id, found := strings.Cut(key, "/")
+	if !found || stage == "" || id == "" {
+		return "", "", false
+	}
+	return stage, id, true
+}
+
+func newTextEmbedder(provider, model string) (textEmbedder, error) {
+	normalizedProvider := strings.TrimSpace(strings.ToLower(provider))
+	if normalizedProvider == "" {
+		normalizedProvider = "local"
+	}
+	switch normalizedProvider {
+	case "local":
+		if strings.TrimSpace(model) == "" {
+			model = "hash-v1"
+		}
+		return &hashEmbedder{model: model}, nil
+	default:
+		return nil, fmt.Errorf("unsupported semantic retrieval provider %q", provider)
+	}
+}
+
+type hashEmbedder struct {
+	model string
+}
+
+func (e *hashEmbedder) ModelName() string {
+	return e.model
+}
+
+func (e *hashEmbedder) Embed(text string) ([]float64, error) {
+	tokens := tokenizeForEmbedding(text)
+	vector := make([]float64, db.RuleEmbeddingDimensions)
+	if len(tokens) == 0 {
+		vector[0] = 1
+		return vector, nil
+	}
+
+	for _, token := range tokens {
+		hash := fnv.New64a()
+		if _, err := hash.Write([]byte(token)); err != nil {
+			return nil, err
+		}
+		sum := hash.Sum64()
+		index := int(sum % uint64(db.RuleEmbeddingDimensions))
+		sign := 1.0
+		if (sum>>8)&1 == 1 {
+			sign = -1
+		}
+		vector[index] += sign
+	}
+
+	var norm float64
+	for _, value := range vector {
+		norm += value * value
+	}
+	if norm == 0 {
+		vector[0] = 1
+		return vector, nil
+	}
+
+	norm = math.Sqrt(norm)
+	for i := range vector {
+		vector[i] /= norm
+	}
+	return vector, nil
+}
+
+func tokenizeForEmbedding(text string) []string {
+	text = strings.ToLower(text)
+	replacer := strings.NewReplacer(
+		"\n", " ",
+		"\r", " ",
+		"\t", " ",
+		"/", " ",
+		"-", " ",
+		"_", " ",
+		":", " ",
+		",", " ",
+		".", " ",
+		"(", " ",
+		")", " ",
+		"[", " ",
+		"]", " ",
+		"{", " ",
+		"}", " ",
+	)
+	text = replacer.Replace(text)
+	return strings.Fields(text)
+}


### PR DESCRIPTION
Closes #16

- add optional pgvector-backed semantic rule retrieval with Q-value reranking
- keep YAML as the source of truth and sync the derived index at startup and after synthesis
- add fallback and tests for Postgres/SQLite behavior, prompt selection, and recorded rule IDs