### PR TITLE
fix: prepare feedback PR workspaces

### DIFF
--- a/docs/pr-61-signal-report.md
+++ b/docs/pr-61-signal-report.md
@@ -32,6 +32,9 @@ directory but does not clone, fetch, or check out the PR head branch.
   head branch.
 - Feedback responders and CI fixers now run from a checked-out PR branch rather
   than an empty or stale directory.
+- Follow-up regression coverage now exercises `preparePRWorkspace` directly so
+  the tracked-branch checkout path is verified in tests, not only by manual PR
+  inspection.
 
 ## Review Comments
 

--- a/docs/pr-61-signal-report.md
+++ b/docs/pr-61-signal-report.md
@@ -1,0 +1,47 @@
+# Signal Report: PR 61 Feedback Workspaces Track PR Head Branches
+
+Issue: https://github.com/majiayu000/auto-contributor/issues/60
+PR: https://github.com/majiayu000/auto-contributor/pull/61
+
+## Root Cause
+
+GitHub-synced pull requests could be stored locally without a `branch_name`,
+and the feedback / CI-fix paths only called `createWorkspace`, which creates a
+directory but does not clone, fetch, or check out the PR head branch.
+
+## Branch Diagnosis
+
+- `internal/github/pr.go` keeps `gh search prs` on the supported JSON fields,
+  then backfills each PR's `headRefName` through `gh pr view`.
+- `internal/db/db.go` now updates `pull_requests.branch_name` when an existing
+  tracked PR is re-synced with newly discovered branch data.
+- `internal/pipeline/feedback.go` refreshes the tracked branch name from
+  `GetPRInfo` before feedback or CI-fix handling continues.
+- `internal/pipeline/pipeline.go` replaces empty-directory workspaces in the
+  feedback paths with clone/fetch/checkout preparation for the tracked PR head
+  branch.
+- `internal/github/pr.go` retries `gh pr view` without `lockReason` when the
+  installed GitHub CLI does not support that field, so feedback polling stays
+  live on older `gh` builds.
+
+## Resolution
+
+- Open-PR sync persists head branch names instead of leaving GitHub-synced rows
+  stranded with empty `branch_name`.
+- Existing tracked PR rows are backfilled when later GitHub calls expose the
+  head branch.
+- Feedback responders and CI fixers now run from a checked-out PR branch rather
+  than an empty or stale directory.
+
+## Review Comments
+
+- PR review comments: none.
+- PR submitted reviews: none.
+
+## Validation
+
+- `gofmt -w .`: passed
+- `go vet ./...`: passed
+- `go build ./...`: passed
+- `go test ./...`: passed
+- `cargo check && cargo test`: not applicable; repository has no `Cargo.toml`

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -866,6 +866,16 @@ func (db *DB) UpdatePRFeedbackCheck(prID int64, round int) error {
 	return err
 }
 
+// UpdatePRBranchName stores the latest GitHub head branch for a tracked PR.
+func (db *DB) UpdatePRBranchName(prID int64, branchName string) error {
+	query := fmt.Sprintf(`
+		UPDATE pull_requests SET branch_name = %s, updated_at = CURRENT_TIMESTAMP
+		WHERE id = %s
+	`, db.placeholder(1), db.placeholder(2))
+	_, err := db.Exec(query, branchName, prID)
+	return err
+}
+
 // UpdatePRReviewStats updates review_comment_count and first_review_at.
 func (db *DB) UpdatePRReviewStats(prID int64, commentCount int, firstReviewAt *time.Time) error {
 	query := fmt.Sprintf(`
@@ -884,6 +894,11 @@ func (db *DB) EnsurePRWithIssue(repo string, prNumber int, prURL, branchName, ti
 	query := fmt.Sprintf(`SELECT id FROM pull_requests WHERE pr_url = %s`, db.placeholder(1))
 	err := db.QueryRow(query, prURL).Scan(&prID)
 	if err == nil {
+		if branchName != "" {
+			if err := db.UpdatePRBranchName(prID, branchName); err != nil {
+				return nil, fmt.Errorf("update PR branch name: %w", err)
+			}
+		}
 		return db.getPRByID(prID)
 	}
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -161,10 +161,16 @@ func testCreatePullRequestPopulatesIDAndSupportsUpdate(t *testing.T, db *DB) {
 	if err := db.UpdatePRFeedbackCheck(pr.ID, 2); err != nil {
 		t.Fatalf("update PR feedback check: %v", err)
 	}
+	if err := db.UpdatePRBranchName(pr.ID, "fix/updated-head"); err != nil {
+		t.Fatalf("update PR branch name: %v", err)
+	}
 
 	stored, err := db.getPRByID(pr.ID)
 	if err != nil {
 		t.Fatalf("get PR by ID: %v", err)
+	}
+	if stored.BranchName != "fix/updated-head" {
+		t.Fatalf("stored branch = %q, want %q", stored.BranchName, "fix/updated-head")
 	}
 	if stored.Status != models.PRStatusOpen {
 		t.Fatalf("stored status = %q, want %q", stored.Status, models.PRStatusOpen)
@@ -174,6 +180,43 @@ func testCreatePullRequestPopulatesIDAndSupportsUpdate(t *testing.T, db *DB) {
 	}
 	if stored.LastFeedbackCheckAt == nil {
 		t.Fatal("stored last feedback check timestamp is nil")
+	}
+}
+
+func TestEnsurePRWithIssueUpdatesExistingBranchName(t *testing.T) {
+	db := newSQLiteTestDB(t)
+
+	pr, err := db.EnsurePRWithIssue(
+		"owner/repo",
+		42,
+		"https://github.com/owner/repo/pull/42",
+		"",
+		"fix bug",
+		"body",
+	)
+	if err != nil {
+		t.Fatalf("EnsurePRWithIssue initial: %v", err)
+	}
+	if pr.BranchName != "" {
+		t.Fatalf("initial branch = %q, want empty", pr.BranchName)
+	}
+
+	updated, err := db.EnsurePRWithIssue(
+		"owner/repo",
+		42,
+		"https://github.com/owner/repo/pull/42",
+		"fix/bug-42",
+		"fix bug",
+		"body",
+	)
+	if err != nil {
+		t.Fatalf("EnsurePRWithIssue update: %v", err)
+	}
+	if updated.ID != pr.ID {
+		t.Fatalf("updated PR ID = %d, want %d", updated.ID, pr.ID)
+	}
+	if updated.BranchName != "fix/bug-42" {
+		t.Fatalf("updated branch = %q, want %q", updated.BranchName, "fix/bug-42")
 	}
 }
 

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -197,6 +197,30 @@ func TestRepoInfoStruct(t *testing.T) {
 	}
 }
 
+func TestParseUserOpenPRsPreservesHeadRefName(t *testing.T) {
+	data := []byte(`[
+		{
+			"repository": {"nameWithOwner": "owner/repo"},
+			"number": 42,
+			"title": "fix bug",
+			"body": "body",
+			"url": "https://github.com/owner/repo/pull/42",
+			"headRefName": "fix/bug-42"
+		}
+	]`)
+
+	prs, err := parseUserOpenPRs(data)
+	if err != nil {
+		t.Fatalf("parseUserOpenPRs: %v", err)
+	}
+	if len(prs) != 1 {
+		t.Fatalf("got %d PRs, want 1", len(prs))
+	}
+	if prs[0].BranchName != "fix/bug-42" {
+		t.Fatalf("BranchName = %q, want %q", prs[0].BranchName, "fix/bug-42")
+	}
+}
+
 func TestParseChecksOutput_MalformedJSON(t *testing.T) {
 	result := parseChecksOutput([]byte("not json at all"))
 	if result.Status != "unknown" {

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -1,7 +1,11 @@
 package github
 
 import (
+	"context"
 	"encoding/base64"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/majiayu000/auto-contributor/internal/config"
@@ -218,6 +222,63 @@ func TestParseUserOpenPRsPreservesHeadRefName(t *testing.T) {
 	}
 	if prs[0].BranchName != "fix/bug-42" {
 		t.Fatalf("BranchName = %q, want %q", prs[0].BranchName, "fix/bug-42")
+	}
+}
+
+func TestGetPRInfoFallsBackWhenLockReasonUnsupported(t *testing.T) {
+	tempDir := t.TempDir()
+	logPath := filepath.Join(tempDir, "gh.log")
+	scriptPath := filepath.Join(tempDir, "gh")
+	script := `#!/bin/sh
+printf '%s\n' "$*" >> "$GH_TEST_LOG"
+case "$*" in
+  *"--json state,isDraft,headRefName,lockReason,reviews,createdAt,mergedAt,closedAt"*)
+    printf 'Unknown JSON field: "lockReason"\n' >&2
+    exit 1
+    ;;
+  *"--json state,isDraft,headRefName,reviews,createdAt,mergedAt,closedAt"*)
+    printf '%s' '{"state":"OPEN","isDraft":false,"headRefName":"fix/bug-42","createdAt":"2026-04-29T00:00:00Z","mergedAt":"","closedAt":"","reviews":[{"author":{"login":"reviewer"},"state":"COMMENTED","body":"please fix","submittedAt":"2026-04-29T01:00:00Z"}]}'
+    exit 0
+    ;;
+  *)
+    printf 'unexpected args: %s\n' "$*" >&2
+    exit 1
+    ;;
+esac
+`
+	if err := os.WriteFile(scriptPath, []byte(script), 0755); err != nil {
+		t.Fatalf("write fake gh script: %v", err)
+	}
+
+	t.Setenv("GH_TEST_LOG", logPath)
+	t.Setenv("PATH", tempDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	client := New(&config.Config{})
+	info, err := client.GetPRInfo(context.Background(), "owner/repo", 42)
+	if err != nil {
+		t.Fatalf("GetPRInfo: %v", err)
+	}
+	if info.HeadRefName != "fix/bug-42" {
+		t.Fatalf("HeadRefName = %q, want %q", info.HeadRefName, "fix/bug-42")
+	}
+	if len(info.Reviews) != 1 || info.Reviews[0].Author != "reviewer" {
+		t.Fatalf("Reviews = %+v, want reviewer entry", info.Reviews)
+	}
+
+	logData, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read fake gh log: %v", err)
+	}
+	logText := string(logData)
+	lines := strings.Split(strings.TrimSpace(logText), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 gh invocations, log=%q", logText)
+	}
+	if !strings.Contains(logText, "lockReason") {
+		t.Fatalf("expected initial gh call to request lockReason, log=%q", logText)
+	}
+	if !strings.Contains(logText, "--json state,isDraft,headRefName,reviews,createdAt,mergedAt,closedAt") {
+		t.Fatalf("expected fallback gh call without lockReason, log=%q", logText)
 	}
 }
 

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -36,38 +36,40 @@ type PRReviewComment struct {
 
 // PRInfo bundles state + reviews from a single gh call.
 type PRInfo struct {
-	State      string     `json:"state"`
-	IsDraft    bool       `json:"isDraft"`
-	LockReason string     `json:"lockReason"`
-	Reviews    []PRReview `json:"reviews"`
-	CreatedAt  string     `json:"createdAt"` // RFC3339, authoritative GitHub PR open time
-	MergedAt   string     `json:"mergedAt"`  // RFC3339, set when state=MERGED
-	ClosedAt   string     `json:"closedAt"`  // RFC3339, set when state=CLOSED or MERGED
+	State       string     `json:"state"`
+	IsDraft     bool       `json:"isDraft"`
+	HeadRefName string     `json:"headRefName"`
+	LockReason  string     `json:"lockReason"`
+	Reviews     []PRReview `json:"reviews"`
+	CreatedAt   string     `json:"createdAt"` // RFC3339, authoritative GitHub PR open time
+	MergedAt    string     `json:"mergedAt"`  // RFC3339, set when state=MERGED
+	ClosedAt    string     `json:"closedAt"`  // RFC3339, set when state=CLOSED or MERGED
 }
 
 // GetPRInfo fetches state and reviews in one gh call to avoid rate limiting.
 func (c *Client) GetPRInfo(ctx context.Context, repo string, prNum int) (*PRInfo, error) {
-	cmd := exec.CommandContext(ctx, "gh", "pr", "view",
-		fmt.Sprintf("%d", prNum),
-		"-R", repo,
-		"--json", "state,isDraft,lockReason,reviews,createdAt,mergedAt,closedAt")
-
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-	output, err := cmd.Output()
+	output, stderr, err := c.prViewJSON(ctx, repo, prNum, "state,isDraft,headRefName,lockReason,reviews,createdAt,mergedAt,closedAt")
 	if err != nil {
-		return nil, fmt.Errorf("gh pr view %s#%d: %s", repo, prNum, stderr.String())
+		// gh currently does not expose lockReason in every version. Retry without it
+		// so feedback scanning does not fail entirely on a non-critical field.
+		if strings.Contains(stderr, `Unknown JSON field: "lockReason"`) {
+			output, stderr, err = c.prViewJSON(ctx, repo, prNum, "state,isDraft,headRefName,reviews,createdAt,mergedAt,closedAt")
+		}
+		if err != nil {
+			return nil, fmt.Errorf("gh pr view %s#%d: %s", repo, prNum, stderr)
+		}
 	}
 
 	// Parse with nested author object
 	var raw struct {
-		State      string `json:"state"`
-		IsDraft    bool   `json:"isDraft"`
-		LockReason string `json:"lockReason"`
-		CreatedAt  string `json:"createdAt"`
-		MergedAt   string `json:"mergedAt"`
-		ClosedAt   string `json:"closedAt"`
-		Reviews    []struct {
+		State       string `json:"state"`
+		IsDraft     bool   `json:"isDraft"`
+		HeadRefName string `json:"headRefName"`
+		LockReason  string `json:"lockReason"`
+		CreatedAt   string `json:"createdAt"`
+		MergedAt    string `json:"mergedAt"`
+		ClosedAt    string `json:"closedAt"`
+		Reviews     []struct {
 			Author struct {
 				Login string `json:"login"`
 			} `json:"author"`
@@ -81,12 +83,13 @@ func (c *Client) GetPRInfo(ctx context.Context, repo string, prNum int) (*PRInfo
 	}
 
 	info := &PRInfo{
-		State:      raw.State,
-		IsDraft:    raw.IsDraft,
-		LockReason: raw.LockReason,
-		CreatedAt:  raw.CreatedAt,
-		MergedAt:   raw.MergedAt,
-		ClosedAt:   raw.ClosedAt,
+		State:       raw.State,
+		IsDraft:     raw.IsDraft,
+		HeadRefName: raw.HeadRefName,
+		LockReason:  raw.LockReason,
+		CreatedAt:   raw.CreatedAt,
+		MergedAt:    raw.MergedAt,
+		ClosedAt:    raw.ClosedAt,
 	}
 	for _, r := range raw.Reviews {
 		info.Reviews = append(info.Reviews, PRReview{
@@ -97,6 +100,32 @@ func (c *Client) GetPRInfo(ctx context.Context, repo string, prNum int) (*PRInfo
 		})
 	}
 	return info, nil
+}
+
+func (c *Client) prViewJSON(ctx context.Context, repo string, prNum int, fields string) ([]byte, string, error) {
+	cmd := exec.CommandContext(ctx, "gh", "pr", "view",
+		fmt.Sprintf("%d", prNum),
+		"-R", repo,
+		"--json", fields)
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	output, err := cmd.Output()
+	return output, stderr.String(), err
+}
+
+func (c *Client) GetPRHeadRefName(ctx context.Context, repo string, prNum int) (string, error) {
+	output, stderr, err := c.prViewJSON(ctx, repo, prNum, "headRefName")
+	if err != nil {
+		return "", fmt.Errorf("gh pr view %s#%d head ref: %s", repo, prNum, stderr)
+	}
+	var raw struct {
+		HeadRefName string `json:"headRefName"`
+	}
+	if err := json.Unmarshal(output, &raw); err != nil {
+		return "", fmt.Errorf("parse PR head ref: %w", err)
+	}
+	return strings.TrimSpace(raw.HeadRefName), nil
 }
 
 // GetPRStatus gets the CI status of a pull request
@@ -434,14 +463,31 @@ func (c *Client) ListUserOpenPRs(ctx context.Context) ([]GitHubPR, error) {
 		return nil, fmt.Errorf("search open PRs: %w", err)
 	}
 
+	prs, err := parseUserOpenPRs(output)
+	if err != nil {
+		return nil, err
+	}
+	for i := range prs {
+		headRef, err := c.GetPRHeadRefName(ctx, prs[i].Repo, prs[i].Number)
+		if err != nil {
+			log.Warn("failed to fetch PR head branch", "repo", prs[i].Repo, "pr", prs[i].Number, "error", err)
+			continue
+		}
+		prs[i].BranchName = headRef
+	}
+	return prs, nil
+}
+
+func parseUserOpenPRs(output []byte) ([]GitHubPR, error) {
 	var raw []struct {
 		Repository struct {
 			NameWithOwner string `json:"nameWithOwner"`
 		} `json:"repository"`
-		Number int    `json:"number"`
-		Title  string `json:"title"`
-		Body   string `json:"body"`
-		URL    string `json:"url"`
+		Number      int    `json:"number"`
+		Title       string `json:"title"`
+		Body        string `json:"body"`
+		URL         string `json:"url"`
+		HeadRefName string `json:"headRefName"`
 	}
 	if err := json.Unmarshal(output, &raw); err != nil {
 		return nil, fmt.Errorf("parse PR list: %w", err)
@@ -450,11 +496,12 @@ func (c *Client) ListUserOpenPRs(ctx context.Context) ([]GitHubPR, error) {
 	var prs []GitHubPR
 	for _, r := range raw {
 		prs = append(prs, GitHubPR{
-			Repo:   r.Repository.NameWithOwner,
-			Number: r.Number,
-			Title:  r.Title,
-			Body:   r.Body,
-			URL:    r.URL,
+			Repo:       r.Repository.NameWithOwner,
+			Number:     r.Number,
+			Title:      r.Title,
+			Body:       r.Body,
+			URL:        r.URL,
+			BranchName: r.HeadRefName,
 		})
 	}
 	return prs, nil

--- a/internal/pipeline/feedback.go
+++ b/internal/pipeline/feedback.go
@@ -29,6 +29,7 @@ func (p *Pipeline) ProcessPR(ctx context.Context, pr *models.PullRequest) error 
 			return fmt.Errorf("get PR info: %w", err)
 		}
 	}
+	p.refreshPRBranchName(pr, prInfo)
 
 	// Terminal state transitions from GitHub
 	switch prInfo.State {
@@ -104,6 +105,18 @@ func (p *Pipeline) ProcessPR(ctx context.Context, pr *models.PullRequest) error 
 // ProcessFeedback is an alias for ProcessPR for backward compatibility.
 func (p *Pipeline) ProcessFeedback(ctx context.Context, pr *models.PullRequest) error {
 	return p.ProcessPR(ctx, pr)
+}
+
+func (p *Pipeline) refreshPRBranchName(pr *models.PullRequest, prInfo *ghclient.PRInfo) {
+	headBranch := strings.TrimSpace(prInfo.HeadRefName)
+	if headBranch == "" || strings.TrimSpace(pr.BranchName) == headBranch {
+		return
+	}
+
+	pr.BranchName = headBranch
+	if err := p.db.UpdatePRBranchName(pr.ID, headBranch); err != nil {
+		log.WithError(err).WithField("pr", pr.PRURL).Warn("failed to persist PR head branch")
+	}
 }
 
 // handleDraft manages draft PRs: check CI, promote to ready, or fix failures.
@@ -240,7 +253,7 @@ func (p *Pipeline) handleOpen(ctx context.Context, pr *models.PullRequest, prRep
 				if err != nil {
 					break
 				}
-				workspace, err := p.createWorkspace(issue)
+				workspace, err := p.preparePRWorkspace(ctx, prRepo, pr, issue)
 				if err != nil {
 					break
 				}
@@ -354,9 +367,9 @@ func (p *Pipeline) handleOpen(ctx context.Context, pr *models.PullRequest, prRep
 	p.db.UpdatePRReviewStats(pr.ID, totalFeedback, &firstReview)
 
 	// Locate workspace
-	workspace, err := p.createWorkspace(issue)
+	workspace, err := p.preparePRWorkspace(ctx, prRepo, pr, issue)
 	if err != nil {
-		return fmt.Errorf("create workspace: %w", err)
+		return fmt.Errorf("prepare PR workspace: %w", err)
 	}
 
 	// Build context for responder agent (human feedback only)
@@ -417,9 +430,9 @@ func (p *Pipeline) handleOpen(ctx context.Context, pr *models.PullRequest, prRep
 
 // attemptCIFix runs the engineer agent to fix code-level CI failures on a draft PR.
 func (p *Pipeline) attemptCIFix(ctx context.Context, pr *models.PullRequest, prRepo string, issue *models.Issue, ci *ghclient.CIResult) {
-	workspace, err := p.createWorkspace(issue)
+	workspace, err := p.preparePRWorkspace(ctx, prRepo, pr, issue)
 	if err != nil {
-		log.WithError(err).Warn("cannot create workspace for CI fix")
+		log.WithError(err).Warn("cannot prepare workspace for CI fix")
 		return
 	}
 

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/majiayu000/auto-contributor/internal/config"
@@ -326,6 +328,58 @@ func (p *Pipeline) createWorkspace(issue *models.Issue) (string, error) {
 		return "", err
 	}
 	return dir, nil
+}
+
+// preparePRWorkspace ensures feedback/CI fix agents run in the PR head branch,
+// not in an empty directory or the upstream default branch.
+func (p *Pipeline) preparePRWorkspace(ctx context.Context, prRepo string, pr *models.PullRequest, issue *models.Issue) (string, error) {
+	branch := strings.TrimSpace(pr.BranchName)
+	if branch == "" {
+		return "", fmt.Errorf("missing head branch for PR %s", pr.PRURL)
+	}
+
+	workspace, err := p.createWorkspace(issue)
+	if err != nil {
+		return "", err
+	}
+
+	if _, err := os.Stat(filepath.Join(workspace, ".git")); err != nil {
+		os.RemoveAll(workspace)
+		if err := p.gh.CloneRepo(ctx, prRepo, workspace); err != nil {
+			return "", fmt.Errorf("clone %s for PR feedback: %w", prRepo, err)
+		}
+	}
+
+	if err := p.gh.SetupForkRemote(ctx, workspace, prRepo); err != nil {
+		log.WithError(err).WithField("workspace", workspace).Warn("setup fork remote for PR feedback")
+	}
+
+	if err := fetchPRBranch(ctx, workspace, "fork", branch); err != nil {
+		forkErr := err
+		if err := fetchPRBranch(ctx, workspace, "origin", branch); err != nil {
+			return "", fmt.Errorf("fetch PR branch %q from fork (%v) or origin (%w)", branch, forkErr, err)
+		}
+	}
+
+	if err := runGit(ctx, workspace, "checkout", "-B", branch, "FETCH_HEAD"); err != nil {
+		return "", fmt.Errorf("checkout PR branch %q: %w", branch, err)
+	}
+
+	return workspace, nil
+}
+
+func fetchPRBranch(ctx context.Context, workDir, remote, branch string) error {
+	return runGit(ctx, workDir, "fetch", "--depth", "1", remote, branch)
+}
+
+func runGit(ctx context.Context, workDir string, args ...string) error {
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Dir = workDir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("git %s: %s - %w", strings.Join(args, " "), strings.TrimSpace(string(output)), err)
+	}
+	return nil
 }
 
 // cleanupWorkspace removes the workspace directory for a PR after it reaches a terminal state.

--- a/internal/pipeline/workspace_test.go
+++ b/internal/pipeline/workspace_test.go
@@ -1,0 +1,120 @@
+package pipeline
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/majiayu000/auto-contributor/internal/config"
+	ghclient "github.com/majiayu000/auto-contributor/internal/github"
+	"github.com/majiayu000/auto-contributor/pkg/models"
+)
+
+func TestPreparePRWorkspaceChecksOutTrackedBranch(t *testing.T) {
+	remoteDir := createBareRepo(t)
+	seedDir := filepath.Join(t.TempDir(), "seed")
+	runGitCommand(t, "", "init", "--initial-branch=main", seedDir)
+	runGitCommand(t, seedDir, "config", "user.name", "Test User")
+	runGitCommand(t, seedDir, "config", "user.email", "test@example.com")
+	writeFile(t, filepath.Join(seedDir, "tracked.txt"), "main\n")
+	runGitCommand(t, seedDir, "add", "tracked.txt")
+	runGitCommand(t, seedDir, "commit", "-m", "main")
+	runGitCommand(t, seedDir, "remote", "add", "origin", remoteDir)
+	runGitCommand(t, seedDir, "push", "origin", "main")
+
+	runGitCommand(t, seedDir, "checkout", "-b", "fix/bug-42")
+	writeFile(t, filepath.Join(seedDir, "tracked.txt"), "branch\n")
+	runGitCommand(t, seedDir, "commit", "-am", "branch")
+	runGitCommand(t, seedDir, "push", "origin", "fix/bug-42")
+
+	p := newWorkspaceTestPipeline(t)
+	issue := &models.Issue{Repo: "owner/repo", IssueNumber: 60}
+	pr := &models.PullRequest{
+		PRURL:      "https://github.com/owner/repo/pull/42",
+		BranchName: "fix/bug-42",
+	}
+
+	workspace, err := p.createWorkspace(issue)
+	if err != nil {
+		t.Fatalf("createWorkspace: %v", err)
+	}
+	runGitCommand(t, "", "clone", remoteDir, workspace)
+	runGitCommand(t, workspace, "remote", "add", "fork", remoteDir)
+
+	got, err := p.preparePRWorkspace(context.Background(), issue.Repo, pr, issue)
+	if err != nil {
+		t.Fatalf("preparePRWorkspace: %v", err)
+	}
+	if got != workspace {
+		t.Fatalf("workspace = %q, want %q", got, workspace)
+	}
+
+	head := strings.TrimSpace(runGitCommand(t, workspace, "rev-parse", "--abbrev-ref", "HEAD"))
+	if head != "fix/bug-42" {
+		t.Fatalf("HEAD branch = %q, want %q", head, "fix/bug-42")
+	}
+
+	content, err := os.ReadFile(filepath.Join(workspace, "tracked.txt"))
+	if err != nil {
+		t.Fatalf("read tracked file: %v", err)
+	}
+	if string(content) != "branch\n" {
+		t.Fatalf("tracked.txt = %q, want %q", string(content), "branch\n")
+	}
+}
+
+func TestPreparePRWorkspaceRequiresBranchName(t *testing.T) {
+	p := newWorkspaceTestPipeline(t)
+	issue := &models.Issue{Repo: "owner/repo", IssueNumber: 60}
+	pr := &models.PullRequest{PRURL: "https://github.com/owner/repo/pull/42"}
+
+	_, err := p.preparePRWorkspace(context.Background(), issue.Repo, pr, issue)
+	if err == nil {
+		t.Fatal("preparePRWorkspace error = nil, want missing branch error")
+	}
+	if !strings.Contains(err.Error(), "missing head branch") {
+		t.Fatalf("preparePRWorkspace error = %q, want missing head branch", err)
+	}
+}
+
+func newWorkspaceTestPipeline(t *testing.T) *Pipeline {
+	t.Helper()
+	cfg := &config.Config{
+		WorkspaceDir:   t.TempDir(),
+		GitHubUsername: "tester",
+	}
+	return &Pipeline{
+		cfg: cfg,
+		gh:  ghclient.New(cfg),
+	}
+}
+
+func createBareRepo(t *testing.T) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), "remote.git")
+	runGitCommand(t, "", "init", "--bare", dir)
+	return dir
+}
+
+func writeFile(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(body), 0644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func runGitCommand(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %s", strings.Join(args, " "), strings.TrimSpace(string(output)))
+	}
+	return string(output)
+}


### PR DESCRIPTION
## Summary

- fetch and persist PR head branch names for GitHub-synced open PRs
- backfill existing tracked PR rows when `gh pr view` returns `headRefName`
- prepare feedback/CI workspaces by cloning, fetching, and checking out the PR head branch before agents run
- retry `gh pr view` without unsupported `lockReason` so feedback scanning does not fail on older GitHub CLI JSON fields

Fixes #60.

## Validation

- `go test ./...`
- `go vet ./...`
- `go build ./cmd/auto-contributor`
- `go test -race ./...`
