### PR TITLE
fix: close responder PRs remotely

### DIFF
--- a/internal/pipeline/feedback.go
+++ b/internal/pipeline/feedback.go
@@ -396,23 +396,8 @@ func (p *Pipeline) handleOpen(ctx context.Context, pr *models.PullRequest, prRep
 		p.recordEvent(issue, nil, "responder", pr.FeedbackRound+1, start, result.Action, result.Action != "close", truncate(raw, 500), "", responderRules)
 	}
 
-	// Post replies and collect replied comment IDs
-	repliedIDs := make(map[int64]bool)
-	for _, reply := range result.Replies {
-		if err := p.gh.ReplyToPRComment(ctx, prRepo, pr.PRNumber, reply.CommentID, reply.Body); err != nil {
-			log.WithError(err).Warn("failed to post reply")
-			continue
-		}
-		repliedIDs[reply.CommentID] = true
-	}
-
-	// Resolve review threads for addressed comments
-	if result.Action == "addressed" && len(repliedIDs) > 0 {
-		p.resolveAddressedThreads(ctx, prRepo, pr.PRNumber, repliedIDs)
-	}
-
 	newRound := pr.FeedbackRound + 1
-	if err := p.finalizeResponderAction(ctx, pr, prRepo, result, newRound); err != nil {
+	if err := p.executeResponderAction(ctx, pr, prRepo, result, newRound); err != nil {
 		return err
 	}
 
@@ -426,17 +411,42 @@ func (p *Pipeline) handleOpen(ctx context.Context, pr *models.PullRequest, prRep
 	return nil
 }
 
-func (p *Pipeline) finalizeResponderAction(ctx context.Context, pr *models.PullRequest, prRepo string, result FeedbackResult, newRound int) error {
+func (p *Pipeline) executeResponderAction(ctx context.Context, pr *models.PullRequest, prRepo string, result FeedbackResult, newRound int) error {
 	if result.Action == "close" {
 		if err := p.closePRFromResponder(ctx, pr, prRepo); err != nil {
 			return err
 		}
 	}
 
+	repliedIDs := p.postResponderReplies(ctx, pr, prRepo, result.Replies)
+
+	if result.Action == "addressed" && len(repliedIDs) > 0 {
+		p.resolveAddressedThreads(ctx, prRepo, pr.PRNumber, repliedIDs)
+	}
+
 	if err := p.db.UpdatePRFeedbackCheck(pr.ID, newRound); err != nil {
 		return fmt.Errorf("update PR feedback check: %w", err)
 	}
 	return nil
+}
+
+func (p *Pipeline) finalizeResponderAction(ctx context.Context, pr *models.PullRequest, prRepo string, result FeedbackResult, newRound int) error {
+	if err := p.executeResponderAction(ctx, pr, prRepo, result, newRound); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (p *Pipeline) postResponderReplies(ctx context.Context, pr *models.PullRequest, prRepo string, replies []FeedbackReply) map[int64]bool {
+	repliedIDs := make(map[int64]bool)
+	for _, reply := range replies {
+		if err := p.gh.ReplyToPRComment(ctx, prRepo, pr.PRNumber, reply.CommentID, reply.Body); err != nil {
+			log.WithError(err).Warn("failed to post reply")
+			continue
+		}
+		repliedIDs[reply.CommentID] = true
+	}
+	return repliedIDs
 }
 
 func (p *Pipeline) closePRFromResponder(ctx context.Context, pr *models.PullRequest, prRepo string) error {

--- a/internal/pipeline/feedback.go
+++ b/internal/pipeline/feedback.go
@@ -411,12 +411,9 @@ func (p *Pipeline) handleOpen(ctx context.Context, pr *models.PullRequest, prRep
 		p.resolveAddressedThreads(ctx, prRepo, pr.PRNumber, repliedIDs)
 	}
 
-	// Update DB
 	newRound := pr.FeedbackRound + 1
-	p.db.UpdatePRFeedbackCheck(pr.ID, newRound)
-
-	if result.Action == "close" {
-		p.db.UpdatePRStatus(pr.ID, models.PRStatusClosed)
+	if err := p.finalizeResponderAction(ctx, pr, prRepo, result, newRound); err != nil {
+		return err
 	}
 
 	log.WithFields(Fields{
@@ -426,6 +423,30 @@ func (p *Pipeline) handleOpen(ctx context.Context, pr *models.PullRequest, prRep
 		"round":   newRound,
 	}).Info("feedback processed")
 
+	return nil
+}
+
+func (p *Pipeline) finalizeResponderAction(ctx context.Context, pr *models.PullRequest, prRepo string, result FeedbackResult, newRound int) error {
+	if result.Action == "close" {
+		if err := p.closePRFromResponder(ctx, pr, prRepo); err != nil {
+			return err
+		}
+	}
+
+	if err := p.db.UpdatePRFeedbackCheck(pr.ID, newRound); err != nil {
+		return fmt.Errorf("update PR feedback check: %w", err)
+	}
+	return nil
+}
+
+func (p *Pipeline) closePRFromResponder(ctx context.Context, pr *models.PullRequest, prRepo string) error {
+	comment := "Closing because maintainer feedback explicitly asked to close or abandon this PR."
+	if err := p.gh.ClosePR(ctx, prRepo, pr.PRNumber, comment); err != nil {
+		return fmt.Errorf("close PR remotely: %w", err)
+	}
+	if err := p.db.UpdatePRStatus(pr.ID, models.PRStatusClosed); err != nil {
+		return fmt.Errorf("update PR status to closed after remote close: %w", err)
+	}
 	return nil
 }
 

--- a/internal/pipeline/feedback_test.go
+++ b/internal/pipeline/feedback_test.go
@@ -156,6 +156,55 @@ func TestFinalizeResponderActionCloseFailureLeavesPRRetryable(t *testing.T) {
 	}
 }
 
+func TestExecuteResponderActionCloseFailureSkipsReplies(t *testing.T) {
+	logPath := installFakeGH(t, true)
+	database := newFeedbackTestDB(t)
+	_, pr := createFeedbackTestPR(t, database)
+	p := &Pipeline{
+		db: database,
+		gh: ghclient.New(&config.Config{}),
+	}
+
+	err := p.executeResponderAction(
+		context.Background(),
+		pr,
+		"owner/repo",
+		FeedbackResult{
+			Action: "close",
+			Replies: []FeedbackReply{
+				{CommentID: 123, Body: "Acknowledged; closing as requested."},
+			},
+		},
+		pr.FeedbackRound+1,
+	)
+	if err == nil {
+		t.Fatal("executeResponderAction error = nil, want remote close failure")
+	}
+
+	status, round, checked := getFeedbackPRState(t, database, pr.ID)
+	if status != string(models.PRStatusOpen) {
+		t.Fatalf("status = %q, want %q after remote close failure", status, models.PRStatusOpen)
+	}
+	if round != 0 {
+		t.Fatalf("feedback_round = %d, want 0 after remote close failure", round)
+	}
+	if checked.Valid {
+		t.Fatalf("last_feedback_check_at = %q, want NULL after remote close failure", checked.String)
+	}
+
+	logData, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read fake gh log: %v", err)
+	}
+	logText := string(logData)
+	if !strings.Contains(logText, "pr close 42 -R owner/repo") {
+		t.Fatalf("fake gh log = %q, want remote close attempt", logText)
+	}
+	if strings.Contains(logText, "comments/123/replies") {
+		t.Fatalf("fake gh log = %q, reply was posted before remote close succeeded", logText)
+	}
+}
+
 func TestPRResponseHours_BothTimestamps(t *testing.T) {
 	created := "2024-01-01T00:00:00Z"
 	terminal := "2024-01-01T02:00:00Z"

--- a/internal/pipeline/feedback_test.go
+++ b/internal/pipeline/feedback_test.go
@@ -1,10 +1,18 @@
 package pipeline
 
 import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/majiayu000/auto-contributor/internal/config"
+	"github.com/majiayu000/auto-contributor/internal/db"
 	ghclient "github.com/majiayu000/auto-contributor/internal/github"
+	"github.com/majiayu000/auto-contributor/pkg/models"
 )
 
 // TestShouldPromoteDraft verifies the promotion decision for every CI status,
@@ -75,6 +83,79 @@ func TestRepoFromPRURL(t *testing.T) {
 	}
 }
 
+func TestFinalizeResponderActionCloseClosesRemoteBeforeLocalStatus(t *testing.T) {
+	logPath := installFakeGH(t, false)
+	database := newFeedbackTestDB(t)
+	_, pr := createFeedbackTestPR(t, database)
+	p := &Pipeline{
+		db: database,
+		gh: ghclient.New(&config.Config{}),
+	}
+
+	err := p.finalizeResponderAction(
+		context.Background(),
+		pr,
+		"owner/repo",
+		FeedbackResult{Action: "close"},
+		pr.FeedbackRound+1,
+	)
+	if err != nil {
+		t.Fatalf("finalizeResponderAction: %v", err)
+	}
+
+	status, round, checked := getFeedbackPRState(t, database, pr.ID)
+	if status != string(models.PRStatusClosed) {
+		t.Fatalf("status = %q, want %q", status, models.PRStatusClosed)
+	}
+	if round != 1 {
+		t.Fatalf("feedback_round = %d, want 1", round)
+	}
+	if !checked.Valid {
+		t.Fatal("last_feedback_check_at is NULL, want timestamp after remote close")
+	}
+
+	logData, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read fake gh log: %v", err)
+	}
+	logText := string(logData)
+	if !strings.Contains(logText, "pr close 42 -R owner/repo -c Closing because maintainer feedback explicitly asked to close or abandon this PR.") {
+		t.Fatalf("fake gh log = %q, want remote close command with close comment", logText)
+	}
+}
+
+func TestFinalizeResponderActionCloseFailureLeavesPRRetryable(t *testing.T) {
+	installFakeGH(t, true)
+	database := newFeedbackTestDB(t)
+	_, pr := createFeedbackTestPR(t, database)
+	p := &Pipeline{
+		db: database,
+		gh: ghclient.New(&config.Config{}),
+	}
+
+	err := p.finalizeResponderAction(
+		context.Background(),
+		pr,
+		"owner/repo",
+		FeedbackResult{Action: "close"},
+		pr.FeedbackRound+1,
+	)
+	if err == nil {
+		t.Fatal("finalizeResponderAction error = nil, want remote close failure")
+	}
+
+	status, round, checked := getFeedbackPRState(t, database, pr.ID)
+	if status != string(models.PRStatusOpen) {
+		t.Fatalf("status = %q, want %q after remote close failure", status, models.PRStatusOpen)
+	}
+	if round != 0 {
+		t.Fatalf("feedback_round = %d, want 0 after remote close failure", round)
+	}
+	if checked.Valid {
+		t.Fatalf("last_feedback_check_at = %q, want NULL after remote close failure", checked.String)
+	}
+}
+
 func TestPRResponseHours_BothTimestamps(t *testing.T) {
 	created := "2024-01-01T00:00:00Z"
 	terminal := "2024-01-01T02:00:00Z"
@@ -90,4 +171,92 @@ func TestPRResponseHours_Fallback(t *testing.T) {
 	if h < 2.9 || h > 3.1 {
 		t.Errorf("prResponseHours fallback = %v, want ~3.0", h)
 	}
+}
+
+func installFakeGH(t *testing.T, failClose bool) string {
+	t.Helper()
+
+	tempDir := t.TempDir()
+	logPath := filepath.Join(tempDir, "gh.log")
+	scriptPath := filepath.Join(tempDir, "gh")
+	script := `#!/bin/sh
+printf '%s\n' "$*" >> "$GH_TEST_LOG"
+if [ "$GH_TEST_FAIL_CLOSE" = "1" ]; then
+  printf 'close failed\n' >&2
+  exit 1
+fi
+exit 0
+`
+	if err := os.WriteFile(scriptPath, []byte(script), 0755); err != nil {
+		t.Fatalf("write fake gh script: %v", err)
+	}
+
+	t.Setenv("GH_TEST_LOG", logPath)
+	if failClose {
+		t.Setenv("GH_TEST_FAIL_CLOSE", "1")
+	} else {
+		t.Setenv("GH_TEST_FAIL_CLOSE", "0")
+	}
+	t.Setenv("PATH", tempDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return logPath
+}
+
+func newFeedbackTestDB(t *testing.T) *db.DB {
+	t.Helper()
+
+	database, err := db.New(filepath.Join(t.TempDir(), "feedback.db"))
+	if err != nil {
+		t.Fatalf("create test db: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = database.Close()
+	})
+	return database
+}
+
+func createFeedbackTestPR(t *testing.T, database *db.DB) (*models.Issue, *models.PullRequest) {
+	t.Helper()
+
+	issue := &models.Issue{
+		Repo:            "owner/repo",
+		IssueNumber:     70,
+		Title:           "Close action regression",
+		Body:            "close action should close remote PR first",
+		Labels:          "review",
+		Language:        "Go",
+		DifficultyScore: 0.5,
+		Status:          models.IssueStatusCompleted,
+	}
+	if err := database.CreateIssue(issue); err != nil {
+		t.Fatalf("create issue: %v", err)
+	}
+
+	pr := &models.PullRequest{
+		IssueID:    issue.ID,
+		PRURL:      "https://github.com/owner/repo/pull/42",
+		PRNumber:   42,
+		BranchName: "fix/close-action",
+		Status:     models.PRStatusOpen,
+		CIStatus:   "success",
+	}
+	if err := database.CreatePullRequest(pr); err != nil {
+		t.Fatalf("create pull request: %v", err)
+	}
+	return issue, pr
+}
+
+func getFeedbackPRState(t *testing.T, database *db.DB, prID int64) (string, int, sql.NullString) {
+	t.Helper()
+
+	var status string
+	var round int
+	var checked sql.NullString
+	err := database.QueryRow(
+		"SELECT status, feedback_round, last_feedback_check_at FROM pull_requests WHERE id = ?",
+		prID,
+	).Scan(&status, &round, &checked)
+	if err != nil {
+		t.Fatalf("query PR state: %v", err)
+	}
+	return status, round, checked
 }


### PR DESCRIPTION
## Summary
- close responder-requested PRs through GitHub before changing local status
- leave local PR state and feedback check untouched when remote closure fails so feedback can retry
- add regression coverage for successful and failed remote close paths

Fixes #70

## Validation
- go test ./internal/pipeline -run TestFinalizeResponderActionClose -count=1
- go test ./internal/pipeline -count=1
- go build ./...
- go test ./...