### PR TITLE
Fix critic stage rule persistence

### DIFF
--- a/internal/pipeline/synthesizer.go
+++ b/internal/pipeline/synthesizer.go
@@ -11,7 +11,7 @@ import (
 	"github.com/majiayu000/auto-contributor/pkg/models"
 )
 
-var synthesisStages = []string{"scout", "analyst", "engineer", "reviewer", "submitter", "responder"}
+var synthesisStages = []string{"scout", "analyst", "engineer", "reviewer", "critic", "submitter", "responder"}
 
 // RunSynthesis runs the rule synthesis cycle for all stages.
 func (p *Pipeline) RunSynthesis(ctx context.Context) error {

--- a/internal/pipeline/synthesizer_test.go
+++ b/internal/pipeline/synthesizer_test.go
@@ -261,6 +261,83 @@ func TestApplySynthesisResult_UpdatedRuleSetsLastValidatedAt(t *testing.T) {
 	}
 }
 
+func TestSynthesisStagesIncludesCritic(t *testing.T) {
+	for _, stage := range synthesisStages {
+		if stage == "critic" {
+			return
+		}
+	}
+	t.Fatalf("synthesisStages = %v, want critic included", synthesisStages)
+}
+
+func TestApplySynthesisResult_CriticStageCreatesAndUpdatesRules(t *testing.T) {
+	dir := t.TempDir()
+
+	existing := &rules.Rule{
+		ID:              "critic-existing-rule",
+		Stage:           "critic",
+		Severity:        "medium",
+		Confidence:      0.5,
+		Source:          "synthesized",
+		CreatedAt:       "2024-01-01",
+		LastValidatedAt: "2024-01-01",
+		Body:            "Check maintainer-facing risk before submit.",
+	}
+	writeRule(t, dir, existing)
+
+	p := newTestPipeline(t, dir)
+	result := &SynthesizerResult{
+		NewRules: []SynthesizedRule{
+			{
+				ID:            "critic-new-rule",
+				Stage:         "engineer",
+				Severity:      "high",
+				Confidence:    0.65,
+				EvidenceCount: 5,
+				Condition:     "critic finds hidden compatibility risk",
+				Body:          "Treat critic compatibility findings as blocking until rework resolves them.",
+			},
+		},
+		UpdatedRules: []RuleUpdate{
+			{
+				ID:            existing.ID,
+				NewConfidence: 0.75,
+				Reason:        "critic evidence repeated",
+			},
+		},
+	}
+
+	applied := p.applySynthesisResult("critic", result)
+	if applied.newCount != 1 {
+		t.Fatalf("expected 1 new critic rule, got %d", applied.newCount)
+	}
+	if applied.updatedCount != 1 {
+		t.Fatalf("expected 1 updated critic rule, got %d", applied.updatedCount)
+	}
+
+	if err := p.ruleLoader.Reload(); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+	created := p.ruleLoader.ByStageAndID("critic", "critic-new-rule")
+	if created == nil {
+		t.Fatal("new critic rule was not written under critic stage")
+	}
+	if created.Stage != "critic" {
+		t.Errorf("created rule stage = %q, want critic", created.Stage)
+	}
+	updated := p.ruleLoader.ByStageAndID("critic", existing.ID)
+	if updated == nil {
+		t.Fatal("updated critic rule was not found")
+	}
+	if updated.Confidence != 0.75 {
+		t.Errorf("updated confidence = %.2f, want 0.75", updated.Confidence)
+	}
+	today := time.Now().Format("2006-01-02")
+	if updated.LastValidatedAt != today {
+		t.Errorf("updated last_validated_at = %q, want %q", updated.LastValidatedAt, today)
+	}
+}
+
 // TestMergedRuleIsNotDecayedInSameCycle verifies that when a candidate is merged
 // into an existing stale rule, last_validated_at is stamped so that applyDecay
 // running in the same synthesis cycle does not decay the just-reinforced rule.

--- a/internal/rules/loader_test.go
+++ b/internal/rules/loader_test.go
@@ -167,6 +167,40 @@ func TestQuarantineInvalidStage(t *testing.T) {
 	}
 }
 
+func TestCriticStageRuleSurvivesReload(t *testing.T) {
+	dir := t.TempDir()
+
+	critic := writeRuleYAML(t, dir, "critic", "critic-rule.yaml",
+		"id: critic-rule\nstage: critic\nbody: keep critic-specific checks\nconfidence: 0.8\n")
+	global := writeRuleYAML(t, dir, "global", "global-rule.yaml",
+		"id: global-rule\nstage: global\nbody: keep global checks\nconfidence: 0.9\n")
+
+	rl := NewRuleLoader(dir)
+	if err := rl.Load(); err != nil {
+		t.Fatalf("Load() failed: %v", err)
+	}
+	if err := rl.Reload(); err != nil {
+		t.Fatalf("Reload() failed: %v", err)
+	}
+
+	criticRules := rl.ForStage("critic")
+	if len(criticRules) != 2 {
+		t.Fatalf("ForStage(\"critic\") loaded %d rules, want critic + global", len(criticRules))
+	}
+	if got := rl.ByStageAndID("critic", "critic-rule"); got == nil {
+		t.Fatal("critic-stage rule was not loaded after reload")
+	}
+	prompt := rl.FormatForPrompt("critic")
+	if !strings.Contains(prompt, "keep critic-specific checks") || !strings.Contains(prompt, "keep global checks") {
+		t.Fatalf("critic prompt missing critic/global rules:\n%s", prompt)
+	}
+	for _, path := range []string{critic, global} {
+		if _, err := os.Stat(path); err != nil {
+			t.Errorf("valid rule file should remain on disk: %s: %v", path, err)
+		}
+	}
+}
+
 // TestQuarantineUnsafeID verifies that readFromDisk deletes rule files whose
 // ID field contains path traversal characters and does not load them into memory.
 // A rule with stage: engineer but id: ../../../etc/cron.d/pwn would otherwise

--- a/internal/rules/writer.go
+++ b/internal/rules/writer.go
@@ -23,6 +23,7 @@ var allowedStages = map[string]bool{
 	"analyst":   true,
 	"engineer":  true,
 	"reviewer":  true,
+	"critic":    true,
 	"submitter": true,
 	"responder": true,
 	"global":    true,

--- a/internal/rules/writer_test.go
+++ b/internal/rules/writer_test.go
@@ -238,7 +238,7 @@ func TestWriteRule_UnsafeStage(t *testing.T) {
 // TestWriteRule_AllowedStages verifies that WriteRule accepts all valid stage names.
 func TestWriteRule_AllowedStages(t *testing.T) {
 	dir := t.TempDir()
-	stages := []string{"scout", "analyst", "engineer", "reviewer", "submitter", "responder", "global"}
+	stages := []string{"scout", "analyst", "engineer", "reviewer", "critic", "submitter", "responder", "global"}
 	for _, stage := range stages {
 		rule := &Rule{
 			ID:    "test-stage-rule",
@@ -483,7 +483,7 @@ func TestValidateRuleID_Helper(t *testing.T) {
 // distinguishes WriteRule (must reject "") from update/delete helpers and the
 // loader walk (which use "" to mean "search every stage").
 func TestValidateStage_Helper(t *testing.T) {
-	for _, stage := range []string{"scout", "analyst", "engineer", "reviewer", "submitter", "responder", "global"} {
+	for _, stage := range []string{"scout", "analyst", "engineer", "reviewer", "critic", "submitter", "responder", "global"} {
 		if err := validateStage(stage, false); err != nil {
 			t.Errorf("validateStage(%q, false) unexpected error: %v", stage, err)
 		}


### PR DESCRIPTION
Fixes #42

## Summary
- add `critic` to the shared rule stage allowlist so critic-stage rules survive reload and writer/update paths
- include `critic` in rule synthesis stages so labeled critic events can produce or update rules
- add regression tests for critic rule reload and synthesis create/update behavior

## Validation
- `go test ./internal/rules ./internal/pipeline`
- `go test ./...`
- `go build ./...`