### PR TITLE
fix: fail scout on GitHub prefetch errors (#71)

### DIFF
--- a/internal/github/scout_data.go
+++ b/internal/github/scout_data.go
@@ -1,0 +1,295 @@
+package github
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+const maxScoutFieldBytes = 8000
+
+// ScoutData holds pre-collected data for the Scout agent to avoid tool calls.
+type ScoutData struct {
+	IssueComments       ScoutDataField
+	CompetingPRs        ScoutDataField
+	IssueTimeline       ScoutDataField
+	MergedPRs           ScoutDataField
+	RepoMeta            ScoutDataField
+	Branches            ScoutDataField
+	ContributingExcerpt ScoutDataField
+	ClosedPRComments    ScoutDataField
+	WorkflowNames       ScoutDataField
+	RecentPRAuthors     ScoutDataField
+}
+
+// ScoutDataField separates confirmed empty data from fetch failures.
+type ScoutDataField struct {
+	Data    string
+	Failure string
+}
+
+// CollectScoutData pre-fetches the data the Scout agent needs via gh CLI.
+func (c *Client) CollectScoutData(ctx context.Context, repo string, issueNum int, issueTitle string) (*ScoutData, error) {
+	d := &ScoutData{}
+	var failures []error
+
+	collect := func(name string, field *ScoutDataField, args ...string) {
+		*field = collectScoutCommand(ctx, args...)
+		if field.Failure != "" {
+			failures = append(failures, fmt.Errorf("%s: %s", name, field.Failure))
+		}
+	}
+	collectAllowNotFound := func(name string, field *ScoutDataField, args ...string) {
+		*field = collectScoutCommandAllowNotFound(ctx, args...)
+		if field.Failure != "" {
+			failures = append(failures, fmt.Errorf("%s: %s", name, field.Failure))
+		}
+	}
+
+	collect("Issue Comments", &d.IssueComments,
+		"api",
+		fmt.Sprintf("repos/%s/issues/%d/comments", repo, issueNum),
+		"--jq", `[.[] | {author: .user.login, body: .body, created: .created_at}]`)
+
+	d.CompetingPRs = collectCompetingPRs(ctx, repo, issueNum, issueTitle)
+	if d.CompetingPRs.Failure != "" {
+		failures = append(failures, fmt.Errorf("Open PRs Matching This Issue: %s", d.CompetingPRs.Failure))
+	}
+
+	collect("Issue Timeline", &d.IssueTimeline,
+		"api",
+		fmt.Sprintf("repos/%s/issues/%d/timeline", repo, issueNum),
+		"--jq", `[.[] | select(.event == "cross-referenced" or .event == "referenced") | {event: .event, pr_url: .source.issue.pull_request.html_url, source_title: .source.issue.title}]`)
+
+	collect("Recent Merged PRs", &d.MergedPRs,
+		"pr", "list",
+		"-R", repo,
+		"--state", "merged",
+		"--limit", "20",
+		"--json", "number,author,mergedAt")
+
+	collect("Repo Metadata", &d.RepoMeta,
+		"api",
+		fmt.Sprintf("repos/%s", repo),
+		"--jq", `{default_branch: .default_branch, archived: .archived, disabled: .disabled}`)
+
+	collect("Dev/Develop Branches", &d.Branches,
+		"api",
+		fmt.Sprintf("repos/%s/branches", repo),
+		"--jq", `[.[] | select(.name | test("^(dev|develop|next|staging)$")) | .name]`)
+
+	d.ContributingExcerpt = collectContributingExcerpt(ctx, repo)
+	if d.ContributingExcerpt.Failure != "" {
+		failures = append(failures, fmt.Errorf("CONTRIBUTING.md: %s", d.ContributingExcerpt.Failure))
+	}
+
+	collect("Closed PR Assignment Enforcement", &d.ClosedPRComments,
+		"pr", "list",
+		"-R", repo,
+		"--state", "closed",
+		"--limit", "5",
+		"--json", "number,comments",
+		"--jq", `[.[] | .comments[] | select(.body | test("not assigned|must be assigned|require.*assign"; "i")) | {body: .body[:200]}]`)
+
+	collectAllowNotFound("GitHub Workflow Files", &d.WorkflowNames,
+		"api",
+		fmt.Sprintf("repos/%s/contents/.github/workflows", repo),
+		"--jq", `[.[].name]`)
+
+	collect("Recent PR Authors", &d.RecentPRAuthors,
+		"pr", "list",
+		"-R", repo,
+		"--state", "all",
+		"--limit", "10",
+		"--json", "number,author,state")
+
+	if len(failures) > 0 {
+		return d, errors.Join(failures...)
+	}
+	return d, nil
+}
+
+// Format returns the pre-collected data as a prompt section.
+func (d *ScoutData) Format() string {
+	var sb strings.Builder
+	sb.WriteString("## Pre-collected Data (DO NOT re-run these commands)\n\n")
+	sb.WriteString("Successful empty sections mean the query returned no matching data. Sections marked UNKNOWN are fetch failures and must not be treated as absence of risk.\n\n")
+
+	section := func(title string, field ScoutDataField, emptyMessage string) {
+		if field.Failure != "" {
+			sb.WriteString(fmt.Sprintf("### %s\nUNKNOWN: fetch failed. Do not treat this as verified absence.\nError: %s\n\n", title, field.Failure))
+			return
+		}
+		if isEmptyScoutData(field.Data) {
+			sb.WriteString(fmt.Sprintf("### %s\n%s\n\n", title, emptyMessage))
+			return
+		}
+		sb.WriteString(fmt.Sprintf("### %s\n```json\n%s\n```\n\n", title, field.Data))
+	}
+
+	section("Issue Comments", d.IssueComments, "No data found.")
+	section("Open PRs Matching This Issue", d.CompetingPRs, "No data found.")
+	section("Issue Timeline (Cross-references)", d.IssueTimeline, "No data found.")
+	section("Recent Merged PRs (last 20)", d.MergedPRs, "No data found.")
+	section("Repo Metadata", d.RepoMeta, "No data found.")
+	section("Dev/Develop Branches", d.Branches, "No data found.")
+	section("CONTRIBUTING.md", d.ContributingExcerpt, "No assignment-related content found.")
+	section("Closed PR Assignment Enforcement", d.ClosedPRComments, "No data found.")
+	section("GitHub Workflow Files", d.WorkflowNames, "No data found.")
+	section("Recent PR Authors", d.RecentPRAuthors, "No data found.")
+
+	return sb.String()
+}
+
+func collectCompetingPRs(ctx context.Context, repo string, issueNum int, issueTitle string) ScoutDataField {
+	byNumber := collectScoutCommand(ctx,
+		"pr", "list",
+		"-R", repo,
+		"--state", "open",
+		"--search", fmt.Sprintf("%d in:title,body", issueNum),
+		"--json", "number,title,author,updatedAt,url",
+		"--limit", "10")
+
+	byTitle := collectScoutCommand(ctx,
+		"pr", "list",
+		"-R", repo,
+		"--state", "open",
+		"--search", issueTitle,
+		"--json", "number,title,author,updatedAt,url",
+		"--limit", "5")
+
+	var failures []string
+	if byNumber.Failure != "" {
+		failures = append(failures, "by issue number: "+byNumber.Failure)
+	}
+	if byTitle.Failure != "" {
+		failures = append(failures, "by title: "+byTitle.Failure)
+	}
+	if len(failures) > 0 {
+		return ScoutDataField{Failure: strings.Join(failures, "; ")}
+	}
+
+	data := byNumber.Data
+	if !isEmptyScoutData(byTitle.Data) {
+		if data != "" {
+			data += "\n\nSearch by title:\n"
+		}
+		data += byTitle.Data
+	}
+	return ScoutDataField{Data: truncateScoutData(data)}
+}
+
+func collectContributingExcerpt(ctx context.Context, repo string) ScoutDataField {
+	paths := []string{
+		"CONTRIBUTING.md",
+		".github/CONTRIBUTING.md",
+		"docs/CONTRIBUTING.md",
+	}
+	var failures []string
+	for _, path := range paths {
+		content, err := runGH(ctx, "api", fmt.Sprintf("repos/%s/contents/%s", repo, path), "--jq", ".content")
+		if err != nil {
+			if isNotFoundError(err) {
+				continue
+			}
+			failures = append(failures, fmt.Sprintf("%s: %s", path, err.Error()))
+			continue
+		}
+		if isEmptyScoutData(content) {
+			continue
+		}
+
+		decoded, err := decodeScoutBase64(content)
+		if err != nil {
+			return ScoutDataField{Failure: fmt.Sprintf("%s: decode content: %s", path, err.Error())}
+		}
+		return ScoutDataField{Data: extractAssignmentLines(decoded)}
+	}
+
+	if len(failures) > 0 {
+		return ScoutDataField{Failure: strings.Join(failures, "; ")}
+	}
+	return ScoutDataField{}
+}
+
+func extractAssignmentLines(content string) string {
+	var lines []string
+	for _, line := range strings.Split(content, "\n") {
+		lower := strings.ToLower(line)
+		if strings.Contains(lower, "assign") ||
+			strings.Contains(lower, "claim") ||
+			(strings.Contains(lower, "before") && strings.Contains(lower, "pr")) {
+			lines = append(lines, line)
+		}
+	}
+	return truncateScoutData(strings.Join(lines, "\n"))
+}
+
+func collectScoutCommand(ctx context.Context, args ...string) ScoutDataField {
+	data, err := runGH(ctx, args...)
+	if err != nil {
+		return ScoutDataField{Failure: err.Error()}
+	}
+	return ScoutDataField{Data: data}
+}
+
+func collectScoutCommandAllowNotFound(ctx context.Context, args ...string) ScoutDataField {
+	data, err := runGH(ctx, args...)
+	if err != nil {
+		if isNotFoundError(err) {
+			return ScoutDataField{}
+		}
+		return ScoutDataField{Failure: err.Error()}
+	}
+	return ScoutDataField{Data: data}
+}
+
+func runGH(ctx context.Context, args ...string) (string, error) {
+	var stdout, stderr bytes.Buffer
+	cmd := exec.CommandContext(ctx, "gh", args...)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg == "" {
+			msg = err.Error()
+		}
+		return "", fmt.Errorf("gh %s: %w: %s", strings.Join(args, " "), err, msg)
+	}
+	return truncateScoutData(strings.TrimSpace(stdout.String())), nil
+}
+
+func decodeScoutBase64(content string) (string, error) {
+	clean := strings.ReplaceAll(content, "\\n", "")
+	clean = strings.ReplaceAll(clean, "\n", "")
+	clean = strings.ReplaceAll(clean, "\"", "")
+	decoded, err := base64.StdEncoding.DecodeString(clean)
+	if err != nil {
+		return "", err
+	}
+	return string(decoded), nil
+}
+
+func isEmptyScoutData(data string) bool {
+	trimmed := strings.TrimSpace(data)
+	return trimmed == "" || trimmed == "[]" || trimmed == "null"
+}
+
+func isNotFoundError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "not found") || strings.Contains(msg, "http 404")
+}
+
+func truncateScoutData(data string) string {
+	if len(data) <= maxScoutFieldBytes {
+		return data
+	}
+	return data[:maxScoutFieldBytes] + "\n... (truncated)"
+}

--- a/internal/github/scout_data.go
+++ b/internal/github/scout_data.go
@@ -4,13 +4,17 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os/exec"
+	"regexp"
 	"strings"
 )
 
 const maxScoutFieldBytes = 8000
+
+var assignmentCommentPattern = regexp.MustCompile(`(?i)not assigned|must be assigned|require.*assign`)
 
 // ScoutData holds pre-collected data for the Scout agent to avoid tool calls.
 type ScoutData struct {
@@ -87,13 +91,10 @@ func (c *Client) CollectScoutData(ctx context.Context, repo string, issueNum int
 		failures = append(failures, fmt.Errorf("CONTRIBUTING.md: %s", d.ContributingExcerpt.Failure))
 	}
 
-	collect("Closed PR Assignment Enforcement", &d.ClosedPRComments,
-		"pr", "list",
-		"-R", repo,
-		"--state", "closed",
-		"--limit", "5",
-		"--json", "number,comments",
-		"--jq", `[.[] | .comments[] | select(.body | test("not assigned|must be assigned|require.*assign"; "i")) | {body: .body[:200]}]`)
+	d.ClosedPRComments = collectClosedPRAssignmentComments(ctx, repo)
+	if d.ClosedPRComments.Failure != "" {
+		failures = append(failures, fmt.Errorf("Closed PR Assignment Enforcement: %s", d.ClosedPRComments.Failure))
+	}
 
 	collectAllowNotFound("GitHub Workflow Files", &d.WorkflowNames,
 		"api",
@@ -191,7 +192,7 @@ func collectContributingExcerpt(ctx context.Context, repo string) ScoutDataField
 	}
 	var failures []string
 	for _, path := range paths {
-		content, err := runGH(ctx, "api", fmt.Sprintf("repos/%s/contents/%s", repo, path), "--jq", ".content")
+		content, err := runGHRaw(ctx, "api", fmt.Sprintf("repos/%s/contents/%s", repo, path), "--jq", ".content")
 		if err != nil {
 			if isNotFoundError(err) {
 				continue
@@ -214,6 +215,91 @@ func collectContributingExcerpt(ctx context.Context, repo string) ScoutDataField
 		return ScoutDataField{Failure: strings.Join(failures, "; ")}
 	}
 	return ScoutDataField{}
+}
+
+func collectClosedPRAssignmentComments(ctx context.Context, repo string) ScoutDataField {
+	data, err := runGHRaw(ctx,
+		"pr", "list",
+		"-R", repo,
+		"--state", "closed",
+		"--limit", "5",
+		"--json", "number,comments")
+	if err != nil {
+		return ScoutDataField{Failure: err.Error()}
+	}
+
+	filtered, err := extractClosedPRAssignmentComments(data)
+	if err != nil {
+		return ScoutDataField{Failure: err.Error()}
+	}
+	return ScoutDataField{Data: filtered}
+}
+
+func extractClosedPRAssignmentComments(data string) (string, error) {
+	if isEmptyScoutData(data) {
+		return "[]", nil
+	}
+
+	var prs []struct {
+		Comments json.RawMessage `json:"comments"`
+	}
+	if err := json.Unmarshal([]byte(data), &prs); err != nil {
+		return "", fmt.Errorf("parse closed PR comments: %w", err)
+	}
+
+	matches := make([]struct {
+		Body string `json:"body"`
+	}, 0)
+	for _, pr := range prs {
+		comments, err := parseScoutPRComments(pr.Comments)
+		if err != nil {
+			return "", err
+		}
+		for _, comment := range comments {
+			if !assignmentCommentPattern.MatchString(comment.Body) {
+				continue
+			}
+			body := comment.Body
+			if len(body) > 200 {
+				body = body[:200]
+			}
+			matches = append(matches, struct {
+				Body string `json:"body"`
+			}{Body: body})
+		}
+	}
+
+	output, err := json.Marshal(matches)
+	if err != nil {
+		return "", fmt.Errorf("encode closed PR comments: %w", err)
+	}
+	return truncateScoutData(string(output)), nil
+}
+
+type scoutPRComment struct {
+	Body string `json:"body"`
+}
+
+func parseScoutPRComments(raw json.RawMessage) ([]scoutPRComment, error) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil, nil
+	}
+
+	var comments []scoutPRComment
+	if raw[0] == '[' {
+		if err := json.Unmarshal(raw, &comments); err != nil {
+			return nil, fmt.Errorf("parse comments array: %w", err)
+		}
+		return comments, nil
+	}
+
+	var connection struct {
+		Nodes []scoutPRComment `json:"nodes"`
+	}
+	if err := json.Unmarshal(raw, &connection); err != nil {
+		return nil, fmt.Errorf("parse comments connection: %w", err)
+	}
+	return connection.Nodes, nil
 }
 
 func extractAssignmentLines(content string) string {
@@ -249,6 +335,14 @@ func collectScoutCommandAllowNotFound(ctx context.Context, args ...string) Scout
 }
 
 func runGH(ctx context.Context, args ...string) (string, error) {
+	data, err := runGHRaw(ctx, args...)
+	if err != nil {
+		return "", err
+	}
+	return truncateScoutData(data), nil
+}
+
+func runGHRaw(ctx context.Context, args ...string) (string, error) {
 	var stdout, stderr bytes.Buffer
 	cmd := exec.CommandContext(ctx, "gh", args...)
 	cmd.Stdout = &stdout
@@ -260,7 +354,7 @@ func runGH(ctx context.Context, args ...string) (string, error) {
 		}
 		return "", fmt.Errorf("gh %s: %w: %s", strings.Join(args, " "), err, msg)
 	}
-	return truncateScoutData(strings.TrimSpace(stdout.String())), nil
+	return strings.TrimSpace(stdout.String()), nil
 }
 
 func decodeScoutBase64(content string) (string, error) {

--- a/internal/github/scout_data_test.go
+++ b/internal/github/scout_data_test.go
@@ -2,6 +2,8 @@ package github
 
 import (
 	"context"
+	"encoding/base64"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -94,5 +96,68 @@ esac
 	}
 	if strings.Contains(formatted, "### Open PRs Matching This Issue\nNo data found.") {
 		t.Fatalf("failed PR query was rendered as no data:\n%s", formatted)
+	}
+}
+
+func TestCollectContributingExcerptDecodesLargeBase64BeforeTruncating(t *testing.T) {
+	content := strings.Repeat("general contribution guidance\n", 500) +
+		"Please request assignment before opening a PR.\n"
+	encoded := base64.StdEncoding.EncodeToString([]byte(content))
+	if len(encoded) <= maxScoutFieldBytes {
+		t.Fatalf("test fixture base64 length = %d, want > %d", len(encoded), maxScoutFieldBytes)
+	}
+
+	installFakeGH(t, fmt.Sprintf(`#!/bin/sh
+case "$*" in
+  "api repos/owner/repo/contents/CONTRIBUTING.md"*) printf '%%s' '%s'; exit 0 ;;
+  *) printf 'unexpected args: %%s\n' "$*" >&2; exit 1 ;;
+esac
+`, encoded))
+
+	field := collectContributingExcerpt(context.Background(), "owner/repo")
+	if field.Failure != "" {
+		t.Fatalf("collectContributingExcerpt failure = %q", field.Failure)
+	}
+	if !strings.Contains(field.Data, "Please request assignment before opening a PR.") {
+		t.Fatalf("contributing excerpt = %q, want assignment line from large base64 payload", field.Data)
+	}
+	if strings.Contains(field.Data, "... (truncated)") {
+		t.Fatalf("contributing excerpt = %q, want decoded assignment excerpt without base64 truncation marker", field.Data)
+	}
+}
+
+func TestExtractClosedPRAssignmentCommentsSupportsCommentShapes(t *testing.T) {
+	tests := []struct {
+		name string
+		data string
+		want string
+	}{
+		{
+			name: "gh array comments",
+			data: `[{"comments":[{"body":"Must be assigned before opening a PR."},{"body":"Thanks."}]}]`,
+			want: "Must be assigned before opening a PR.",
+		},
+		{
+			name: "connection comments",
+			data: `[{"comments":{"nodes":[{"body":"This requires maintainer assignment before PRs."}]}}]`,
+			want: "requires maintainer assignment",
+		},
+		{
+			name: "empty comments",
+			data: `[{"comments":[]}]`,
+			want: "[]",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := extractClosedPRAssignmentComments(tc.data)
+			if err != nil {
+				t.Fatalf("extractClosedPRAssignmentComments: %v", err)
+			}
+			if !strings.Contains(got, tc.want) {
+				t.Fatalf("extractClosedPRAssignmentComments() = %q, want substring %q", got, tc.want)
+			}
+		})
 	}
 }

--- a/internal/github/scout_data_test.go
+++ b/internal/github/scout_data_test.go
@@ -1,0 +1,98 @@
+package github
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/majiayu000/auto-contributor/internal/config"
+)
+
+func installFakeGH(t *testing.T, script string) {
+	t.Helper()
+
+	tempDir := t.TempDir()
+	scriptPath := filepath.Join(tempDir, "gh")
+	if err := os.WriteFile(scriptPath, []byte(script), 0755); err != nil {
+		t.Fatalf("write fake gh script: %v", err)
+	}
+	t.Setenv("PATH", tempDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func TestCollectScoutDataDistinguishesEmptyResultsFromFailures(t *testing.T) {
+	installFakeGH(t, `#!/bin/sh
+case "$*" in
+  "api repos/owner/repo/issues/7/comments"*) printf '%s' '[]'; exit 0 ;;
+  "pr list -R owner/repo --state open --search 7 in:title,body"*) printf '%s' '[]'; exit 0 ;;
+  "pr list -R owner/repo --state open --search panic in parser"*) printf '%s' '[]'; exit 0 ;;
+  "api repos/owner/repo/issues/7/timeline"*) printf '%s' '[]'; exit 0 ;;
+  "pr list -R owner/repo --state merged"*) printf '%s' '[{"number":1}]'; exit 0 ;;
+  "api repos/owner/repo --jq"*) printf '%s' '{"default_branch":"main","archived":false,"disabled":false}'; exit 0 ;;
+  "api repos/owner/repo/branches"*) printf '%s' '[]'; exit 0 ;;
+  "api repos/owner/repo/contents/CONTRIBUTING.md"*) printf '%s\n' 'Not Found' >&2; exit 1 ;;
+  "api repos/owner/repo/contents/.github/CONTRIBUTING.md"*) printf '%s\n' 'Not Found' >&2; exit 1 ;;
+  "api repos/owner/repo/contents/docs/CONTRIBUTING.md"*) printf '%s\n' 'Not Found' >&2; exit 1 ;;
+  "pr list -R owner/repo --state closed"*) printf '%s' '[]'; exit 0 ;;
+  "api repos/owner/repo/contents/.github/workflows"*) printf '%s\n' 'Not Found' >&2; exit 1 ;;
+  "pr list -R owner/repo --state all"*) printf '%s' '[]'; exit 0 ;;
+  *) printf 'unexpected args: %s\n' "$*" >&2; exit 1 ;;
+esac
+`)
+
+	client := New(&config.Config{})
+	data, err := client.CollectScoutData(context.Background(), "owner/repo", 7, "panic in parser")
+	if err != nil {
+		t.Fatalf("CollectScoutData() error = %v", err)
+	}
+
+	formatted := data.Format()
+	if !strings.Contains(formatted, "### Open PRs Matching This Issue\nNo data found.") {
+		t.Fatalf("empty PR result was not rendered as verified empty:\n%s", formatted)
+	}
+	if strings.Contains(formatted, "UNKNOWN: fetch failed") {
+		t.Fatalf("successful collection should not render UNKNOWN:\n%s", formatted)
+	}
+	if !strings.Contains(formatted, `"default_branch":"main"`) {
+		t.Fatalf("repo metadata missing from formatted data:\n%s", formatted)
+	}
+}
+
+func TestCollectScoutDataReturnsErrorAndMarksUnknownOnCriticalFetchFailure(t *testing.T) {
+	installFakeGH(t, `#!/bin/sh
+case "$*" in
+  "api repos/owner/repo/issues/7/comments"*) printf '%s' '[]'; exit 0 ;;
+  "pr list -R owner/repo --state open --search 7 in:title,body"*) printf '%s\n' 'rate limit exceeded' >&2; exit 1 ;;
+  "pr list -R owner/repo --state open --search panic in parser"*) printf '%s' '[]'; exit 0 ;;
+  "api repos/owner/repo/issues/7/timeline"*) printf '%s' '[]'; exit 0 ;;
+  "pr list -R owner/repo --state merged"*) printf '%s' '[]'; exit 0 ;;
+  "api repos/owner/repo --jq"*) printf '%s' '{"default_branch":"main","archived":false,"disabled":false}'; exit 0 ;;
+  "api repos/owner/repo/branches"*) printf '%s' '[]'; exit 0 ;;
+  "api repos/owner/repo/contents/CONTRIBUTING.md"*) printf '%s\n' 'Not Found' >&2; exit 1 ;;
+  "api repos/owner/repo/contents/.github/CONTRIBUTING.md"*) printf '%s\n' 'Not Found' >&2; exit 1 ;;
+  "api repos/owner/repo/contents/docs/CONTRIBUTING.md"*) printf '%s\n' 'Not Found' >&2; exit 1 ;;
+  "pr list -R owner/repo --state closed"*) printf '%s' '[]'; exit 0 ;;
+  "api repos/owner/repo/contents/.github/workflows"*) printf '%s\n' 'Not Found' >&2; exit 1 ;;
+  "pr list -R owner/repo --state all"*) printf '%s' '[]'; exit 0 ;;
+  *) printf 'unexpected args: %s\n' "$*" >&2; exit 1 ;;
+esac
+`)
+
+	client := New(&config.Config{})
+	data, err := client.CollectScoutData(context.Background(), "owner/repo", 7, "panic in parser")
+	if err == nil {
+		t.Fatal("CollectScoutData() error = nil, want critical fetch failure")
+	}
+	if !strings.Contains(err.Error(), "Open PRs Matching This Issue") {
+		t.Fatalf("error = %q, want competing PR context", err.Error())
+	}
+
+	formatted := data.Format()
+	if !strings.Contains(formatted, "### Open PRs Matching This Issue\nUNKNOWN: fetch failed.") {
+		t.Fatalf("failed PR query was not rendered as UNKNOWN:\n%s", formatted)
+	}
+	if strings.Contains(formatted, "### Open PRs Matching This Issue\nNo data found.") {
+		t.Fatalf("failed PR query was rendered as no data:\n%s", formatted)
+	}
+}

--- a/internal/pipeline/agent_test.go
+++ b/internal/pipeline/agent_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/majiayu000/auto-contributor/internal/config"
 	"github.com/majiayu000/auto-contributor/internal/db"
+	ghclient "github.com/majiayu000/auto-contributor/internal/github"
 	"github.com/majiayu000/auto-contributor/internal/prompt"
 	"github.com/majiayu000/auto-contributor/internal/rules"
 	"github.com/majiayu000/auto-contributor/internal/runtime"
@@ -56,6 +57,22 @@ func writePromptTemplate(t *testing.T, dir, name, body string) {
 	if err := os.WriteFile(filepath.Join(dir, name+".md"), []byte(body), 0644); err != nil {
 		t.Fatalf("write %s prompt: %v", name, err)
 	}
+}
+
+func installFailingGH(t *testing.T, stderr string) {
+	t.Helper()
+
+	tempDir := t.TempDir()
+	scriptPath := filepath.Join(tempDir, "gh")
+	script := "#!/bin/sh\nprintf '%s\\n' " + shellQuote(stderr) + " >&2\nexit 1\n"
+	if err := os.WriteFile(scriptPath, []byte(script), 0755); err != nil {
+		t.Fatalf("write fake gh script: %v", err)
+	}
+	t.Setenv("PATH", tempDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
 }
 
 func newLoopTestPipeline(t *testing.T, rt runtime.Runtime) (*Pipeline, *db.DB) {
@@ -350,6 +367,77 @@ func TestRunScoutUsesSemanticRetrieverRuleSelection(t *testing.T) {
 	want := []string{"scout/semantic-one", "global/semantic-two"}
 	if strings.Join(recorded, ",") != strings.Join(want, ",") {
 		t.Fatalf("recorded rule IDs = %v, want %v", recorded, want)
+	}
+}
+
+func TestRunScoutFailsBeforeRuntimeWhenPrecollectionFails(t *testing.T) {
+	installFailingGH(t, "rate limit exceeded")
+
+	rt := &stubRuntime{outputs: []stubOutput{
+		{output: `{"verdict":"PROCEED","reason":"","difficulty":1,"has_competing_pr":false,"suggested_approach":"minimal fix"}`},
+	}}
+	database, err := db.New(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("create test db: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = database.Close()
+	})
+
+	promptsDir := t.TempDir()
+	writePromptTemplate(t, promptsDir, "scout", `scout {{.ScoutData}}`)
+
+	ps := prompt.NewStore(promptsDir)
+	if err := ps.Load(); err != nil {
+		t.Fatalf("load prompts: %v", err)
+	}
+
+	rl := rules.NewRuleLoader(t.TempDir())
+	if err := rl.Load(); err != nil {
+		t.Fatalf("load rules: %v", err)
+	}
+
+	p := &Pipeline{
+		cfg:        &config.Config{WorkspaceDir: t.TempDir()},
+		db:         database,
+		gh:         ghclient.New(&config.Config{}),
+		prompts:    ps,
+		runner:     NewAgentRunner(ps, rt, 0),
+		ruleLoader: rl,
+	}
+
+	issue := &models.Issue{
+		Repo:        "owner/repo",
+		IssueNumber: 7,
+		Title:       "panic in parser",
+	}
+	if err := database.CreateIssue(issue); err != nil {
+		t.Fatalf("create issue: %v", err)
+	}
+
+	_, err = p.runScout(context.Background(), issue)
+	if err == nil {
+		t.Fatal("runScout() error = nil, want scout data collection failure")
+	}
+	if !strings.Contains(err.Error(), "collect scout data") || !strings.Contains(err.Error(), "rate limit exceeded") {
+		t.Fatalf("runScout() error = %q, want precollection rate-limit failure", err.Error())
+	}
+	if rt.index != 0 {
+		t.Fatalf("runtime calls = %d, want 0", rt.index)
+	}
+
+	events, err := database.GetEventsByIssue(issue.ID)
+	if err != nil {
+		t.Fatalf("get events: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("event count = %d, want 1", len(events))
+	}
+	if events[0].Stage != "scout" || events[0].Success || events[0].Verdict != "error" {
+		t.Fatalf("event = %+v, want failed scout error", events[0])
+	}
+	if !strings.Contains(events[0].ErrorMessage, "collect scout data") {
+		t.Fatalf("event error = %q, want collection failure", events[0].ErrorMessage)
 	}
 }
 

--- a/internal/pipeline/agents.go
+++ b/internal/pipeline/agents.go
@@ -15,6 +15,7 @@ import (
 
 func (p *Pipeline) runScout(ctx context.Context, issue *models.Issue) (*ScoutResult, error) {
 	stageRules, rulesFormatted := p.getRulesForStageIssue("scout", issue)
+	start := time.Now()
 	tmplCtx := map[string]any{
 		"Repo":        issue.Repo,
 		"IssueNumber": issue.IssueNumber,
@@ -23,12 +24,21 @@ func (p *Pipeline) runScout(ctx context.Context, issue *models.Issue) (*ScoutRes
 		"Rules":       rulesFormatted,
 	}
 
+	if p.gh != nil {
+		scoutData, err := p.gh.CollectScoutData(ctx, issue.Repo, issue.IssueNumber, issue.Title)
+		if err != nil {
+			err = fmt.Errorf("collect scout data: %w", err)
+			p.recordEvent(issue, nil, "scout", 1, start, "error", false, "", err.Error(), stageRules)
+			return nil, err
+		}
+		tmplCtx["ScoutData"] = scoutData.Format()
+	}
+
 	// Inject repo_structure lessons so scout can detect wrong-repo patterns
 	if lessons, err := p.db.GetRecentLessons(10); err == nil && len(lessons) > 0 {
 		tmplCtx["PastLessons"] = formatLessonsForPrompt(lessons)
 	}
 
-	start := time.Now()
 	var result ScoutResult
 	if _, err := p.runner.RunJSONWithPolicy(ctx, "scout", p.cfg.WorkspaceDir, tmplCtx, &result, runtime.ExecutionPolicyUntrusted); err != nil {
 		p.recordEvent(issue, nil, "scout", 1, start, "", false, "", err.Error(), stageRules)

--- a/prompts/scout.md
+++ b/prompts/scout.md
@@ -20,11 +20,24 @@ If any `repo_structure` lesson indicates that changes for **{{ .Repo }}** belong
 output VERDICT: SKIP with reason referencing that lesson.
 
 {{ end }}
-## Checks (execute ALL before making a decision)
+{{ if .ScoutData }}
+## Pre-Collected GitHub Data
+
+The pipeline already fetched GitHub context for this issue. Use this data for the checks below. Successful empty sections mean the query returned no matching data; UNKNOWN sections are fetch failures and must not be treated as verified absence of risk.
+
+{{ .ScoutData }}
+{{ end }}
+## Checks
+
+{{ if .ScoutData }}
+Review the pre-collected data before making a decision. Do not re-run commands for sections that are already present.
+{{ else }}
+Execute ALL checks before making a decision.
+{{ end }}
 
 ### 1. Upstream Redirection Check
 
-Read all issue comments carefully. Look for maintainer signals:
+Read all issue comments carefully{{ if .ScoutData }} from the "Issue Comments" pre-collected section{{ end }}. Look for maintainer signals:
 - "upstream", "other repo", "separate repo", "belongs in X"
 - Links to issues in other repositories
 - Suggestions to fix elsewhere
@@ -36,15 +49,23 @@ If ANY upstream redirection is found, output VERDICT: SKIP with reason.
 Search for existing PRs that address this issue using ALL three methods:
 
 **2a. Search by issue number and title:**
+{{ if .ScoutData }}
+Use the "Open PRs Matching This Issue" pre-collected section.
+{{ else }}
 ```
 gh pr list -R {{ .Repo }} --state open --search "{{ .IssueNumber }} in:title,body"
 gh pr list -R {{ .Repo }} --state open --search "{{ .IssueTitle }}"
 ```
+{{ end }}
 
 **2b. Check issue timeline for linked PRs and referenced commits:**
+{{ if .ScoutData }}
+Use the "Issue Timeline (Cross-references)" pre-collected section.
+{{ else }}
 ```
 gh api repos/{{ .Repo }}/issues/{{ .IssueNumber }}/timeline --jq '.[] | select(.event == "cross-referenced" or .event == "referenced") | {event, source: .source.issue.pull_request.html_url}'
 ```
+{{ end }}
 
 **2c. Read issue comments for mentions of existing PRs or commits:**
 Look for patterns like "#1234", "PR", "pull request", "commit", "fix in", "already fixed", "merged".
@@ -66,10 +87,14 @@ Check if anyone has claimed this issue:
 ### 4b. Target Branch Check
 
 Check if the repo has a `dev` or `develop` branch and whether PRs should go there:
+{{ if .ScoutData }}
+Use the "Repo Metadata", "Dev/Develop Branches", "CONTRIBUTING.md", and "Recent Merged PRs" pre-collected sections.
+{{ else }}
 ```
 gh api repos/{{ .Repo }} --jq '.default_branch'
 gh api repos/{{ .Repo }}/branches --jq '.[].name' | grep -E '^(dev|develop|next|staging)$'
 ```
+{{ end }}
 Also check CONTRIBUTING.md or open merged PRs to see which base branch maintainers expect.
 Record the correct base branch in your output field `target_branch`.
 


### PR DESCRIPTION
Fixes #71.

## Summary
- add scout GitHub pre-collection with per-field failure state instead of silent empty fallbacks
- fail the scout stage before runtime execution when critical GitHub context cannot be fetched
- update the scout prompt to use pre-collected data and distinguish verified empty results from unknown failures

## Validation
- go build ./...
- go test ./...