### PR TITLE
Fix synced PR branch persistence

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -899,15 +899,18 @@ func (db *DB) UpdatePRReviewStats(prID int64, commentCount int, firstReviewAt *t
 // EnsurePRWithIssue creates Issue + PR records if they don't already exist in the DB.
 // Used by feedback-loop to sync GitHub-discovered PRs into the local database.
 func (db *DB) EnsurePRWithIssue(repo string, prNumber int, prURL, branchName, title, body string) (*models.PullRequest, error) {
+	branchName = strings.TrimSpace(branchName)
+	if branchName == "" {
+		return nil, fmt.Errorf("branch name is required for synced PR %s#%d", repo, prNumber)
+	}
+
 	// Check if PR already exists by URL
 	var prID int64
 	query := fmt.Sprintf(`SELECT id FROM pull_requests WHERE pr_url = %s`, db.placeholder(1))
 	err := db.QueryRow(query, prURL).Scan(&prID)
 	if err == nil {
-		if branchName != "" {
-			if err := db.UpdatePRBranchName(prID, branchName); err != nil {
-				return nil, fmt.Errorf("update PR branch name: %w", err)
-			}
+		if err := db.UpdatePRBranchName(prID, branchName); err != nil {
+			return nil, fmt.Errorf("update PR branch name: %w", err)
 		}
 		return db.getPRByID(prID)
 	}

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -249,15 +249,15 @@ func TestEnsurePRWithIssueUpdatesExistingBranchName(t *testing.T) {
 		"owner/repo",
 		42,
 		"https://github.com/owner/repo/pull/42",
-		"",
+		"fix/old-branch",
 		"fix bug",
 		"body",
 	)
 	if err != nil {
 		t.Fatalf("EnsurePRWithIssue initial: %v", err)
 	}
-	if pr.BranchName != "" {
-		t.Fatalf("initial branch = %q, want empty", pr.BranchName)
+	if pr.BranchName != "fix/old-branch" {
+		t.Fatalf("initial branch = %q, want %q", pr.BranchName, "fix/old-branch")
 	}
 
 	updated, err := db.EnsurePRWithIssue(
@@ -276,6 +276,25 @@ func TestEnsurePRWithIssueUpdatesExistingBranchName(t *testing.T) {
 	}
 	if updated.BranchName != "fix/bug-42" {
 		t.Fatalf("updated branch = %q, want %q", updated.BranchName, "fix/bug-42")
+	}
+}
+
+func TestEnsurePRWithIssueRequiresBranchName(t *testing.T) {
+	db := newSQLiteTestDB(t)
+
+	_, err := db.EnsurePRWithIssue(
+		"owner/repo",
+		42,
+		"https://github.com/owner/repo/pull/42",
+		" ",
+		"fix bug",
+		"body",
+	)
+	if err == nil {
+		t.Fatal("EnsurePRWithIssue error = nil, want branch name required error")
+	}
+	if !strings.Contains(err.Error(), "branch name is required") {
+		t.Fatalf("EnsurePRWithIssue error = %q, want branch name required", err)
 	}
 }
 

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -225,6 +225,94 @@ func TestParseUserOpenPRsPreservesHeadRefName(t *testing.T) {
 	}
 }
 
+func TestListUserOpenPRsFetchesHeadRefName(t *testing.T) {
+	tempDir := t.TempDir()
+	logPath := filepath.Join(tempDir, "gh.log")
+	scriptPath := filepath.Join(tempDir, "gh")
+	script := `#!/bin/sh
+printf '%s\n' "$*" >> "$GH_TEST_LOG"
+case "$*" in
+  "search prs --author majiayu000 --state open --limit 50 --json repository,number,title,body,url")
+    printf '%s' '[{"repository":{"nameWithOwner":"owner/repo"},"number":42,"title":"fix bug","body":"body","url":"https://github.com/owner/repo/pull/42"}]'
+    exit 0
+    ;;
+  "pr view 42 -R owner/repo --json headRefName")
+    printf '%s' '{"headRefName":"fix/bug-42"}'
+    exit 0
+    ;;
+  *)
+    printf 'unexpected args: %s\n' "$*" >&2
+    exit 1
+    ;;
+esac
+`
+	if err := os.WriteFile(scriptPath, []byte(script), 0755); err != nil {
+		t.Fatalf("write fake gh script: %v", err)
+	}
+
+	t.Setenv("GH_TEST_LOG", logPath)
+	t.Setenv("PATH", tempDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	client := New(&config.Config{GitHubUsername: "majiayu000"})
+	prs, err := client.ListUserOpenPRs(context.Background())
+	if err != nil {
+		t.Fatalf("ListUserOpenPRs: %v", err)
+	}
+	if len(prs) != 1 {
+		t.Fatalf("got %d PRs, want 1", len(prs))
+	}
+	if prs[0].BranchName != "fix/bug-42" {
+		t.Fatalf("BranchName = %q, want %q", prs[0].BranchName, "fix/bug-42")
+	}
+
+	logData, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read fake gh log: %v", err)
+	}
+	logText := string(logData)
+	if !strings.Contains(logText, "search prs --author majiayu000") {
+		t.Fatalf("expected gh search call, log=%q", logText)
+	}
+	if !strings.Contains(logText, "pr view 42 -R owner/repo --json headRefName") {
+		t.Fatalf("expected gh pr view headRefName call, log=%q", logText)
+	}
+}
+
+func TestListUserOpenPRsRejectsEmptyHeadRefName(t *testing.T) {
+	tempDir := t.TempDir()
+	scriptPath := filepath.Join(tempDir, "gh")
+	script := `#!/bin/sh
+case "$*" in
+  "search prs --author majiayu000 --state open --limit 50 --json repository,number,title,body,url")
+    printf '%s' '[{"repository":{"nameWithOwner":"owner/repo"},"number":42,"title":"fix bug","body":"body","url":"https://github.com/owner/repo/pull/42"}]'
+    exit 0
+    ;;
+  "pr view 42 -R owner/repo --json headRefName")
+    printf '%s' '{"headRefName":""}'
+    exit 0
+    ;;
+  *)
+    printf 'unexpected args: %s\n' "$*" >&2
+    exit 1
+    ;;
+esac
+`
+	if err := os.WriteFile(scriptPath, []byte(script), 0755); err != nil {
+		t.Fatalf("write fake gh script: %v", err)
+	}
+
+	t.Setenv("PATH", tempDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	client := New(&config.Config{GitHubUsername: "majiayu000"})
+	_, err := client.ListUserOpenPRs(context.Background())
+	if err == nil {
+		t.Fatal("ListUserOpenPRs error = nil, want empty headRefName error")
+	}
+	if !strings.Contains(err.Error(), "empty headRefName") {
+		t.Fatalf("ListUserOpenPRs error = %q, want empty headRefName", err)
+	}
+}
+
 func TestGetPRInfoFallsBackWhenLockReasonUnsupported(t *testing.T) {
 	tempDir := t.TempDir()
 	logPath := filepath.Join(tempDir, "gh.log")

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -476,12 +476,18 @@ func (c *Client) ListUserOpenPRs(ctx context.Context) ([]GitHubPR, error) {
 		return nil, err
 	}
 	for i := range prs {
-		headRef, err := c.GetPRHeadRefName(ctx, prs[i].Repo, prs[i].Number)
-		if err != nil {
-			log.Warn("failed to fetch PR head branch", "repo", prs[i].Repo, "pr", prs[i].Number, "error", err)
-			continue
+		if strings.TrimSpace(prs[i].BranchName) == "" {
+			headRef, err := c.GetPRHeadRefName(ctx, prs[i].Repo, prs[i].Number)
+			if err != nil {
+				return nil, fmt.Errorf("fetch PR head branch for %s#%d: %w", prs[i].Repo, prs[i].Number, err)
+			}
+			prs[i].BranchName = headRef
+		} else {
+			prs[i].BranchName = strings.TrimSpace(prs[i].BranchName)
 		}
-		prs[i].BranchName = headRef
+		if prs[i].BranchName == "" {
+			return nil, fmt.Errorf("fetch PR head branch for %s#%d: empty headRefName", prs[i].Repo, prs[i].Number)
+		}
 	}
 	return prs, nil
 }


### PR DESCRIPTION
Fixes #72.

## Summary
- fail `ListUserOpenPRs` when a synced PR head branch cannot be resolved
- require `EnsurePRWithIssue` callers to provide a non-empty branch before persistence
- add GitHub client and DB regression tests for branch propagation

## Validation
- go build ./...
- go test -count=1 ./...