### PR TITLE
Guard reviewer parse failures fail closed

### DIFF
--- a/internal/pipeline/agent_test.go
+++ b/internal/pipeline/agent_test.go
@@ -235,6 +235,7 @@ func TestEngineerReviewLoop_ReviewerParseFailureBlocksAndFailsIssue(t *testing.T
 		{output: "FIX_COMPLETE"},
 		{output: "not json at all"},
 		{output: "still not json"},
+		{output: `{"verdict":"approve","confidence":1,"issues_found":[],"summary":"must not be reached"}`},
 	}}
 	p, database := newLoopTestPipeline(t, rt)
 
@@ -269,6 +270,9 @@ func TestEngineerReviewLoop_ReviewerParseFailureBlocksAndFailsIssue(t *testing.T
 	}
 	if !strings.Contains(err.Error(), "parse reviewer JSON output") {
 		t.Fatalf("got error %q, want reviewer parse failure", err)
+	}
+	if rt.index != 3 {
+		t.Fatalf("runtime calls = %d, want 3 (engineer, reviewer, json recovery only)", rt.index)
 	}
 
 	stored, err := database.GetIssueByID(issue.ID)
@@ -461,6 +465,7 @@ func TestEngineerReviewLoop_ReviewerRuntimeFailureBlocksAndFailsIssue(t *testing
 	rt := &stubRuntime{outputs: []stubOutput{
 		{output: "FIX_COMPLETE"},
 		{err: errors.New("reviewer runtime exploded")},
+		{output: `{"verdict":"approve","confidence":1,"issues_found":[],"summary":"must not be reached"}`},
 	}}
 	p, database := newLoopTestPipeline(t, rt)
 
@@ -495,6 +500,9 @@ func TestEngineerReviewLoop_ReviewerRuntimeFailureBlocksAndFailsIssue(t *testing
 	}
 	if !strings.Contains(err.Error(), "reviewer runtime exploded") {
 		t.Fatalf("got error %q, want reviewer runtime failure", err)
+	}
+	if rt.index != 2 {
+		t.Fatalf("runtime calls = %d, want 2 (engineer and failing reviewer only)", rt.index)
 	}
 
 	stored, err := database.GetIssueByID(issue.ID)


### PR DESCRIPTION
## Summary
- Strengthen reviewer fail-closed regression coverage for parse and runtime failures.
- Add sentinel approve outputs after each failure path and assert they are never consumed.
- Confirm reviewer failures remain failed issue events instead of progressing toward approval.

## Root Cause
Issue #68 identified that reviewer runtime or JSON parse failures could be treated as approval. Current `origin/main` already fails closed in `engineerReviewLoopWithStats`; this PR locks that behavior with explicit regression assertions so a later fallback cannot consume an approve result after a failed reviewer gate.

## Validation
- `go test ./internal/pipeline -run 'TestEngineerReviewLoop_Reviewer(Parse|Runtime)FailureBlocksAndFailsIssue' -count=1`
- `git diff --check`
- `go build ./...`
- `go test ./...`

Closes #68
