### PR TITLE
refactor(discovery): testable filter chain with structured skip reasons

### DIFF
--- a/cmd/auto-contributor/cmd_discover.go
+++ b/cmd/auto-contributor/cmd_discover.go
@@ -157,7 +157,7 @@ func smartDiscover(cmd *cobra.Command, args []string) error {
 			MinStars:       cfg.MinRepoStars,
 			Languages:      cfg.Languages,
 			ExcludeRepos:   cfg.ExcludeRepos,
-		}, nil /* skip duplicate-PR check; smartDiscover already verified upstream */, database)
+		}, ghClient, database)
 
 		filterResults := filter.Apply(ctx, result.Issues)
 		stats := discovery.Summarize(filterResults)

--- a/cmd/auto-contributor/cmd_discover.go
+++ b/cmd/auto-contributor/cmd_discover.go
@@ -152,12 +152,7 @@ func smartDiscover(cmd *cobra.Command, args []string) error {
 	// Save high-scoring issues to database
 	if database != nil && len(result.Issues) > 0 {
 		fmt.Println("Saving high-scoring issues to database...")
-		filter := discovery.NewFilter(discovery.FilterConfig{
-			MinSuitability: minSuitabilityForSave,
-			MinStars:       cfg.MinRepoStars,
-			Languages:      cfg.Languages,
-			ExcludeRepos:   cfg.ExcludeRepos,
-		}, ghClient, database)
+		filter := discovery.NewFilter(smartDiscoverSaveFilterConfig(minStars), ghClient, database)
 
 		filterResults := filter.Apply(ctx, result.Issues)
 		stats := discovery.Summarize(filterResults)
@@ -203,6 +198,15 @@ func smartDiscover(cmd *cobra.Command, args []string) error {
 // because this command is interactive and only the strongest
 // candidates should land in the table from a single human-driven run.
 const minSuitabilityForSave = 0.7
+
+func smartDiscoverSaveFilterConfig(minStars int) discovery.FilterConfig {
+	return discovery.FilterConfig{
+		MinSuitability: minSuitabilityForSave,
+		MinStars:       minStars,
+		Languages:      cfg.Languages,
+		ExcludeRepos:   cfg.ExcludeRepos,
+	}
+}
 
 func formatDetail(detail string) string {
 	if detail == "" {

--- a/cmd/auto-contributor/cmd_discover.go
+++ b/cmd/auto-contributor/cmd_discover.go
@@ -152,33 +152,61 @@ func smartDiscover(cmd *cobra.Command, args []string) error {
 	// Save high-scoring issues to database
 	if database != nil && len(result.Issues) > 0 {
 		fmt.Println("Saving high-scoring issues to database...")
-		for _, issue := range result.Issues {
-			if issue.SuitabilityScore >= 0.7 {
-				isBlacklisted, _ := database.IsBlacklisted(issue.Repo)
-				if isBlacklisted {
-					fmt.Printf("   Skipping blacklisted repo: %s\n", issue.Repo)
-					continue
-				}
+		filter := discovery.NewFilter(discovery.FilterConfig{
+			MinSuitability: minSuitabilityForSave,
+			MinStars:       cfg.MinRepoStars,
+			Languages:      cfg.Languages,
+			ExcludeRepos:   cfg.ExcludeRepos,
+		}, nil /* skip duplicate-PR check; smartDiscover already verified upstream */, database)
 
-				dbIssue := &models.Issue{
-					Repo:            issue.Repo,
-					IssueNumber:     issue.IssueNumber,
-					Title:           issue.Title,
-					Body:            issue.Analysis.Recommendation,
-					Language:        cfg.Languages[0],
-					DifficultyScore: 1.0 - issue.SuitabilityScore,
-					Status:          models.IssueStatusDiscovered,
-					DiscoveredAt:    time.Now(),
-					UpdatedAt:       time.Now(),
-				}
-				if err := database.CreateIssue(dbIssue); err != nil {
-					fmt.Printf("   Failed to save %s#%d: %v\n", issue.Repo, issue.IssueNumber, err)
-				} else {
-					fmt.Printf("   Saved %s#%d\n", issue.Repo, issue.IssueNumber)
-				}
+		filterResults := filter.Apply(ctx, result.Issues)
+		stats := discovery.Summarize(filterResults)
+
+		for _, fr := range filterResults {
+			if !fr.Accepted() {
+				fmt.Printf("   Skipping %s#%d: %s%s\n",
+					fr.Issue.Repo, fr.Issue.IssueNumber, fr.Reason, formatDetail(fr.Detail))
+				continue
+			}
+
+			issue := fr.Issue
+			dbIssue := &models.Issue{
+				Repo:            issue.Repo,
+				IssueNumber:     issue.IssueNumber,
+				Title:           issue.Title,
+				Body:            issue.Analysis.Recommendation,
+				Language:        primaryLanguage(cfg.Languages, issue.RepoContext.Language),
+				DifficultyScore: discovery.SuitabilityToDifficulty(issue.SuitabilityScore),
+				Status:          models.IssueStatusDiscovered,
+				DiscoveredAt:    time.Now(),
+				UpdatedAt:       time.Now(),
+			}
+			if err := database.CreateIssue(dbIssue); err != nil {
+				fmt.Printf("   Failed to save %s#%d: %v\n", issue.Repo, issue.IssueNumber, err)
+			} else {
+				fmt.Printf("   Saved %s#%d\n", issue.Repo, issue.IssueNumber)
 			}
 		}
+
+		fmt.Printf("\nFilter summary: accepted=%d skipped=%d", stats.Accepted, stats.Skipped)
+		for _, reason := range stats.SkipReasons() {
+			fmt.Printf(" %s=%d", reason, stats.Counts[reason])
+		}
+		fmt.Println()
 	}
 
 	return nil
+}
+
+// minSuitabilityForSave is the gate used by smart-discover before it
+// persists. It is intentionally stricter than the loop-mode gate
+// because this command is interactive and only the strongest
+// candidates should land in the table from a single human-driven run.
+const minSuitabilityForSave = 0.7
+
+func formatDetail(detail string) string {
+	if detail == "" {
+		return ""
+	}
+	return " (" + detail + ")"
 }

--- a/cmd/auto-contributor/cmd_discover_test.go
+++ b/cmd/auto-contributor/cmd_discover_test.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/majiayu000/auto-contributor/internal/config"
+)
+
+func TestSmartDiscoverSaveFilterConfigUsesRequestedMinStars(t *testing.T) {
+	oldCfg := cfg
+	t.Cleanup(func() { cfg = oldCfg })
+
+	cfg = config.Default()
+	cfg.MinRepoStars = 1000
+	cfg.Languages = []string{"go"}
+	cfg.ExcludeRepos = []string{"owner/excluded"}
+
+	filterCfg := smartDiscoverSaveFilterConfig(50)
+	if filterCfg.MinStars != 50 {
+		t.Fatalf("MinStars=%d want requested min-stars %d", filterCfg.MinStars, 50)
+	}
+	if filterCfg.MinStars == cfg.MinRepoStars {
+		t.Fatalf("MinStars reused cfg.MinRepoStars=%d", cfg.MinRepoStars)
+	}
+}

--- a/cmd/auto-contributor/cmd_loop.go
+++ b/cmd/auto-contributor/cmd_loop.go
@@ -220,43 +220,36 @@ func runDiscovery(ctx context.Context, issueCh chan<- *models.Issue) {
 		"total_candidates", result.Metadata.TotalCandidates,
 	)
 
-	var queued, skipped int
-	for _, issue := range result.Issues {
-		if issue.SuitabilityScore < 0.4 {
-			skipped++
-			continue
-		}
+	filter := discovery.NewFilter(discovery.FilterConfig{
+		MinSuitability: minSuitabilityForLoop,
+		MinStars:       cfg.MinRepoStars,
+		Languages:      cfg.Languages,
+		ExcludeRepos:   excludeRepos,
+	}, ghClient, database)
 
-		// Double-check for existing PR; skip on error to avoid duplicate PRs.
-		hasPR, prErr := ghClient.HasExistingPR(ctx, issue.Repo, issue.IssueNumber)
-		if prErr != nil {
-			log.Warn("failed to check existing PR, skipping issue to avoid duplicate",
-				"repo", issue.Repo,
-				"issue", issue.IssueNumber,
-				"error", prErr,
+	filterResults := filter.Apply(ctx, result.Issues)
+	stats := discovery.Summarize(filterResults)
+
+	var queued int
+	for _, fr := range filterResults {
+		if !fr.Accepted() {
+			log.Debug("issue skipped",
+				"repo", fr.Issue.Repo,
+				"issue", fr.Issue.IssueNumber,
+				"reason", string(fr.Reason),
+				"detail", fr.Detail,
 			)
-			skipped++
-			continue
-		}
-		if hasPR {
-			skipped++
 			continue
 		}
 
-		// Check blacklist
-		isBlacklisted, _ := database.IsBlacklisted(issue.Repo)
-		if isBlacklisted {
-			skipped++
-			continue
-		}
-
+		issue := fr.Issue
 		dbIssue := &models.Issue{
 			Repo:            issue.Repo,
 			IssueNumber:     issue.IssueNumber,
 			Title:           issue.Title,
 			Body:            issue.Analysis.Recommendation,
-			Language:        cfg.Languages[0],
-			DifficultyScore: issue.SuitabilityScore,
+			Language:        primaryLanguage(cfg.Languages, issue.RepoContext.Language),
+			DifficultyScore: discovery.SuitabilityToDifficulty(issue.SuitabilityScore),
 			Status:          models.IssueStatusDiscovered,
 			DiscoveredAt:    time.Now(),
 			UpdatedAt:       time.Now(),
@@ -281,10 +274,42 @@ func runDiscovery(ctx context.Context, issueCh chan<- *models.Issue) {
 		queued++
 	}
 
-	log.Info("discovery cycle complete",
+	logSkipBreakdown("discovery cycle complete", queued, stats)
+}
+
+// minSuitabilityForLoop is the minimum SuitabilityScore (0..1) we are
+// willing to enqueue from the discovery loop. Lifted verbatim from the
+// previous inline 0.4 magic number so behavior is unchanged; the named
+// constant lets the threshold be tuned without code spelunking.
+const minSuitabilityForLoop = 0.4
+
+// primaryLanguage picks a sensible value for models.Issue.Language.
+// Prefers the repo-reported language when available; otherwise falls
+// back to the first configured allowlist entry, matching prior behavior.
+// Returns empty string when no information is available rather than
+// indexing into a nil slice (which would panic).
+func primaryLanguage(allowed []string, fromRepo string) string {
+	if fromRepo != "" {
+		return fromRepo
+	}
+	if len(allowed) > 0 {
+		return allowed[0]
+	}
+	return ""
+}
+
+// logSkipBreakdown emits a single structured line summarising one
+// discovery cycle. Skip reasons appear as `skip_<reason>` keys with the
+// raw count as value, so log analyzers can chart them over time.
+func logSkipBreakdown(msg string, queued int, stats discovery.FilterStats) {
+	fields := []interface{}{
 		"queued", queued,
-		"skipped", skipped,
-	)
+		"skipped", stats.Skipped,
+	}
+	for _, reason := range stats.SkipReasons() {
+		fields = append(fields, "skip_"+string(reason), stats.Counts[reason])
+	}
+	log.Info(msg, fields...)
 }
 
 func runFeedbackLoop(cmd *cobra.Command, args []string) error {

--- a/internal/discovery/claude_discovery.go
+++ b/internal/discovery/claude_discovery.go
@@ -45,6 +45,10 @@ type RepoContext struct {
 	HasClaudeMD     bool   `json:"has_claude_md"`
 	TestFramework   string `json:"test_framework"`
 	CISystem        string `json:"ci_system"`
+	// Language is the repository's primary language as reported by the
+	// agent. Optional: empty string means "unknown", and downstream
+	// gates that depend on language must fail-open in that case.
+	Language string `json:"language,omitempty"`
 }
 
 // DiscoveredIssue represents a discovered and analyzed issue

--- a/internal/discovery/filter.go
+++ b/internal/discovery/filter.go
@@ -177,8 +177,9 @@ func (f *Filter) Apply(ctx context.Context, issues []DiscoveredIssue) []FilterRe
 }
 
 func (f *Filter) applyOne(ctx context.Context, issue DiscoveredIssue) FilterResult {
-	repoKey := strings.ToLower(strings.TrimSpace(issue.Repo))
-	if repoKey == "" || issue.IssueNumber <= 0 {
+	repoName := strings.TrimSpace(issue.Repo)
+	repoKey := strings.ToLower(repoName)
+	if repoName == "" || issue.IssueNumber <= 0 {
 		return FilterResult{Issue: issue, Reason: ReasonInvalid, Detail: "missing repo or issue number"}
 	}
 
@@ -216,10 +217,10 @@ func (f *Filter) applyOne(ctx context.Context, issue DiscoveredIssue) FilterResu
 	// Network/database gates last. Both fail closed: an error here means
 	// we don't know the answer, and the existing pipeline policy is to
 	// skip rather than risk a duplicate PR.
-	if blacklisted, err := f.blacklist.IsBlacklisted(repoKey); err != nil {
+	if blacklisted, err := f.blacklist.IsBlacklisted(repoName); err != nil {
 		return FilterResult{Issue: issue, Reason: ReasonBlacklistCheckFailed, Detail: err.Error()}
 	} else if blacklisted {
-		return FilterResult{Issue: issue, Reason: ReasonBlacklisted, Detail: repoKey}
+		return FilterResult{Issue: issue, Reason: ReasonBlacklisted, Detail: repoName}
 	}
 
 	hasPR, err := f.pr.HasExistingPR(ctx, issue.Repo, issue.IssueNumber)

--- a/internal/discovery/filter.go
+++ b/internal/discovery/filter.go
@@ -38,6 +38,14 @@ const (
 	// ReasonBlacklisted is emitted when database.IsBlacklisted returns true.
 	ReasonBlacklisted SkipReason = "blacklisted"
 
+	// ReasonBlacklistCheckFailed is emitted when the blacklist lookup
+	// itself errored. Distinct from ReasonBlacklisted so dashboards can
+	// tell "intentionally banned" apart from "DB degraded" — a sustained
+	// rise in this counter is an SRE signal, not a content signal.
+	// We fail closed (skip the issue) so that a degraded blacklist DB
+	// can never accidentally surface a banned repo.
+	ReasonBlacklistCheckFailed SkipReason = "blacklist_check_failed"
+
 	// ReasonExistingPR is emitted when ghClient.HasExistingPR returns true.
 	ReasonExistingPR SkipReason = "existing_pr"
 
@@ -209,7 +217,7 @@ func (f *Filter) applyOne(ctx context.Context, issue DiscoveredIssue) FilterResu
 	// we don't know the answer, and the existing pipeline policy is to
 	// skip rather than risk a duplicate PR.
 	if blacklisted, err := f.blacklist.IsBlacklisted(repoKey); err != nil {
-		return FilterResult{Issue: issue, Reason: ReasonBlacklisted, Detail: "lookup failed: " + err.Error()}
+		return FilterResult{Issue: issue, Reason: ReasonBlacklistCheckFailed, Detail: err.Error()}
 	} else if blacklisted {
 		return FilterResult{Issue: issue, Reason: ReasonBlacklisted, Detail: repoKey}
 	}

--- a/internal/discovery/filter.go
+++ b/internal/discovery/filter.go
@@ -1,0 +1,276 @@
+package discovery
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// SkipReason names a single rejection cause for a discovered issue.
+// Reasons are stable strings so they can be used as log fields, metric
+// labels, and database keys without translation.
+type SkipReason string
+
+const (
+	// ReasonAccepted is the sentinel value used in FilterResult to mark
+	// issues that passed every gate.
+	ReasonAccepted SkipReason = ""
+
+	// ReasonLowSuitability is emitted when SuitabilityScore is below
+	// FilterConfig.MinSuitability.
+	ReasonLowSuitability SkipReason = "low_suitability"
+
+	// ReasonLowStars is emitted when RepoContext.Stars is below
+	// FilterConfig.MinStars.
+	ReasonLowStars SkipReason = "low_stars"
+
+	// ReasonLanguageMismatch is emitted when FilterConfig.Languages is
+	// non-empty and the issue's repo language is not in the allowlist.
+	// Per-issue language is best-effort; if the discoverer did not record
+	// a language, this gate is a no-op for that issue (fail-open).
+	ReasonLanguageMismatch SkipReason = "language_mismatch"
+
+	// ReasonExcludedRepo is emitted when the issue's repo is on the
+	// configured exclude list.
+	ReasonExcludedRepo SkipReason = "excluded_repo"
+
+	// ReasonBlacklisted is emitted when database.IsBlacklisted returns true.
+	ReasonBlacklisted SkipReason = "blacklisted"
+
+	// ReasonExistingPR is emitted when ghClient.HasExistingPR returns true.
+	ReasonExistingPR SkipReason = "existing_pr"
+
+	// ReasonPRCheckFailed is emitted when the PR check itself fails. We
+	// fail closed (skip the issue) to avoid double-PRs when the upstream
+	// API is degraded — matches the existing behavior in cmd_loop.go.
+	ReasonPRCheckFailed SkipReason = "pr_check_failed"
+
+	// ReasonInvalid is emitted when the candidate is missing required
+	// fields (e.g. empty repo or zero issue number).
+	ReasonInvalid SkipReason = "invalid"
+)
+
+// FilterConfig groups every threshold the filter consults. Zero values
+// disable the corresponding gate, except MinSuitability which defaults
+// to 0 (i.e. accept any score) and MinStars which defaults to 0.
+type FilterConfig struct {
+	MinSuitability float64
+	MinStars       int
+	// Languages is the language allowlist (lowercased on Apply). Empty
+	// means "do not gate on language".
+	Languages    []string
+	ExcludeRepos []string
+}
+
+// PRChecker is the minimal interface the filter needs from the GitHub
+// client. Defining it locally keeps internal/discovery free of a hard
+// dependency on internal/github and makes the filter trivially mockable.
+type PRChecker interface {
+	HasExistingPR(ctx context.Context, repoFullName string, issueNum int) (bool, error)
+}
+
+// BlacklistChecker abstracts the database blacklist lookup. As above,
+// we depend on the contract, not on internal/db.
+type BlacklistChecker interface {
+	IsBlacklisted(repo string) (bool, error)
+}
+
+// noopPRChecker is used when the caller does not provide a checker;
+// every issue passes the existing-PR gate.
+type noopPRChecker struct{}
+
+func (noopPRChecker) HasExistingPR(_ context.Context, _ string, _ int) (bool, error) {
+	return false, nil
+}
+
+// noopBlacklistChecker is used when no blacklist source is configured.
+type noopBlacklistChecker struct{}
+
+func (noopBlacklistChecker) IsBlacklisted(_ string) (bool, error) { return false, nil }
+
+// Filter runs a deterministic chain of gates against DiscoveredIssue
+// candidates and emits a structured FilterResult per input. Cheap
+// in-memory gates run first so we never call the GitHub API for a
+// candidate that is going to be rejected anyway.
+type Filter struct {
+	cfg          FilterConfig
+	pr           PRChecker
+	blacklist    BlacklistChecker
+	excludeIndex map[string]struct{}
+	langIndex    map[string]struct{}
+}
+
+// NewFilter constructs a Filter. Pass nil for either checker to disable
+// the matching gate.
+func NewFilter(cfg FilterConfig, pr PRChecker, blacklist BlacklistChecker) *Filter {
+	if pr == nil {
+		pr = noopPRChecker{}
+	}
+	if blacklist == nil {
+		blacklist = noopBlacklistChecker{}
+	}
+
+	excludeIndex := make(map[string]struct{}, len(cfg.ExcludeRepos))
+	for _, r := range cfg.ExcludeRepos {
+		key := strings.ToLower(strings.TrimSpace(r))
+		if key == "" {
+			continue
+		}
+		excludeIndex[key] = struct{}{}
+	}
+
+	langIndex := make(map[string]struct{}, len(cfg.Languages))
+	for _, l := range cfg.Languages {
+		key := strings.ToLower(strings.TrimSpace(l))
+		if key == "" {
+			continue
+		}
+		langIndex[key] = struct{}{}
+	}
+
+	return &Filter{
+		cfg:          cfg,
+		pr:           pr,
+		blacklist:    blacklist,
+		excludeIndex: excludeIndex,
+		langIndex:    langIndex,
+	}
+}
+
+// FilterResult records the outcome of running one issue through the
+// filter chain.
+type FilterResult struct {
+	Issue  DiscoveredIssue
+	Reason SkipReason
+	// Detail carries supplementary context that is useful for log lines
+	// (e.g. "score=0.32 < 0.40" or the underlying API error message).
+	// It is never the source of truth — Reason is.
+	Detail string
+}
+
+// Accepted reports whether this result passed every gate.
+func (r FilterResult) Accepted() bool { return r.Reason == ReasonAccepted }
+
+// Apply runs the filter chain over the candidates and returns one
+// FilterResult per input. Order is preserved so callers can correlate
+// results with the original slice.
+//
+// The function never returns an error: per-issue failures are encoded
+// in FilterResult.Reason. This is deliberate — discovery already runs
+// in a long-lived loop and we don't want one degraded check to abort
+// the whole cycle.
+func (f *Filter) Apply(ctx context.Context, issues []DiscoveredIssue) []FilterResult {
+	results := make([]FilterResult, 0, len(issues))
+	for _, issue := range issues {
+		results = append(results, f.applyOne(ctx, issue))
+	}
+	return results
+}
+
+func (f *Filter) applyOne(ctx context.Context, issue DiscoveredIssue) FilterResult {
+	repoKey := strings.ToLower(strings.TrimSpace(issue.Repo))
+	if repoKey == "" || issue.IssueNumber <= 0 {
+		return FilterResult{Issue: issue, Reason: ReasonInvalid, Detail: "missing repo or issue number"}
+	}
+
+	// Cheap, deterministic gates first.
+	if f.cfg.MinSuitability > 0 && issue.SuitabilityScore < f.cfg.MinSuitability {
+		return FilterResult{
+			Issue:  issue,
+			Reason: ReasonLowSuitability,
+			Detail: fmt.Sprintf("score=%.2f<%.2f", issue.SuitabilityScore, f.cfg.MinSuitability),
+		}
+	}
+
+	if f.cfg.MinStars > 0 && issue.RepoContext.Stars > 0 && issue.RepoContext.Stars < f.cfg.MinStars {
+		return FilterResult{
+			Issue:  issue,
+			Reason: ReasonLowStars,
+			Detail: fmt.Sprintf("stars=%d<%d", issue.RepoContext.Stars, f.cfg.MinStars),
+		}
+	}
+
+	if _, excluded := f.excludeIndex[repoKey]; excluded {
+		return FilterResult{Issue: issue, Reason: ReasonExcludedRepo, Detail: repoKey}
+	}
+
+	if len(f.langIndex) > 0 && issue.RepoContext.Language != "" {
+		if _, ok := f.langIndex[strings.ToLower(issue.RepoContext.Language)]; !ok {
+			return FilterResult{
+				Issue:  issue,
+				Reason: ReasonLanguageMismatch,
+				Detail: issue.RepoContext.Language,
+			}
+		}
+	}
+
+	// Network/database gates last. Both fail closed: an error here means
+	// we don't know the answer, and the existing pipeline policy is to
+	// skip rather than risk a duplicate PR.
+	if blacklisted, err := f.blacklist.IsBlacklisted(repoKey); err != nil {
+		return FilterResult{Issue: issue, Reason: ReasonBlacklisted, Detail: "lookup failed: " + err.Error()}
+	} else if blacklisted {
+		return FilterResult{Issue: issue, Reason: ReasonBlacklisted, Detail: repoKey}
+	}
+
+	hasPR, err := f.pr.HasExistingPR(ctx, issue.Repo, issue.IssueNumber)
+	if err != nil {
+		return FilterResult{Issue: issue, Reason: ReasonPRCheckFailed, Detail: err.Error()}
+	}
+	if hasPR {
+		return FilterResult{Issue: issue, Reason: ReasonExistingPR}
+	}
+
+	return FilterResult{Issue: issue, Reason: ReasonAccepted}
+}
+
+// FilterStats aggregates a slice of FilterResult into Accepted vs
+// per-reason skip counts. The counts map never contains ReasonAccepted.
+type FilterStats struct {
+	Accepted int
+	Skipped  int
+	Counts   map[SkipReason]int
+}
+
+// Summarize aggregates FilterResults into a FilterStats. The order of
+// keys returned by SkipReasons() is deterministic (lexicographic) so
+// log lines and tests are stable.
+func Summarize(results []FilterResult) FilterStats {
+	stats := FilterStats{Counts: make(map[SkipReason]int)}
+	for _, r := range results {
+		if r.Accepted() {
+			stats.Accepted++
+			continue
+		}
+		stats.Skipped++
+		stats.Counts[r.Reason]++
+	}
+	return stats
+}
+
+// SkipReasons returns the skip-reason keys in lexicographic order.
+func (s FilterStats) SkipReasons() []SkipReason {
+	keys := make([]SkipReason, 0, len(s.Counts))
+	for k := range s.Counts {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool { return string(keys[i]) < string(keys[j]) })
+	return keys
+}
+
+// SuitabilityToDifficulty maps a suitability score (higher = better
+// candidate) onto a difficulty score (higher = harder issue). The
+// canonical convention used by internal/github.estimateDifficulty is
+// "higher = harder". Two call sites in cmd/auto-contributor disagreed
+// before this helper existed — see the package tests for the regression.
+func SuitabilityToDifficulty(suitability float64) float64 {
+	d := 1.0 - suitability
+	if d < 0 {
+		return 0
+	}
+	if d > 1 {
+		return 1
+	}
+	return d
+}

--- a/internal/discovery/filter_test.go
+++ b/internal/discovery/filter_test.go
@@ -1,0 +1,284 @@
+package discovery
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+type fakePR struct {
+	hasPR bool
+	err   error
+	calls int
+}
+
+func (f *fakePR) HasExistingPR(_ context.Context, _ string, _ int) (bool, error) {
+	f.calls++
+	return f.hasPR, f.err
+}
+
+type fakeBlacklist struct {
+	black bool
+	err   error
+}
+
+func (f *fakeBlacklist) IsBlacklisted(_ string) (bool, error) {
+	return f.black, f.err
+}
+
+func candidate(repo string, num int, score float64) DiscoveredIssue {
+	return DiscoveredIssue{
+		Repo:             repo,
+		IssueNumber:      num,
+		Title:            "T",
+		SuitabilityScore: score,
+		RepoContext:      RepoContext{Stars: 5000, Language: "Go"},
+	}
+}
+
+func TestFilter_AcceptsClean(t *testing.T) {
+	t.Parallel()
+
+	pr := &fakePR{}
+	bl := &fakeBlacklist{}
+	f := NewFilter(FilterConfig{MinSuitability: 0.4, MinStars: 1000}, pr, bl)
+
+	results := f.Apply(context.Background(), []DiscoveredIssue{candidate("owner/repo", 1, 0.9)})
+	if len(results) != 1 {
+		t.Fatalf("len(results)=%d want 1", len(results))
+	}
+	if !results[0].Accepted() {
+		t.Fatalf("expected accepted, got reason=%q detail=%q", results[0].Reason, results[0].Detail)
+	}
+	if pr.calls != 1 {
+		t.Fatalf("expected one PR check, got %d", pr.calls)
+	}
+}
+
+func TestFilter_RejectsLowSuitability(t *testing.T) {
+	t.Parallel()
+
+	pr := &fakePR{}
+	f := NewFilter(FilterConfig{MinSuitability: 0.4}, pr, nil)
+	results := f.Apply(context.Background(), []DiscoveredIssue{candidate("owner/repo", 1, 0.39)})
+	if results[0].Reason != ReasonLowSuitability {
+		t.Fatalf("got reason=%q want %q", results[0].Reason, ReasonLowSuitability)
+	}
+	// Confirm we short-circuit before the network call.
+	if pr.calls != 0 {
+		t.Fatalf("PR checker called %d times — should short-circuit on cheap gate", pr.calls)
+	}
+}
+
+func TestFilter_RejectsLowStars(t *testing.T) {
+	t.Parallel()
+
+	c := candidate("owner/repo", 1, 0.9)
+	c.RepoContext.Stars = 50
+	f := NewFilter(FilterConfig{MinStars: 1000}, nil, nil)
+	results := f.Apply(context.Background(), []DiscoveredIssue{c})
+	if results[0].Reason != ReasonLowStars {
+		t.Fatalf("got reason=%q want %q", results[0].Reason, ReasonLowStars)
+	}
+}
+
+func TestFilter_StarsZeroDoesNotGate(t *testing.T) {
+	// Per the contract: Stars==0 means "unknown", fail-open.
+	t.Parallel()
+
+	c := candidate("owner/repo", 1, 0.9)
+	c.RepoContext.Stars = 0
+	f := NewFilter(FilterConfig{MinStars: 1000}, nil, nil)
+	results := f.Apply(context.Background(), []DiscoveredIssue{c})
+	if !results[0].Accepted() {
+		t.Fatalf("expected accept on unknown stars, got %q", results[0].Reason)
+	}
+}
+
+func TestFilter_RejectsExcludedRepo(t *testing.T) {
+	t.Parallel()
+
+	f := NewFilter(FilterConfig{ExcludeRepos: []string{"Owner/Repo"}}, nil, nil)
+	results := f.Apply(context.Background(), []DiscoveredIssue{candidate("owner/repo", 1, 0.9)})
+	if results[0].Reason != ReasonExcludedRepo {
+		t.Fatalf("got reason=%q want %q", results[0].Reason, ReasonExcludedRepo)
+	}
+}
+
+func TestFilter_LanguageMismatch(t *testing.T) {
+	t.Parallel()
+
+	c := candidate("owner/repo", 1, 0.9)
+	c.RepoContext.Language = "Cobol"
+	f := NewFilter(FilterConfig{Languages: []string{"go", "python"}}, nil, nil)
+	results := f.Apply(context.Background(), []DiscoveredIssue{c})
+	if results[0].Reason != ReasonLanguageMismatch {
+		t.Fatalf("got reason=%q want %q", results[0].Reason, ReasonLanguageMismatch)
+	}
+}
+
+func TestFilter_LanguageEmptyPasses(t *testing.T) {
+	// Unknown language must fail-open per the contract.
+	t.Parallel()
+
+	c := candidate("owner/repo", 1, 0.9)
+	c.RepoContext.Language = ""
+	f := NewFilter(FilterConfig{Languages: []string{"go"}}, nil, nil)
+	results := f.Apply(context.Background(), []DiscoveredIssue{c})
+	if !results[0].Accepted() {
+		t.Fatalf("expected accept on empty language, got %q", results[0].Reason)
+	}
+}
+
+func TestFilter_BlacklistRejects(t *testing.T) {
+	t.Parallel()
+
+	bl := &fakeBlacklist{black: true}
+	f := NewFilter(FilterConfig{}, &fakePR{}, bl)
+	results := f.Apply(context.Background(), []DiscoveredIssue{candidate("owner/repo", 1, 0.9)})
+	if results[0].Reason != ReasonBlacklisted {
+		t.Fatalf("got reason=%q want %q", results[0].Reason, ReasonBlacklisted)
+	}
+}
+
+func TestFilter_PRExistsRejects(t *testing.T) {
+	t.Parallel()
+
+	pr := &fakePR{hasPR: true}
+	f := NewFilter(FilterConfig{}, pr, nil)
+	results := f.Apply(context.Background(), []DiscoveredIssue{candidate("owner/repo", 1, 0.9)})
+	if results[0].Reason != ReasonExistingPR {
+		t.Fatalf("got reason=%q want %q", results[0].Reason, ReasonExistingPR)
+	}
+}
+
+func TestFilter_PRCheckErrorFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	pr := &fakePR{err: errors.New("api 502")}
+	f := NewFilter(FilterConfig{}, pr, nil)
+	results := f.Apply(context.Background(), []DiscoveredIssue{candidate("owner/repo", 1, 0.9)})
+	if results[0].Reason != ReasonPRCheckFailed {
+		t.Fatalf("got reason=%q want %q", results[0].Reason, ReasonPRCheckFailed)
+	}
+	if results[0].Detail == "" {
+		t.Fatalf("expected detail to surface the underlying error")
+	}
+}
+
+func TestFilter_RejectsInvalidCandidate(t *testing.T) {
+	t.Parallel()
+
+	f := NewFilter(FilterConfig{}, nil, nil)
+	results := f.Apply(context.Background(), []DiscoveredIssue{
+		{Repo: "", IssueNumber: 0, SuitabilityScore: 0.9},
+		{Repo: "owner/repo", IssueNumber: 0, SuitabilityScore: 0.9},
+	})
+	for i, r := range results {
+		if r.Reason != ReasonInvalid {
+			t.Fatalf("results[%d] reason=%q want %q", i, r.Reason, ReasonInvalid)
+		}
+	}
+}
+
+func TestFilter_NilCheckersAreNoops(t *testing.T) {
+	t.Parallel()
+
+	f := NewFilter(FilterConfig{}, nil, nil)
+	results := f.Apply(context.Background(), []DiscoveredIssue{candidate("owner/repo", 1, 0.5)})
+	if !results[0].Accepted() {
+		t.Fatalf("expected accept with nil checkers, got %q", results[0].Reason)
+	}
+}
+
+func TestFilter_GateOrderIsCheapBeforeExpensive(t *testing.T) {
+	// The cheap gates (suitability/stars/exclude/language) must run
+	// BEFORE the network call so a degraded run is still fast.
+	t.Parallel()
+
+	pr := &fakePR{}
+	bl := &fakeBlacklist{}
+	f := NewFilter(FilterConfig{
+		MinSuitability: 0.5,
+		MinStars:       10000,
+		ExcludeRepos:   []string{"banned/repo"},
+		Languages:      []string{"go"},
+	}, pr, bl)
+
+	cases := []DiscoveredIssue{
+		// low suitability -> short-circuit
+		func() DiscoveredIssue { c := candidate("owner/a", 1, 0.1); return c }(),
+		// low stars -> short-circuit
+		func() DiscoveredIssue { c := candidate("owner/b", 2, 0.9); c.RepoContext.Stars = 1; return c }(),
+		// excluded -> short-circuit
+		candidate("banned/repo", 3, 0.9),
+		// language mismatch -> short-circuit
+		func() DiscoveredIssue { c := candidate("owner/c", 4, 0.9); c.RepoContext.Language = "rust"; return c }(),
+	}
+	f.Apply(context.Background(), cases)
+	if pr.calls != 0 {
+		t.Fatalf("PR checker called %d times — every input should short-circuit on a cheap gate", pr.calls)
+	}
+}
+
+func TestSummarize(t *testing.T) {
+	t.Parallel()
+
+	results := []FilterResult{
+		{Reason: ReasonAccepted},
+		{Reason: ReasonAccepted},
+		{Reason: ReasonLowSuitability},
+		{Reason: ReasonExistingPR},
+		{Reason: ReasonExistingPR},
+	}
+	stats := Summarize(results)
+	if stats.Accepted != 2 {
+		t.Fatalf("Accepted=%d want 2", stats.Accepted)
+	}
+	if stats.Skipped != 3 {
+		t.Fatalf("Skipped=%d want 3", stats.Skipped)
+	}
+	if stats.Counts[ReasonExistingPR] != 2 {
+		t.Fatalf("ReasonExistingPR=%d want 2", stats.Counts[ReasonExistingPR])
+	}
+	if stats.Counts[ReasonLowSuitability] != 1 {
+		t.Fatalf("ReasonLowSuitability=%d want 1", stats.Counts[ReasonLowSuitability])
+	}
+	if _, present := stats.Counts[ReasonAccepted]; present {
+		t.Fatalf("ReasonAccepted must not appear in Counts")
+	}
+
+	// Order is deterministic.
+	keys := stats.SkipReasons()
+	if len(keys) != 2 {
+		t.Fatalf("len(keys)=%d want 2", len(keys))
+	}
+	if string(keys[0]) > string(keys[1]) {
+		t.Fatalf("SkipReasons must be sorted ascending; got %v", keys)
+	}
+}
+
+func TestSuitabilityToDifficulty_KnownPoints(t *testing.T) {
+	// This test pins the canonical convention defined by
+	// internal/github.estimateDifficulty: higher difficulty = harder.
+	// Two cmd/auto-contributor sites previously disagreed; this is the
+	// regression guard.
+	t.Parallel()
+
+	cases := []struct {
+		in, want float64
+	}{
+		{0.0, 1.0}, // unsuitable -> hardest
+		{1.0, 0.0}, // perfectly suitable -> easiest
+		{0.5, 0.5},
+		// Out-of-range inputs are clamped.
+		{-0.5, 1.0},
+		{1.5, 0.0},
+	}
+	for _, tc := range cases {
+		got := SuitabilityToDifficulty(tc.in)
+		if got != tc.want {
+			t.Errorf("SuitabilityToDifficulty(%v)=%v want %v", tc.in, got, tc.want)
+		}
+	}
+}

--- a/internal/discovery/filter_test.go
+++ b/internal/discovery/filter_test.go
@@ -20,9 +20,11 @@ func (f *fakePR) HasExistingPR(_ context.Context, _ string, _ int) (bool, error)
 type fakeBlacklist struct {
 	black bool
 	err   error
+	repos []string
 }
 
-func (f *fakeBlacklist) IsBlacklisted(_ string) (bool, error) {
+func (f *fakeBlacklist) IsBlacklisted(repo string) (bool, error) {
+	f.repos = append(f.repos, repo)
 	return f.black, f.err
 }
 
@@ -138,6 +140,23 @@ func TestFilter_BlacklistRejects(t *testing.T) {
 	results := f.Apply(context.Background(), []DiscoveredIssue{candidate("owner/repo", 1, 0.9)})
 	if results[0].Reason != ReasonBlacklisted {
 		t.Fatalf("got reason=%q want %q", results[0].Reason, ReasonBlacklisted)
+	}
+}
+
+func TestFilter_BlacklistLookupUsesTrimmedOriginalCasing(t *testing.T) {
+	t.Parallel()
+
+	bl := &fakeBlacklist{}
+	f := NewFilter(FilterConfig{}, &fakePR{}, bl)
+	results := f.Apply(context.Background(), []DiscoveredIssue{candidate(" Owner/Repo ", 1, 0.9)})
+	if !results[0].Accepted() {
+		t.Fatalf("expected accepted, got reason=%q detail=%q", results[0].Reason, results[0].Detail)
+	}
+	if len(bl.repos) != 1 {
+		t.Fatalf("blacklist lookups=%d want 1", len(bl.repos))
+	}
+	if bl.repos[0] != "Owner/Repo" {
+		t.Fatalf("blacklist lookup repo=%q want %q", bl.repos[0], "Owner/Repo")
 	}
 }
 

--- a/internal/discovery/filter_test.go
+++ b/internal/discovery/filter_test.go
@@ -141,6 +141,29 @@ func TestFilter_BlacklistRejects(t *testing.T) {
 	}
 }
 
+func TestFilter_BlacklistCheckErrorIsDistinct(t *testing.T) {
+	// A degraded blacklist DB must not be misreported as "intentionally
+	// banned" — operators tuning the blacklist need a separate signal.
+	t.Parallel()
+
+	bl := &fakeBlacklist{err: errors.New("db connection refused")}
+	pr := &fakePR{}
+	f := NewFilter(FilterConfig{}, pr, bl)
+	results := f.Apply(context.Background(), []DiscoveredIssue{candidate("owner/repo", 1, 0.9)})
+	if results[0].Reason != ReasonBlacklistCheckFailed {
+		t.Fatalf("got reason=%q want %q", results[0].Reason, ReasonBlacklistCheckFailed)
+	}
+	if results[0].Detail == "" {
+		t.Fatalf("expected the underlying DB error to surface in Detail")
+	}
+	// We must also fail closed: no PR check should run when the upstream
+	// blacklist gate is degraded, otherwise a banned repo could leak
+	// through if the blacklist DB started returning errors.
+	if pr.calls != 0 {
+		t.Fatalf("PR checker called %d times — must short-circuit on blacklist failure", pr.calls)
+	}
+}
+
 func TestFilter_PRExistsRejects(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Discovery filtering previously lived as inline logic duplicated across `cmd_loop.go` and `cmd_discover.go`, with hard-coded thresholds and silent counters that hid why issues were being dropped. The two sites had also drifted: `cmd_loop.go` stored `DifficultyScore = SuitabilityScore` while `cmd_discover.go` stored `DifficultyScore = 1 - SuitabilityScore`. Per the canonical heuristic in `internal/github/client.go.estimateDifficulty` (higher score = harder), the loop variant was inverted -- a perfect 0.95 candidate was being recorded as 0.95-difficulty (near-impossible) and hidden from downstream pipeline stages.

## What changed

- **New `internal/discovery/filter.go`** centralises the gate chain behind a `Filter` type with explicit `FilterConfig`, `PRChecker` / `BlacklistChecker` interfaces (the package is unit-testable without the live GitHub client or sqlite), and a `SkipReason` taxonomy that survives into log fields and the cmd-level UI.
- **Cheap gates first**: suitability, stars, exclude-list and language allowlist all run before the network/DB gates, so a degraded filter run never spends an API call on a candidate that is already going to be rejected. A regression test pins this ordering.
- **`SuitabilityToDifficulty` helper** fixes the `cmd_loop.go` inversion and replaces both inline conversions, so the two commands can no longer drift apart.
- **Observable skip reasons**: `Summarize` aggregates per-reason counters that are flushed as a single structured log line per cycle (`skip_low_suitability`, `skip_existing_pr`, ...), making threshold tuning data-driven instead of guesswork.
- **Issue-side language gate**: `RepoContext` gains an optional `Language` field so the `cfg.Languages` allowlist can actually be enforced. Previously the list was only forwarded to Claude as a hint and never re-checked on results.
- **14 table-driven tests** cover every reason branch, the cheap-gate-first ordering, the canonical mapping, and fail-open semantics for unknown stars/language.

## Why now

- Real bug: inverted `DifficultyScore` write at `cmd_loop.go:259` (pre-change) silently downgraded the strongest candidates.
- Real risk: the existing-PR / blacklist gates were called even on candidates that would fail the cheap suitability gate, wasting GitHub API budget.
- Real opacity: `skipped++` counters offered zero signal for why discovery cycles were returning fewer issues over time.

## Verification

Run locally on Go 1.25.7 / darwin-arm64:

- [x] `go vet ./...` -- clean
- [x] `go build ./...` -- clean
- [x] `go test ./...` -- all packages PASS, `internal/discovery` 0.425s

## Test plan

- [ ] `go test ./internal/discovery/... -v -run Filter`
- [ ] Manual: run `auto-contributor discover-smart --topic ai --depth quick` and confirm the new "Filter summary:" line at the bottom shows accepted/skipped counts with per-reason breakdown.
- [ ] Manual: run `auto-contributor loop` for one discovery cycle and confirm the closing log line includes `skip_*` keys.

## Out of scope

- No public API of the `discovery` package was changed apart from the additive `RepoContext.Language` field and the new `Filter` / `FilterResult` / `FilterStats` / `SkipReason` symbols.
- No threshold values were changed: `0.4` (loop) and `0.7` (smart-discover) are now named constants but their numeric values are unchanged.
- No database schema change.