### PR TITLE
fix(sec): consolidate SEC-07 rule path traversal guards (#46)

### DIFF
--- a/internal/pipeline/synthesizer.go
+++ b/internal/pipeline/synthesizer.go
@@ -223,10 +223,10 @@ func (p *Pipeline) applySynthesisResult(stage string, result *SynthesizerResult)
 		if nr.ID == "" || nr.Body == "" {
 			continue
 		}
-		// Reject IDs that contain path separators or dot-dot sequences; WriteRule
-		// uses the ID as a filename component and an unsafe value could escape the
-		// rules/{stage} directory via path traversal.
-		if strings.ContainsAny(nr.ID, "/\\") || strings.Contains(nr.ID, "..") {
+		// WriteRule uses the ID as a filename component and rejects unsafe values,
+		// but log the rejection here so synthesis batches surface attacker-controlled
+		// IDs in observability rather than silently failing inside WriteRule.
+		if !rules.IsSafeRuleID(nr.ID) {
 			log.WithFields(Fields{"rule": nr.ID}).Warn("skipping rule with unsafe ID")
 			continue
 		}

--- a/internal/rules/writer.go
+++ b/internal/rules/writer.go
@@ -28,17 +28,46 @@ var allowedStages = map[string]bool{
 	"global":    true,
 }
 
+// IsAllowedStage reports whether stage is a known rule stage directory.
+// Exported so callers outside this package (e.g. the synthesizer) can apply
+// the same allowlist before passing values to WriteRule/UpdateRule*/DeleteRule.
+func IsAllowedStage(stage string) bool { return allowedStages[stage] }
+
+// IsSafeRuleID reports whether id is safe to use as a rule filename component.
+// Exported so callers outside this package can pre-filter LLM-emitted IDs before
+// reaching the writer helpers.
+func IsSafeRuleID(id string) bool { return validateRuleID(id) == nil }
+
+// validateRuleID rejects rule IDs that could escape the rules/{stage} directory
+// via path traversal (SEC-07). Empty IDs, path separators, dot-dot segments,
+// and any value whose filepath.Base differs from itself are all rejected.
+func validateRuleID(id string) error {
+	if id == "" || strings.ContainsAny(id, "/\\") || strings.Contains(id, "..") || filepath.Base(id) != id {
+		return fmt.Errorf("unsafe rule ID %q", id)
+	}
+	return nil
+}
+
+// validateStage rejects stage values outside the known-good allowlist (SEC-07).
+// allowEmpty=true permits "" for callers that walk every stage directory and
+// only need to filter LLM-supplied values.
+func validateStage(stage string, allowEmpty bool) error {
+	if stage == "" && allowEmpty {
+		return nil
+	}
+	if !allowedStages[stage] {
+		return fmt.Errorf("unsafe rule stage %q", stage)
+	}
+	return nil
+}
+
 // WriteRule writes a Rule to a YAML file in rules/{stage}/ directory.
 func WriteRule(rulesDir string, rule *Rule) error {
-	// Defense-in-depth: reject IDs that could escape the rules/{stage} directory
-	// via path traversal (e.g. "../../../etc/passwd" or absolute paths).
-	if rule.ID == "" || strings.ContainsAny(rule.ID, "/\\") || strings.Contains(rule.ID, "..") || filepath.Base(rule.ID) != rule.ID {
-		return fmt.Errorf("unsafe rule ID %q", rule.ID)
+	if err := validateRuleID(rule.ID); err != nil {
+		return err
 	}
-	// Validate Stage against the known-good allowlist to prevent LLM-generated
-	// values like "../../../etc/cron.d" from escaping the rules directory (SEC-07).
-	if !allowedStages[rule.Stage] {
-		return fmt.Errorf("unsafe rule stage %q", rule.Stage)
+	if err := validateStage(rule.Stage, false); err != nil {
+		return err
 	}
 	writeMu.Lock()
 	defer writeMu.Unlock()
@@ -59,8 +88,11 @@ func WriteRule(rulesDir string, rule *Rule) error {
 
 // UpdateRuleConfidence updates only the confidence field of an existing rule file.
 func UpdateRuleConfidence(rulesDir string, ruleID string, stage string, newConfidence float64) error {
-	if stage != "" && !allowedStages[stage] {
-		return fmt.Errorf("unsafe rule stage %q", stage)
+	if err := validateRuleID(ruleID); err != nil {
+		return err
+	}
+	if err := validateStage(stage, true); err != nil {
+		return err
 	}
 	writeMu.Lock()
 	defer writeMu.Unlock()
@@ -91,8 +123,11 @@ func UpdateRuleConfidence(rulesDir string, ruleID string, stage string, newConfi
 
 // UpdateRuleLastValidatedAt updates the last_validated_at field of an existing rule file.
 func UpdateRuleLastValidatedAt(rulesDir string, ruleID string, stage string, validatedAt string) error {
-	if stage != "" && !allowedStages[stage] {
-		return fmt.Errorf("unsafe rule stage %q", stage)
+	if err := validateRuleID(ruleID); err != nil {
+		return err
+	}
+	if err := validateStage(stage, true); err != nil {
+		return err
 	}
 	writeMu.Lock()
 	defer writeMu.Unlock()
@@ -123,8 +158,11 @@ func UpdateRuleLastValidatedAt(rulesDir string, ruleID string, stage string, val
 
 // UpdateRuleQValue updates the q_value, retrieval_count, and success_count fields of an existing rule file.
 func UpdateRuleQValue(rulesDir string, ruleID string, stage string, qValue float64, retrievalCount int, successCount int) error {
-	if stage != "" && !allowedStages[stage] {
-		return fmt.Errorf("unsafe rule stage %q", stage)
+	if err := validateRuleID(ruleID); err != nil {
+		return err
+	}
+	if err := validateStage(stage, true); err != nil {
+		return err
 	}
 	writeMu.Lock()
 	defer writeMu.Unlock()
@@ -158,18 +196,14 @@ func UpdateRuleQValue(rulesDir string, ruleID string, stage string, qValue float
 // DeleteRule removes a rule file from disk.
 // Holds writeMu to prevent races with UpdateRuleQValue and Reload.
 func DeleteRule(rulesDir string, ruleID string, stage string) error {
-	// Validate stage against the allowlist to prevent path traversal (SEC-07).
-	// Without this guard, an invalid stage causes findRuleFile to return ""
-	// which this function would treat as "already gone", silently leaving
-	// attacker-controlled rule files on disk and active in later runs.
-	if stage != "" && !allowedStages[stage] {
-		return fmt.Errorf("unsafe rule stage %q", stage)
+	// An invalid stage would otherwise cause findRuleFile to return "" which
+	// this function treats as "already gone", silently leaving attacker-controlled
+	// rule files on disk and active in later runs.
+	if err := validateStage(stage, true); err != nil {
+		return err
 	}
-	// Validate ruleID to prevent path traversal (SEC-07).
-	// A poisoned rule with id: ../../../etc/cron.d/pwn and a valid stage would
-	// otherwise reach filepath.Join in findRuleFile and delete an external file.
-	if ruleID == "" || strings.ContainsAny(ruleID, "/\\") || strings.Contains(ruleID, "..") || filepath.Base(ruleID) != ruleID {
-		return fmt.Errorf("unsafe rule ID %q", ruleID)
+	if err := validateRuleID(ruleID); err != nil {
+		return err
 	}
 
 	writeMu.Lock()
@@ -187,8 +221,11 @@ func DeleteRule(rulesDir string, ruleID string, stage string) error {
 // (floored at minConf). The entire read-check-write runs under writeMu, which prevents
 // a concurrent stampRuleValidation write from racing with the applyDecay decision.
 func DecayRuleIfStale(rulesDir, ruleID, stage string, decayFactor, minConf float64, staleDays int) error {
-	if stage != "" && !allowedStages[stage] {
-		return fmt.Errorf("unsafe rule stage %q", stage)
+	if err := validateRuleID(ruleID); err != nil {
+		return err
+	}
+	if err := validateStage(stage, true); err != nil {
+		return err
 	}
 	writeMu.Lock()
 	defer writeMu.Unlock()
@@ -239,14 +276,13 @@ func DecayRuleIfStale(rulesDir, ruleID, stage string, decayFactor, minConf float
 // so that applyDecay cannot observe a stale last_validated_at between the two writes.
 // It is called when a candidate rule is merged into an existing rule during dedup.
 func IncrementEvidenceCount(rulesDir string, ruleID string, stage string) error {
-	if stage != "" && !allowedStages[stage] {
-		return fmt.Errorf("unsafe rule stage %q", stage)
-	}
-	// Reject IDs that could escape the rules directory via path traversal.
 	// ruleID originates from dedup.MatchedRuleID which is loaded from rule YAML
 	// and may be attacker-controlled; apply the same guard used in WriteRule.
-	if ruleID == "" || strings.ContainsAny(ruleID, "/\\") || strings.Contains(ruleID, "..") || filepath.Base(ruleID) != ruleID {
-		return fmt.Errorf("unsafe rule ID %q", ruleID)
+	if err := validateRuleID(ruleID); err != nil {
+		return err
+	}
+	if err := validateStage(stage, true); err != nil {
+		return err
 	}
 
 	writeMu.Lock()
@@ -281,16 +317,13 @@ func IncrementEvidenceCount(rulesDir string, ruleID string, stage string) error 
 // Symlinks are rejected: a poisoned symlink (e.g. rules/engineer/id.yaml -> /etc/cron.d/pwn)
 // would otherwise become an out-of-tree write primitive via the Update*/Decay helpers (SEC-07).
 func findRuleFile(rulesDir, ruleID, stage string) string {
-	// Validate stage against the allowlist to prevent path traversal (SEC-07).
-	// All callers pass stage values that originate from rule YAML (r.Stage), which
-	// may be attacker-controlled; reject any value not in the known-good set.
-	if stage != "" && !allowedStages[stage] {
+	// All callers pass stage and ruleID values that may originate from rule YAML
+	// (loaded verbatim from disk) or LLM output; both must be filtered through
+	// the same guards used by WriteRule before they are joined into a path.
+	if validateStage(stage, true) != nil {
 		return ""
 	}
-	// Validate ruleID to prevent path traversal via attacker-controlled rule IDs (SEC-07).
-	// RuleLoader.Load reads id: fields verbatim from disk; a poisoned rule with
-	// id: ../../../etc/cron.d/pwn would otherwise escape rulesDir via filepath.Join.
-	if ruleID == "" || strings.ContainsAny(ruleID, "/\\") || strings.Contains(ruleID, "..") || filepath.Base(ruleID) != ruleID {
+	if validateRuleID(ruleID) != nil {
 		return ""
 	}
 

--- a/internal/rules/writer_test.go
+++ b/internal/rules/writer_test.go
@@ -447,6 +447,66 @@ func TestUpdateFunctions_UnsafeRuleIDReturnsError(t *testing.T) {
 	}
 }
 
+// TestValidateRuleID_Helper verifies the shared validation helper used by
+// every writer entry point and re-exported as IsSafeRuleID for the synthesizer.
+func TestValidateRuleID_Helper(t *testing.T) {
+	bad := []string{
+		"",
+		"..",
+		"../etc",
+		"a/b",
+		"a\\b",
+		"./local",
+		"/abs",
+	}
+	for _, id := range bad {
+		if err := validateRuleID(id); err == nil {
+			t.Errorf("validateRuleID(%q) should error", id)
+		}
+		if IsSafeRuleID(id) {
+			t.Errorf("IsSafeRuleID(%q) should be false", id)
+		}
+	}
+
+	good := []string{"safe-id", "rule-001", "abc.def", "with_underscore"}
+	for _, id := range good {
+		if err := validateRuleID(id); err != nil {
+			t.Errorf("validateRuleID(%q) unexpected error: %v", id, err)
+		}
+		if !IsSafeRuleID(id) {
+			t.Errorf("IsSafeRuleID(%q) should be true", id)
+		}
+	}
+}
+
+// TestValidateStage_Helper verifies the shared stage allowlist helper. allowEmpty
+// distinguishes WriteRule (must reject "") from update/delete helpers and the
+// loader walk (which use "" to mean "search every stage").
+func TestValidateStage_Helper(t *testing.T) {
+	for _, stage := range []string{"scout", "analyst", "engineer", "reviewer", "submitter", "responder", "global"} {
+		if err := validateStage(stage, false); err != nil {
+			t.Errorf("validateStage(%q, false) unexpected error: %v", stage, err)
+		}
+		if !IsAllowedStage(stage) {
+			t.Errorf("IsAllowedStage(%q) should be true", stage)
+		}
+	}
+	if err := validateStage("", true); err != nil {
+		t.Errorf("validateStage(\"\", allowEmpty=true) unexpected error: %v", err)
+	}
+	if err := validateStage("", false); err == nil {
+		t.Error("validateStage(\"\", allowEmpty=false) should error")
+	}
+	for _, stage := range []string{"..", "../etc", "scout/../..", "unknown", "/abs"} {
+		if err := validateStage(stage, true); err == nil {
+			t.Errorf("validateStage(%q, true) should error", stage)
+		}
+		if IsAllowedStage(stage) {
+			t.Errorf("IsAllowedStage(%q) should be false", stage)
+		}
+	}
+}
+
 func containsStr(s, substr string) bool {
 	for i := 0; i <= len(s)-len(substr); i++ {
 		if s[i:i+len(substr)] == substr {


### PR DESCRIPTION
## Summary
- Closes #46. Multiple SEC-07 fixes already landed across the rule writer, but each entry point carried its own copy of the path-traversal guard. Drift between copies meant some Update* helpers only validated stage upfront and relied on findRuleFile to fail closed on bad IDs, producing a generic "rule file not found" instead of an explicit unsafe-ID rejection.
- Extract `validateRuleID` / `validateStage` helpers in `internal/rules/writer.go` and apply them at the top of every public writer function (`WriteRule`, `UpdateRuleConfidence`, `UpdateRuleLastValidatedAt`, `UpdateRuleQValue`, `DeleteRule`, `DecayRuleIfStale`, `IncrementEvidenceCount`, plus internal `findRuleFile`).
- Re-export `IsAllowedStage` and `IsSafeRuleID` so the pipeline synthesizer uses the same allowlist instead of an inline regex check.
- No behaviour change for safe inputs; bad stage or ruleID inputs now produce a consistent unsafe-input error from every entry point.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [x] New unit tests `TestValidateRuleID_Helper` and `TestValidateStage_Helper` cover the shared helpers and the re-exported `IsSafeRuleID` / `IsAllowedStage` predicates.
- [x] Existing SEC-07 regression tests (`TestWriteRule_UnsafeStage`, `TestFindRuleFile_UnsafeStage`, `TestUpdateFunctions_UnsafeStageReturnsError`, `TestUpdateFunctions_UnsafeRuleIDReturnsError`, symlink rejection tests) still pass.

Refs: internal/rules/writer.go, internal/pipeline/synthesizer.go (issue #46 references).