### PR TITLE
Fix #73: fail closed on supplemental migrations

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -115,7 +115,9 @@ func (db *DB) Migrate() error {
 
 	// Column-level migrations intentionally ignore errors (column may already exist).
 	db.runMigrations()
-	db.MigrateLessons()
+	if err := db.MigrateLessons(); err != nil {
+		return fmt.Errorf("migrate lessons: %w", err)
+	}
 	if err := db.MigrateEvents(); err != nil {
 		return fmt.Errorf("migrate events: %w", err)
 	}

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -160,6 +160,56 @@ func TestMigrateRuleEmbeddingsPostgresCreatesVectorSchema(t *testing.T) {
 	}
 }
 
+func TestMigratePropagatesLessonsDDLFailure(t *testing.T) {
+	stub := &migrationExecStub{
+		failOn:  "CREATE TABLE IF NOT EXISTS review_lessons",
+		failErr: fmt.Errorf("permission denied"),
+	}
+	registerMigrationExecStub(t, stub)
+
+	sqlDB, err := sql.Open(migrationExecStubDriverName, "")
+	if err != nil {
+		t.Fatalf("open migration exec stub db: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = sqlDB.Close()
+	})
+
+	db := &DB{DB: sqlDB, dbType: DBTypePostgres}
+	err = db.Migrate()
+	if err == nil {
+		t.Fatal("Migrate() error = nil, want lessons DDL failure")
+	}
+	if !strings.Contains(err.Error(), "migrate lessons: create review_lessons table: permission denied") {
+		t.Fatalf("Migrate() error = %q", err)
+	}
+}
+
+func TestMigrateTrajectoriesPropagatesSQLiteDropIndexFailure(t *testing.T) {
+	stub := &migrationExecStub{
+		failOn:  "DROP INDEX IF EXISTS idx_trajectories_issue_unique",
+		failErr: fmt.Errorf("database is locked"),
+	}
+	registerMigrationExecStub(t, stub)
+
+	sqlDB, err := sql.Open(migrationExecStubDriverName, "")
+	if err != nil {
+		t.Fatalf("open migration exec stub db: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = sqlDB.Close()
+	})
+
+	db := &DB{DB: sqlDB, dbType: DBTypeSQLite}
+	err = db.MigrateTrajectories()
+	if err == nil {
+		t.Fatal("MigrateTrajectories() error = nil, want drop-index failure")
+	}
+	if !strings.Contains(err.Error(), "drop idx_trajectories_issue_unique: database is locked") {
+		t.Fatalf("MigrateTrajectories() error = %q", err)
+	}
+}
+
 func testCreatePullRequestPopulatesIDAndSupportsUpdate(t *testing.T, db *DB) {
 
 	uniqueSuffix := time.Now().UnixNano()
@@ -294,13 +344,16 @@ func newSQLiteTestDB(t *testing.T) *DB {
 
 const createPullRequestPostgresStubDriverName = "create_pull_request_postgres_stub"
 const ruleEmbeddingsPostgresStubDriverName = "rule_embeddings_postgres_stub"
+const migrationExecStubDriverName = "migration_exec_stub"
 
 var createPullRequestPostgresStubValue atomic.Pointer[createPullRequestPostgresStub]
 var ruleEmbeddingsPostgresStubValue atomic.Pointer[ruleEmbeddingsPostgresStub]
+var migrationExecStubValue atomic.Pointer[migrationExecStub]
 
 func init() {
 	sql.Register(createPullRequestPostgresStubDriverName, createPullRequestPostgresStubDriver{})
 	sql.Register(ruleEmbeddingsPostgresStubDriverName, ruleEmbeddingsPostgresStubDriver{})
+	sql.Register(migrationExecStubDriverName, migrationExecStubDriver{})
 }
 
 func registerCreatePullRequestPostgresStub(t *testing.T, stub *createPullRequestPostgresStub) {
@@ -319,6 +372,14 @@ func registerRuleEmbeddingsPostgresStub(t *testing.T, stub *ruleEmbeddingsPostgr
 	})
 }
 
+func registerMigrationExecStub(t *testing.T, stub *migrationExecStub) {
+	t.Helper()
+	migrationExecStubValue.Store(stub)
+	t.Cleanup(func() {
+		migrationExecStubValue.Store(nil)
+	})
+}
+
 type createPullRequestPostgresStub struct {
 	nextID     int64
 	queryCount int
@@ -329,6 +390,7 @@ type createPullRequestPostgresStub struct {
 
 type createPullRequestPostgresStubDriver struct{}
 type ruleEmbeddingsPostgresStubDriver struct{}
+type migrationExecStubDriver struct{}
 
 func (createPullRequestPostgresStubDriver) Open(string) (driver.Conn, error) {
 	stub := createPullRequestPostgresStubValue.Load()
@@ -346,6 +408,14 @@ func (ruleEmbeddingsPostgresStubDriver) Open(string) (driver.Conn, error) {
 	return &ruleEmbeddingsPostgresStubConn{stub: stub}, nil
 }
 
+func (migrationExecStubDriver) Open(string) (driver.Conn, error) {
+	stub := migrationExecStubValue.Load()
+	if stub == nil {
+		return nil, fmt.Errorf("migration exec stub not registered")
+	}
+	return &migrationExecStubConn{stub: stub}, nil
+}
+
 type createPullRequestPostgresStubConn struct {
 	stub *createPullRequestPostgresStub
 }
@@ -356,6 +426,16 @@ type ruleEmbeddingsPostgresStub struct {
 
 type ruleEmbeddingsPostgresStubConn struct {
 	stub *ruleEmbeddingsPostgresStub
+}
+
+type migrationExecStub struct {
+	failOn      string
+	failErr     error
+	execQueries []string
+}
+
+type migrationExecStubConn struct {
+	stub *migrationExecStub
 }
 
 func (c *createPullRequestPostgresStubConn) Prepare(string) (driver.Stmt, error) {
@@ -398,6 +478,34 @@ func (c *ruleEmbeddingsPostgresStubConn) QueryContext(_ context.Context, _ strin
 
 func (c *ruleEmbeddingsPostgresStubConn) ExecContext(_ context.Context, query string, _ []driver.NamedValue) (driver.Result, error) {
 	c.stub.execQueries = append(c.stub.execQueries, normalizeWhitespace(query))
+	return driver.RowsAffected(0), nil
+}
+
+func (c *migrationExecStubConn) Prepare(string) (driver.Stmt, error) {
+	return nil, fmt.Errorf("prepare not implemented")
+}
+
+func (c *migrationExecStubConn) Close() error {
+	return nil
+}
+
+func (c *migrationExecStubConn) Begin() (driver.Tx, error) {
+	return nil, fmt.Errorf("transactions not implemented")
+}
+
+func (c *migrationExecStubConn) QueryContext(_ context.Context, _ string, _ []driver.NamedValue) (driver.Rows, error) {
+	return nil, fmt.Errorf("unexpected QueryContext call")
+}
+
+func (c *migrationExecStubConn) ExecContext(_ context.Context, query string, _ []driver.NamedValue) (driver.Result, error) {
+	normalized := normalizeWhitespace(query)
+	c.stub.execQueries = append(c.stub.execQueries, normalized)
+	if c.stub.failOn != "" && strings.Contains(normalized, c.stub.failOn) {
+		if c.stub.failErr != nil {
+			return nil, c.stub.failErr
+		}
+		return nil, fmt.Errorf("forced migration exec failure")
+	}
 	return driver.RowsAffected(0), nil
 }
 
@@ -444,6 +552,9 @@ func namedValuesToValues(args []driver.NamedValue) []driver.Value {
 var _ driver.Conn = (*createPullRequestPostgresStubConn)(nil)
 var _ driver.QueryerContext = (*createPullRequestPostgresStubConn)(nil)
 var _ driver.ExecerContext = (*createPullRequestPostgresStubConn)(nil)
+var _ driver.Conn = (*migrationExecStubConn)(nil)
+var _ driver.QueryerContext = (*migrationExecStubConn)(nil)
+var _ driver.ExecerContext = (*migrationExecStubConn)(nil)
 var _ driver.Rows = (*createPullRequestPostgresStubRows)(nil)
 
 func TestListRepoProfilesNoFilterSQLite(t *testing.T) {

--- a/internal/db/lessons.go
+++ b/internal/db/lessons.go
@@ -7,10 +7,9 @@ import (
 )
 
 // MigrateLessons creates the review_lessons table if it doesn't exist.
-// Called from runMigrations.
-func (db *DB) MigrateLessons() {
+func (db *DB) MigrateLessons() error {
 	if db.IsPostgres() {
-		db.Exec(`
+		if _, err := db.Exec(`
 			CREATE TABLE IF NOT EXISTS review_lessons (
 				id SERIAL PRIMARY KEY,
 				pr_id INTEGER NOT NULL REFERENCES pull_requests(id),
@@ -20,25 +19,31 @@ func (db *DB) MigrateLessons() {
 				source_comment TEXT,
 				reviewer TEXT,
 				created_at TIMESTAMP DEFAULT NOW()
-			)`)
-		db.Exec(`CREATE INDEX IF NOT EXISTS idx_lessons_repo ON review_lessons(repo)`)
-		db.Exec(`CREATE INDEX IF NOT EXISTS idx_lessons_category ON review_lessons(category)`)
-	} else {
-		db.Exec(`
-			CREATE TABLE IF NOT EXISTS review_lessons (
-				id INTEGER PRIMARY KEY AUTOINCREMENT,
-				pr_id INTEGER NOT NULL,
-				repo TEXT NOT NULL,
-				category TEXT NOT NULL,
-				lesson TEXT NOT NULL,
-				source_comment TEXT,
-				reviewer TEXT,
-				created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-				FOREIGN KEY (pr_id) REFERENCES pull_requests(id)
-			)`)
-		db.Exec(`CREATE INDEX IF NOT EXISTS idx_lessons_repo ON review_lessons(repo)`)
-		db.Exec(`CREATE INDEX IF NOT EXISTS idx_lessons_category ON review_lessons(category)`)
+			)`); err != nil {
+			return fmt.Errorf("create review_lessons table: %w", err)
+		}
+	} else if _, err := db.Exec(`
+		CREATE TABLE IF NOT EXISTS review_lessons (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			pr_id INTEGER NOT NULL,
+			repo TEXT NOT NULL,
+			category TEXT NOT NULL,
+			lesson TEXT NOT NULL,
+			source_comment TEXT,
+			reviewer TEXT,
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			FOREIGN KEY (pr_id) REFERENCES pull_requests(id)
+		)`); err != nil {
+		return fmt.Errorf("create review_lessons table: %w", err)
 	}
+
+	if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_lessons_repo ON review_lessons(repo)`); err != nil {
+		return fmt.Errorf("create idx_lessons_repo: %w", err)
+	}
+	if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_lessons_category ON review_lessons(category)`); err != nil {
+		return fmt.Errorf("create idx_lessons_category: %w", err)
+	}
+	return nil
 }
 
 // SaveReviewLesson inserts a new review lesson.

--- a/internal/db/trajectories.go
+++ b/internal/db/trajectories.go
@@ -87,7 +87,9 @@ func (db *DB) MigrateTrajectories() error {
 			return fmt.Errorf("create idx_trajectories_success: %w", err)
 		}
 		// Drop the old named unique index if it exists (created by earlier schema versions).
-		db.Exec(`DROP INDEX IF EXISTS idx_trajectories_issue_unique`)
+		if _, err := db.Exec(`DROP INDEX IF EXISTS idx_trajectories_issue_unique`); err != nil {
+			return fmt.Errorf("drop idx_trajectories_issue_unique: %w", err)
+		}
 		// Add pr_number column to existing SQLite tables; "duplicate column name" means already present.
 		if _, err := db.Exec(`ALTER TABLE trajectories ADD COLUMN pr_number INTEGER NOT NULL DEFAULT 0`); err != nil {
 			if !strings.Contains(err.Error(), "duplicate column name") {
@@ -100,11 +102,12 @@ func (db *DB) MigrateTrajectories() error {
 		var oldSQL string
 		if err := db.QueryRow(
 			`SELECT sql FROM sqlite_master WHERE type='table' AND name='trajectories'`,
-		).Scan(&oldSQL); err == nil {
-			if regexp.MustCompile(`(?i)\bissue_id\b[^,\n)]*\bUNIQUE\b`).MatchString(oldSQL) {
-				if err := db.rebuildTrajectoriesTable(); err != nil {
-					return fmt.Errorf("rebuild trajectories table: %w", err)
-				}
+		).Scan(&oldSQL); err != nil {
+			return fmt.Errorf("inspect trajectories schema: %w", err)
+		}
+		if regexp.MustCompile(`(?i)\bissue_id\b[^,\n)]*\bUNIQUE\b`).MatchString(oldSQL) {
+			if err := db.rebuildTrajectoriesTable(); err != nil {
+				return fmt.Errorf("rebuild trajectories table: %w", err)
 			}
 		}
 	}
@@ -168,10 +171,19 @@ func (db *DB) rebuildTrajectoriesTable() error {
 		return fmt.Errorf("commit trajectories rebuild: %w", err)
 	}
 
-	// Rebuild indexes after table recreation (outside transaction; non-fatal if they already exist).
-	db.Exec(`CREATE INDEX IF NOT EXISTS idx_trajectories_issue ON trajectories(issue_id)`)
-	db.Exec(`CREATE INDEX IF NOT EXISTS idx_trajectories_outcome ON trajectories(outcome_label)`)
-	db.Exec(`CREATE INDEX IF NOT EXISTS idx_trajectories_success ON trajectories(success)`)
+	indexes := []struct {
+		name  string
+		query string
+	}{
+		{name: "idx_trajectories_issue", query: `CREATE INDEX IF NOT EXISTS idx_trajectories_issue ON trajectories(issue_id)`},
+		{name: "idx_trajectories_outcome", query: `CREATE INDEX IF NOT EXISTS idx_trajectories_outcome ON trajectories(outcome_label)`},
+		{name: "idx_trajectories_success", query: `CREATE INDEX IF NOT EXISTS idx_trajectories_success ON trajectories(success)`},
+	}
+	for _, index := range indexes {
+		if _, err := db.Exec(index.query); err != nil {
+			return fmt.Errorf("create %s: %w", index.name, err)
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- Fixes #73 by propagating `review_lessons` migration errors through `DB.Migrate`.
- Makes remaining trajectories DDL/schema-inspection failures return errors instead of continuing silently.
- Adds regression tests for fail-closed lessons and trajectories migration failures.

## Validation
- `go test ./internal/db`
- `go build ./...`
- `go test ./...`