### PR TITLE
fix: align responder thread resolution prompt

### DIFF
--- a/internal/pipeline/prompt_security_test.go
+++ b/internal/pipeline/prompt_security_test.go
@@ -91,6 +91,24 @@ func TestBuildResponderCtx_IsolatesGitHubFeedbackPayloads(t *testing.T) {
 	}
 }
 
+func TestResponderPromptDescribesGatedThreadResolution(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("..", "..", "prompts", "responder.md"))
+	if err != nil {
+		t.Fatalf("read responder prompt: %v", err)
+	}
+
+	rendered := string(data)
+	lower := strings.ToLower(rendered)
+	if strings.Contains(lower, "automatically resolve threads you reply to") ||
+		strings.Contains(lower, "automatically resolved") {
+		t.Fatalf("responder prompt must not promise unconditional automatic thread resolution: %s", rendered)
+	}
+
+	if !strings.Contains(rendered, "Thread resolution is a separate gated pipeline action") {
+		t.Fatalf("responder prompt should describe gated thread resolution, got: %s", rendered)
+	}
+}
+
 func TestRunJSONWithPolicy_RecoveryDoesNotEscalateUntrustedPolicy(t *testing.T) {
 	promptsDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(promptsDir, "scout.md"), []byte(`{{.Input}}`), 0644); err != nil {

--- a/prompts/responder.md
+++ b/prompts/responder.md
@@ -88,7 +88,8 @@ git push fork {{ .BranchName }}
 
 - For EVERY inline comment (id:NNN), include a reply in the `replies` array with the matching `comment_id`
 - Reply text should confirm the fix ("Done, fixed in this commit") or explain why not
-- Do NOT skip comments — the system will automatically resolve threads you reply to
+- Do NOT skip comments; replies are required for audit trail and maintainer communication
+- Thread resolution is a separate gated pipeline action after code changes are addressed and replies are successfully posted
 
 {{ if .Rules }}
 {{ .Rules }}


### PR DESCRIPTION
## Summary
- remove the responder prompt promise that replied inline comments are automatically resolved
- state that replies are required for audit and maintainer communication
- document thread resolution as a separate gated pipeline action after addressed changes and successful replies
- add a regression test for the prompt contract

## Validation
- go test ./internal/pipeline -run TestResponderPromptDescribesGatedThreadResolution -count=1
- go test ./internal/pipeline ./internal/github ./internal/prompt
- go test ./...

Closes #86