### PR TITLE
docs: add launch readiness boundaries

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,26 @@
+---
+name: Bug report
+about: Report incorrect behavior in Auto-Contributor
+title: "bug: "
+labels: bug
+assignees: ""
+---
+
+## What Happened
+
+
+## Expected Behavior
+
+
+## Reproduction Steps
+
+1. Describe the first command or action.
+
+## Safety Impact
+
+- [ ] Could create or update GitHub content unexpectedly.
+- [ ] Could hide a failed command, CI result, or review signal.
+- [ ] Could process a repository or issue outside the intended scope.
+- [ ] No safety impact.
+
+## Logs or Evidence

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,21 @@
+---
+name: Feature request
+about: Propose a bounded Auto-Contributor improvement
+title: "feature: "
+labels: enhancement
+assignees: ""
+---
+
+## Goal
+
+
+## Context
+
+
+## Safety Boundaries
+
+- [ ] The change keeps GitHub writes explicit and reviewable.
+- [ ] The change does not require committed secrets or credentials.
+- [ ] The change defines how completion will be verified.
+
+## Done When

--- a/.github/ISSUE_TEMPLATE/launch_readiness.md
+++ b/.github/ISSUE_TEMPLATE/launch_readiness.md
@@ -1,0 +1,18 @@
+---
+name: Launch readiness task
+about: Track release, documentation, safety, or repository metadata work
+title: "launch: "
+labels: documentation
+assignees: ""
+---
+
+## Scope
+
+
+## Done When
+
+- [ ] The trust or launch gap is documented.
+- [ ] Required operator action is explicit.
+- [ ] Verification evidence is listed.
+
+## Non-Goals

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+## Summary
+
+- Describe the change and the operator-visible behavior.
+
+## Safety Boundaries
+
+- [ ] This PR does not add or commit secrets, tokens, or local credentials.
+- [ ] Any GitHub writes are documented and require explicit user/operator action.
+- [ ] The change keeps repository selection, issue selection, and PR submission behavior reviewable.
+
+## Verification
+
+- [ ] `go vet ./...`
+- [ ] `go build ./...`
+- [ ] `go test ./...`
+
+## Linked Issue
+
+Refs #

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to Auto-Contributor are documented in this file.
+
+## Unreleased
+
+- Added launch-readiness documentation covering trust boundaries, proof checklist,
+  limitations, and contribution templates.
+- Added an MIT license file to match the README license declaration.
+- Added issue and pull request templates for safer external review.
+
+## 0.1.0 - Initial launch baseline
+
+- Provides a Go CLI for discovering GitHub issues, running Claude Code on a
+  bounded issue, signing commits, and opening pull requests through GitHub CLI.
+- Includes CI coverage for `go vet ./...`, `go build ./...`, and
+  `go test ./...`.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 majiayu000
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -44,10 +44,8 @@ github_email: "your-email@example.com"
 claude_timeout: 999m
 claude_max_retries: 2
 
-# Worker settings
-worker_count: 1              # Sequential processing recommended
-worker_queue_size: 5
-issue_check_interval: 60m
+# Pipeline settings
+max_concurrent_pipelines: 1  # Sequential processing recommended for launch proof
 
 # Language filter
 languages:
@@ -92,8 +90,8 @@ log_level: info
 ### Single Issue
 
 ```bash
-# Solve a specific issue
-./auto-contributor solve --repo owner/repo --issue 123
+# Process a specific issue through the pipeline
+./auto-contributor pipeline --repo owner/repo --issue 123
 ```
 
 ### Smart Discovery Only
@@ -111,7 +109,7 @@ log_level: info
 | Command | Description |
 |---------|-------------|
 | `loop` | Continuous discovery and solving (~1 issue/hour) |
-| `solve` | Solve a single specific issue |
+| `pipeline` | Process a single specific issue through the agent pipeline |
 | `discover` | Basic issue discovery |
 | `discover-smart` | Claude-powered intelligent discovery |
 | `stats` | Show statistics |
@@ -199,7 +197,7 @@ you are willing to let create branches, commits, and pull requests.
 
 - It uses the authenticated `gh` session for GitHub API reads and writes.
 - It creates commits and pull requests only through explicit CLI commands such
-  as `solve` or `loop`.
+  as `pipeline` or `loop`.
 - It checks for existing pull requests before starting work on an issue.
 - It signs generated commits with the configured Git identity for DCO workflows.
 - It stores runtime state in the local SQLite database under
@@ -209,7 +207,7 @@ you are willing to let create branches, commits, and pull requests.
 
 Recommended operating limits:
 
-- Start with `worker_count: 1` and one target repository or issue.
+- Start with `max_concurrent_pipelines: 1` and one target repository or issue.
 - Run a dry discovery pass before enabling PR creation.
 - Review generated diffs and PR bodies before broadening repository scope.
 - Use a GitHub token with the narrowest permissions that still allow the
@@ -229,7 +227,7 @@ gh auth status
 ./auto-contributor discover-smart --topic golang --limit 3 --output issues.json
 
 # 3. Run one bounded issue after manually selecting it.
-./auto-contributor solve --repo owner/repo --issue 123
+./auto-contributor pipeline --repo owner/repo --issue 123
 
 # 4. Review local state and the created pull request before continuing.
 git status --short
@@ -267,7 +265,7 @@ Default configuration targets ~1 issue per hour:
 
 | Parameter | Value | Purpose |
 |-----------|-------|---------|
-| `worker_count` | 1 | Sequential processing |
+| `max_concurrent_pipelines` | 1 | Sequential processing |
 | `interval` | 60min | Discovery cycle interval |
 | `Limit` | 2 | Issues per discovery cycle |
 | `claude_timeout` | 999m | No timeout, let Claude work |

--- a/README.md
+++ b/README.md
@@ -191,6 +191,76 @@ Features:
 - Issue queue
 - PR history
 
+## Safety Boundaries
+
+Auto-Contributor is designed for controlled contribution workflows, not
+unsupervised repository maintenance. Run it from an account and token scope that
+you are willing to let create branches, commits, and pull requests.
+
+- It uses the authenticated `gh` session for GitHub API reads and writes.
+- It creates commits and pull requests only through explicit CLI commands such
+  as `solve` or `loop`.
+- It checks for existing pull requests before starting work on an issue.
+- It signs generated commits with the configured Git identity for DCO workflows.
+- It stores runtime state in the local SQLite database under
+  `~/.auto-contributor/`.
+- It does not require GitHub or Claude credentials to be stored in this
+  repository.
+
+Recommended operating limits:
+
+- Start with `worker_count: 1` and one target repository or issue.
+- Run a dry discovery pass before enabling PR creation.
+- Review generated diffs and PR bodies before broadening repository scope.
+- Use a GitHub token with the narrowest permissions that still allow the
+  intended repositories and pull request actions.
+
+More launch-readiness detail is tracked in `docs/launch-readiness.md`.
+
+## Controlled Single-Issue Flow
+
+This controlled single-issue flow shows the intended reviewable path:
+
+```bash
+# 1. Confirm authentication and repository access.
+gh auth status
+
+# 2. Discover candidates without creating branches or pull requests.
+./auto-contributor discover-smart --topic golang --limit 3 --output issues.json
+
+# 3. Run one bounded issue after manually selecting it.
+./auto-contributor solve --repo owner/repo --issue 123
+
+# 4. Review local state and the created pull request before continuing.
+git status --short
+gh pr view --repo owner/repo --web
+```
+
+The CI baseline for this repository is `go vet ./...`, `go build ./...`, and
+`go test ./...`, as defined in `.github/workflows/ci.yml`.
+
+## Limitations and Non-Goals
+
+- It cannot determine whether a maintainer wants a contribution beyond the
+  signals available in issues, labels, existing pull requests, and repository
+  history.
+- It does not bypass branch protections, required reviews, DCO checks, or CI.
+- It does not guarantee that generated pull requests will be accepted.
+- It is not a secrets manager and should not receive GitHub or Claude
+  credentials through committed files.
+- It is not intended for high-risk repositories without human review of issue
+  choice, generated code, and PR content.
+
+## Launch Metadata
+
+- License: MIT, see `LICENSE`.
+- Release notes: see `CHANGELOG.md`.
+- Launch readiness: see `docs/launch-readiness.md`.
+- Suggested GitHub topics: `automation`, `github`, `claude-code`, `pull-requests`,
+  `go`.
+- Initial release recommendation: create a `v0.1.0` GitHub release from a
+  reviewed main branch after the launch-readiness PR merges.
+
 ## Rate Limiting
 
 Default configuration targets ~1 issue per hour:

--- a/docs/launch-readiness.md
+++ b/docs/launch-readiness.md
@@ -18,7 +18,7 @@ Auto-Contributor performs high-trust actions:
 
 - reads GitHub issues, pull requests, repository metadata, and CI state through
   the authenticated `gh` session;
-- creates local branches, generated commits, and pull requests when `solve` or
+- creates local branches, generated commits, and pull requests when `pipeline` or
   `loop` is run;
 - signs commits with the configured Git identity for DCO compliance;
 - stores local runtime state in `~/.auto-contributor/data.db`.
@@ -37,7 +37,7 @@ go vet ./...
 go build ./...
 go test ./...
 ./auto-contributor discover-smart --topic golang --limit 3 --output issues.json
-./auto-contributor solve --repo owner/repo --issue 123
+./auto-contributor pipeline --repo owner/repo --issue 123
 git status --short
 gh pr view --repo owner/repo --web
 ```

--- a/docs/launch-readiness.md
+++ b/docs/launch-readiness.md
@@ -1,0 +1,68 @@
+# Launch Readiness
+
+This document records the trust boundaries and release checklist for
+Auto-Contributor before broader public use.
+
+## Current File-Backed Readiness
+
+- License declaration is backed by `LICENSE`.
+- Release notes are tracked in `CHANGELOG.md`.
+- Issue and pull request templates define the minimum safety and verification
+  evidence expected from future changes.
+- The README documents operating limits, permissions, local state, and
+  limitations.
+
+## Trust Boundaries
+
+Auto-Contributor performs high-trust actions:
+
+- reads GitHub issues, pull requests, repository metadata, and CI state through
+  the authenticated `gh` session;
+- creates local branches, generated commits, and pull requests when `solve` or
+  `loop` is run;
+- signs commits with the configured Git identity for DCO compliance;
+- stores local runtime state in `~/.auto-contributor/data.db`.
+
+Credentials and tokens must stay outside the repository. Use `gh auth login`,
+the Claude Code CLI login flow, environment variables, or the local operator
+environment instead of committed configuration.
+
+## Controlled Single-Issue Flow
+
+Use this flow to produce launch proof before broadening scope:
+
+```bash
+gh auth status
+go vet ./...
+go build ./...
+go test ./...
+./auto-contributor discover-smart --topic golang --limit 3 --output issues.json
+./auto-contributor solve --repo owner/repo --issue 123
+git status --short
+gh pr view --repo owner/repo --web
+```
+
+Record the selected repository, issue number, created pull request, and
+verification output in the release notes before tagging a launch release.
+
+## Limitations
+
+- Maintainer acceptance cannot be inferred from a green local build alone.
+- Branch protections, CI requirements, DCO checks, and human reviews remain the
+  authority on whether a pull request can merge.
+- Generated code and PR text require review before expanding beyond a single
+  target repository or issue.
+- Auto-Contributor is not a secrets manager and should not receive credentials
+  through committed files.
+- External repository behavior can change between discovery, implementation,
+  and submission.
+
+## Post-Merge Repository Metadata
+
+These actions require repository-owner permissions and should happen after the
+readiness PR merges:
+
+- add GitHub topics: `automation`, `github`, `claude-code`, `pull-requests`,
+  `go`;
+- create an initial GitHub release from a reviewed main branch;
+- attach the controlled single-issue proof or release notes to that release.


### PR DESCRIPTION
## Summary

- add MIT license file and changelog baseline
- document safety boundaries, limitations, controlled single-issue proof flow, and post-merge metadata actions
- add issue and PR templates with safety/verification prompts

## Verification

- `git diff --check`
- `go vet ./...`
- `go build ./...`
- `go test ./...`

## Follow-up

Repository topics and an initial GitHub release require owner-side metadata changes after this file-backed readiness PR merges.

Refs #81
