### PR TITLE
fix: scope rule validation stamps by stage

### DIFF
--- a/internal/pipeline/lessons.go
+++ b/internal/pipeline/lessons.go
@@ -251,6 +251,25 @@ func (p *Pipeline) stampRuleValidation(pr *models.PullRequest) {
 	today := time.Now().Format("2006-01-02")
 	rulesDir := p.ruleLoader.RulesDir()
 	seenRules := make(map[string]bool)
+	stamped := 0
+
+	stampRule := func(stage, ruleID, originalKey string) {
+		normalizedKey := stage + "/" + ruleID
+		if seenRules[normalizedKey] {
+			return
+		}
+		seenRules[normalizedKey] = true
+
+		rule := p.ruleLoader.ByStageAndID(stage, ruleID)
+		if rule == nil || rule.Source != "synthesized" {
+			return
+		}
+		if err := rules.UpdateRuleLastValidatedAt(rulesDir, ruleID, stage, today); err != nil {
+			log.WithFields(Fields{"rule": originalKey, "error": err}).Warn("failed to stamp rule last_validated_at")
+			return
+		}
+		stamped++
+	}
 
 	for _, e := range events {
 		if e.ExperiencesUsed == "" {
@@ -264,24 +283,16 @@ func (p *Pipeline) stampRuleValidation(pr *models.PullRequest) {
 		}
 
 		for _, key := range ruleKeys {
-			stage := e.Stage
-			ruleID := key
 			if parts := strings.SplitN(key, "/", 2); len(parts) == 2 {
-				stage = parts[0]
-				ruleID = parts[1]
-			}
-			normalizedKey := stage + "/" + ruleID
-			if seenRules[normalizedKey] {
+				stampRule(parts[0], parts[1], key)
 				continue
 			}
-			seenRules[normalizedKey] = true
 
-			rule := p.ruleLoader.ByStageAndID(stage, ruleID)
-			if rule == nil || rule.Source != "synthesized" {
-				continue
-			}
-			if err := rules.UpdateRuleLastValidatedAt(rulesDir, ruleID, stage, today); err != nil {
-				log.WithFields(Fields{"rule": key, "error": err}).Warn("failed to stamp rule last_validated_at")
+			// Legacy records stored bare rule IDs. Those IDs came from rules injected
+			// for the event stage, which includes stage-specific and global rules.
+			stampRule(e.Stage, key, key)
+			if e.Stage != "global" {
+				stampRule("global", key, key)
 			}
 		}
 	}
@@ -294,7 +305,7 @@ func (p *Pipeline) stampRuleValidation(pr *models.PullRequest) {
 
 	log.WithFields(Fields{
 		"pr":    pr.PRURL,
-		"rules": len(seenRules),
+		"rules": stamped,
 	}).Info("stamped last_validated_at on synthesized rules for merged PR")
 }
 

--- a/internal/pipeline/lessons_test.go
+++ b/internal/pipeline/lessons_test.go
@@ -108,3 +108,98 @@ func TestStampRuleValidation_LegacyRuleIDsRemainDistinctPerStage(t *testing.T) {
 		}
 	}
 }
+
+func TestStampRuleValidation_LegacyRuleIDsStampOnlyMatchingStageAndGlobal(t *testing.T) {
+	dir := t.TempDir()
+	today := time.Now().Format("2006-01-02")
+
+	for _, rule := range []*rules.Rule{
+		{
+			ID:         "legacy-shared-rule",
+			Stage:      "engineer",
+			Severity:   "medium",
+			Confidence: 0.8,
+			Source:     "synthesized",
+			CreatedAt:  "2024-01-01",
+			Body:       "Engineer-stage synthesized rule.",
+		},
+		{
+			ID:         "legacy-shared-rule",
+			Stage:      "reviewer",
+			Severity:   "medium",
+			Confidence: 0.8,
+			Source:     "synthesized",
+			CreatedAt:  "2024-01-01",
+			Body:       "Reviewer-stage synthesized rule.",
+		},
+		{
+			ID:         "legacy-shared-rule",
+			Stage:      "global",
+			Severity:   "medium",
+			Confidence: 0.8,
+			Source:     "synthesized",
+			CreatedAt:  "2024-01-01",
+			Body:       "Global synthesized rule.",
+		},
+	} {
+		writeRule(t, dir, rule)
+	}
+
+	database, err := db.New(filepath.Join(dir, "pipeline.db"))
+	if err != nil {
+		t.Fatalf("db.New: %v", err)
+	}
+	defer database.Close()
+
+	now := time.Now()
+	if err := database.RecordEvent(&models.PipelineEvent{
+		IssueID:         1,
+		Repo:            "majiayu000/auto-contributor",
+		IssueNumber:     41,
+		Stage:           "engineer",
+		Round:           1,
+		StartedAt:       now,
+		CompletedAt:     &now,
+		DurationSeconds: 1,
+		Verdict:         "PROCEED",
+		Success:         true,
+		ExperiencesUsed: `["legacy-shared-rule"]`,
+	}); err != nil {
+		t.Fatalf("RecordEvent: %v", err)
+	}
+
+	p := &Pipeline{
+		db:         database,
+		ruleLoader: rules.NewRuleLoader(dir),
+	}
+	if err := p.ruleLoader.Load(); err != nil {
+		t.Fatalf("RuleLoader.Load: %v", err)
+	}
+
+	p.stampRuleValidation(&models.PullRequest{
+		IssueID: 1,
+		PRURL:   "https://github.com/majiayu000/auto-contributor/pull/41",
+	})
+
+	if err := p.ruleLoader.Reload(); err != nil {
+		t.Fatalf("RuleLoader.Reload: %v", err)
+	}
+
+	for _, stage := range []string{"engineer", "global"} {
+		got := p.ruleLoader.ByStageAndID(stage, "legacy-shared-rule")
+		if got == nil {
+			t.Fatalf("rule %s/legacy-shared-rule not found after stamp", stage)
+		}
+		if got.LastValidatedAt != today {
+			t.Errorf("%s last_validated_at = %q, want %q", stage, got.LastValidatedAt, today)
+		}
+	}
+
+	reviewer := p.ruleLoader.ByStageAndID("reviewer", "legacy-shared-rule")
+	if reviewer == nil {
+		t.Fatal("rule reviewer/legacy-shared-rule not found after stamp")
+	}
+	if reviewer.LastValidatedAt != "" {
+		t.Errorf("reviewer last_validated_at = %q, want empty", reviewer.LastValidatedAt)
+	}
+}


### PR DESCRIPTION
## Summary
- stamp synthesized rules by `stage/ruleID` instead of bare rule ID
- keep legacy bare IDs scoped to the event stage plus `global`
- add a regression where the same rule ID exists in multiple stages

Closes #41

## Verification
- `go test ./...`
- `go vet ./...`
- `go build ./...`
- `git diff --check`