### PR TITLE
Fix JSON fallback isolation for side-effect agents

### DIFF
--- a/internal/pipeline/agent.go
+++ b/internal/pipeline/agent.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -48,8 +49,8 @@ func (r *AgentRunner) RunJSON(ctx context.Context, agentName string, workDir str
 }
 
 // RunJSONWithPolicy is like RunWithPolicy but also extracts a JSON object from the output.
-// If extraction fails, it does a lightweight retry using the same execution policy so
-// untrusted prompts never fall back to a more privileged runtime.
+// If extraction fails, it does a lightweight recovery in an isolated temp workspace
+// with untrusted execution so the original agent prompt is not re-run.
 func (r *AgentRunner) RunJSONWithPolicy(ctx context.Context, agentName string, workDir string, tmplCtx map[string]any, dest any, policy runtime.ExecutionPolicy) (string, error) {
 	rendered, err := r.prompts.Render(agentName, tmplCtx)
 	if err != nil {
@@ -72,12 +73,24 @@ func (r *AgentRunner) RunJSONWithPolicy(ctx context.Context, agentName string, w
 		"output_tail": truncate(raw[max(0, len(raw)-500):], 500),
 	}).Warn("JSON extraction failed, attempting lightweight recovery")
 
-	// Lightweight retry: ask Claude to extract JSON from the existing output
-	// instead of re-running the entire agent (which costs 3-7 min)
 	tail := raw
 	if len(tail) > 3000 {
 		tail = tail[len(tail)-3000:]
 	}
+
+	recoveryWorkDir, err := os.MkdirTemp("", "auto-contributor-json-recovery-*")
+	if err != nil {
+		return raw, fmt.Errorf("parse %s JSON output: prepare recovery workspace: %w", agentName, err)
+	}
+	defer func() {
+		if err := os.RemoveAll(recoveryWorkDir); err != nil {
+			log.WithError(err).WithField("workdir", recoveryWorkDir).Warn("failed to remove JSON recovery workspace")
+		}
+	}()
+
+	// Lightweight recovery asks the runtime to extract JSON from existing text
+	// in an empty temp directory with untrusted execution, so parse failures do
+	// not re-run side-effect agent prompts in the repository workspace.
 	recoveryPrompt := fmt.Sprintf(`The following is output from an agent that was supposed to return JSON but the JSON is missing or malformed.
 Extract or reconstruct the JSON result based on the analysis below. Output ONLY a valid JSON object, nothing else.
 
@@ -87,7 +100,7 @@ Extract or reconstruct the JSON result based on the analysis below. Output ONLY 
 
 Output the JSON now:`, tail)
 
-	recoveryRaw, err := r.runWithPrompt(ctx, agentName, workDir, recoveryPrompt, policy)
+	recoveryRaw, err := r.runWithPrompt(ctx, "json-recovery", recoveryWorkDir, recoveryPrompt, runtime.ExecutionPolicyUntrusted)
 	if err != nil {
 		return raw, fmt.Errorf("parse %s JSON output: recovery failed: %w", agentName, err)
 	}

--- a/internal/pipeline/agent_test.go
+++ b/internal/pipeline/agent_test.go
@@ -24,6 +24,7 @@ type stubRuntime struct {
 	index    int
 	policies []runtime.ExecutionPolicy
 	prompts  []string
+	workDirs []string
 }
 
 type stubOutput struct {
@@ -41,6 +42,7 @@ func (r *stubRuntime) Execute(ctx context.Context, workDir string, prompt string
 	}
 	r.policies = append(r.policies, policy)
 	r.prompts = append(r.prompts, prompt)
+	r.workDirs = append(r.workDirs, workDir)
 	result := r.outputs[r.index]
 	r.index++
 	return result.output, result.err

--- a/internal/pipeline/prompt_security_test.go
+++ b/internal/pipeline/prompt_security_test.go
@@ -91,7 +91,7 @@ func TestBuildResponderCtx_IsolatesGitHubFeedbackPayloads(t *testing.T) {
 	}
 }
 
-func TestRunJSONWithPolicy_RecoveryKeepsRequestedPolicy(t *testing.T) {
+func TestRunJSONWithPolicy_RecoveryDoesNotEscalateUntrustedPolicy(t *testing.T) {
 	promptsDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(promptsDir, "scout.md"), []byte(`{{.Input}}`), 0644); err != nil {
 		t.Fatalf("write prompt: %v", err)
@@ -120,6 +120,53 @@ func TestRunJSONWithPolicy_RecoveryKeepsRequestedPolicy(t *testing.T) {
 		if policy != runtime.ExecutionPolicyUntrusted {
 			t.Fatalf("call %d policy = %q, want %q", i, policy, runtime.ExecutionPolicyUntrusted)
 		}
+	}
+}
+
+func TestRunJSONWithPolicy_RecoveryIsIsolatedFromSideEffectAgentWorkspace(t *testing.T) {
+	promptsDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(promptsDir, "submitter.md"), []byte(`submit {{.Input}}`), 0644); err != nil {
+		t.Fatalf("write prompt: %v", err)
+	}
+
+	ps := prompt.NewStore(promptsDir)
+	if err := ps.Load(); err != nil {
+		t.Fatalf("load prompts: %v", err)
+	}
+
+	rt := &stubRuntime{outputs: []stubOutput{
+		{output: "side effect already happened, but no json"},
+		{output: `{"pr_url":"https://github.com/owner/repo/pull/1"}`},
+	}}
+	runner := NewAgentRunner(ps, rt, 0)
+
+	workDir := t.TempDir()
+	var dest map[string]any
+	if _, err := runner.RunJSONWithPolicy(context.Background(), "submitter", workDir, map[string]any{"Input": "owner/repo"}, &dest, runtime.ExecutionPolicyTrusted); err != nil {
+		t.Fatalf("RunJSONWithPolicy: %v", err)
+	}
+
+	if len(rt.prompts) != 2 {
+		t.Fatalf("runtime call count = %d, want 2", len(rt.prompts))
+	}
+	if rt.prompts[0] != "submit owner/repo" {
+		t.Fatalf("first prompt = %q, want rendered submitter prompt", rt.prompts[0])
+	}
+	if rt.prompts[1] == rt.prompts[0] {
+		t.Fatal("recovery reran the original submitter prompt")
+	}
+	if !strings.Contains(rt.prompts[1], "side effect already happened") {
+		t.Fatalf("recovery prompt should preserve original raw output, got: %s", rt.prompts[1])
+	}
+
+	if got := rt.policies; len(got) != 2 || got[0] != runtime.ExecutionPolicyTrusted || got[1] != runtime.ExecutionPolicyUntrusted {
+		t.Fatalf("policies = %v, want [trusted untrusted]", got)
+	}
+	if got := rt.workDirs; len(got) != 2 || got[0] != workDir || got[1] == workDir {
+		t.Fatalf("workDirs = %v, want original workspace then isolated recovery workspace", got)
+	}
+	if _, err := os.Stat(rt.workDirs[1]); !os.IsNotExist(err) {
+		t.Fatalf("recovery workspace should be removed after parsing, stat err=%v", err)
 	}
 }
 


### PR DESCRIPTION
Closes #69.

## Summary
- run JSON recovery in an isolated temp workspace instead of the original repository workspace
- force recovery to use untrusted execution and a dedicated recovery agent label
- add regression coverage proving submitter recovery does not rerun the original prompt in the repo workspace

## Validation
- go test ./internal/pipeline
- go build ./...
- go test ./...